### PR TITLE
Format header coin balance with commas

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -94,7 +94,7 @@
     const data = snapshot.val() || {};
     const balance = data.balance || 0;
 
-    document.getElementById('balance-amount').innerText = Number(balance).toLocaleString();
+    document.getElementById('balance-amount').innerText = Number(balance).toLocaleString('en-US');
     document.getElementById('user-balance').classList.remove('hidden');
     document.getElementById('username-display').innerText = data.username || user.displayName || user.email || 'User';
     document.getElementById('signin-desktop').classList.add('hidden');

--- a/scripts/auth.js
+++ b/scripts/auth.js
@@ -29,7 +29,7 @@ window.addEventListener('DOMContentLoaded', () => {
       }
 
       // Show balances
-      const formattedBalance = Number(userData.balance || 0).toLocaleString();
+      const formattedBalance = Number(userData.balance || 0).toLocaleString('en-US');
       if (balanceAmount) balanceAmount.innerText = formattedBalance;
       if (balanceMobile) balanceMobile.innerText = formattedBalance;
       if (popupBalance) popupBalance.innerText = `${formattedBalance} coins`;
@@ -66,7 +66,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
     } else {
       // Signed out state
-      const zeroBalance = Number(0).toLocaleString();
+      const zeroBalance = Number(0).toLocaleString('en-US');
       if (userBalanceWrapper) userBalanceWrapper.classList.add('hidden');
       if (balanceAmount) balanceAmount.innerText = zeroBalance;
       if (balanceMobile) balanceMobile.innerText = zeroBalance;

--- a/scripts/header.js
+++ b/scripts/header.js
@@ -76,8 +76,8 @@ document.addEventListener("DOMContentLoaded", () => {
       const mobileAuth = document.getElementById("mobile-auth-button");
       const inventoryLink = document.getElementById("inventory-link");
 
-      if (balanceDesktop) balanceDesktop.innerText = parseInt(balance, 10).toLocaleString();
-      if (balanceMobile) balanceMobile.innerText = parseInt(balance, 10).toLocaleString();
+      if (balanceDesktop) balanceDesktop.innerText = parseInt(balance, 10).toLocaleString('en-US');
+      if (balanceMobile) balanceMobile.innerText = parseInt(balance, 10).toLocaleString('en-US');
       if (userBalanceDiv) userBalanceDiv.classList.remove("hidden");
       if (usernameDisplay) usernameDisplay.innerText = user.displayName || data.username || user.email || "User";
       if (signinDesktop) signinDesktop.classList.add("hidden");

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -14,7 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
     userRef.once('value').then(snapshot => {
       const data = snapshot.val();
 const balanceEl = document.getElementById('balance-amount');
-if (balanceEl) balanceEl.innerText = Number(data.balance || 0).toLocaleString();
+if (balanceEl) balanceEl.innerText = Number(data.balance || 0).toLocaleString('en-US');
       document.getElementById('username-display').innerText = user.displayName || user.email;
     });
 

--- a/scripts/navbar.js
+++ b/scripts/navbar.js
@@ -30,7 +30,7 @@ document.addEventListener("DOMContentLoaded", () => {
         userRef.once("value").then((snap) => {
           const data = snap.val() || {};
           const balance = data.balance || 0;
-          const formattedBalance = Number(balance).toLocaleString();
+          const formattedBalance = Number(balance).toLocaleString('en-US');
           const username = user.displayName || data.username || user.email;
 
           usernameEl.innerText = username;
@@ -58,7 +58,7 @@ document.addEventListener("DOMContentLoaded", () => {
           }
         });
       } else {
-        const zeroBalance = Number(0).toLocaleString();
+        const zeroBalance = Number(0).toLocaleString('en-US');
         usernameEl.innerText = "User";
         balanceEl.innerText = zeroBalance;
         if (balanceMobile) balanceMobile.innerText = zeroBalance;

--- a/scripts/topup.js
+++ b/scripts/topup.js
@@ -111,9 +111,11 @@ firebase.auth().onAuthStateChanged(async (user) => {
 
               await userRef.update({ balance: newBalance });
 
-              const formattedBalance = Number(newBalance).toLocaleString();
-              document.getElementById("balance-amount").innerText = formattedBalance;
-              document.getElementById("balance-amount-mobile").innerText = formattedBalance;
+              const formattedBalance = Number(newBalance).toLocaleString('en-US');
+              const balanceAmountEl = document.getElementById("balance-amount");
+              if (balanceAmountEl) balanceAmountEl.innerText = formattedBalance;
+              const balanceMobileEl = document.getElementById("balance-amount-mobile");
+              if (balanceMobileEl) balanceMobileEl.innerText = formattedBalance;
 
               const popupBalance = document.getElementById("popup-balance");
               if (popupBalance) popupBalance.innerText = `${formattedBalance} coins`;

--- a/termsandconditions.html
+++ b/termsandconditions.html
@@ -101,7 +101,7 @@
     const data = snapshot.val() || {};
     const balance = data.balance || 0;
 
-    document.getElementById('balance-amount').innerText = Number(balance).toLocaleString();
+    document.getElementById('balance-amount').innerText = Number(balance).toLocaleString('en-US');
     document.getElementById('user-balance').classList.remove('hidden');
     document.getElementById('username-display').innerText = data.username || user.displayName || user.email || 'User';
     document.getElementById('signin-desktop').classList.add('hidden');


### PR DESCRIPTION
## Summary
- Format header balances using locale-aware commas for easier reading.
- Apply the same formatting after top-ups and during auth checks to keep all balances consistent.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fd8847cec83209ec8e31582bb3144