### PR TITLE
feat: add demo spin option

### DIFF
--- a/case.html
+++ b/case.html
@@ -268,7 +268,16 @@ renderSpinner(prizeList.slice(0, 30), null, true); // show preview spinner
   `;
 }).join("");
 enablePrizePopups();
-const freeBtn = document.getElementById("try-free-button");
+const actionButtons = document.getElementById("action-buttons");
+let freeBtn = document.getElementById("try-free-button");
+if (!freeBtn && actionButtons) {
+  freeBtn = document.createElement("button");
+  freeBtn.id = "try-free-button";
+  freeBtn.className = "px-6 py-3 rounded-full bg-gray-700 text-white font-bold flex items-center justify-center shadow-lg transition-transform transform hover:scale-105 focus:outline-none";
+  freeBtn.textContent = "Try for Free";
+  actionButtons.appendChild(freeBtn);
+}
+if (freeBtn) {
 freeBtn.addEventListener("click", () => {
   freeBtn.disabled = true;
   freeBtn.classList.add("cursor-not-allowed", "opacity-60");
@@ -293,6 +302,7 @@ freeBtn.addEventListener("click", () => {
     });
   }, 150);
 });
+}
 
 document.getElementById("open-case-button").addEventListener("click", async () => {
 

--- a/case.html
+++ b/case.html
@@ -93,6 +93,9 @@
       <span id="button-price">...</span>
     </span>
   </button>
+  <button id="try-free-button" class="px-6 py-3 rounded-full bg-gray-700 text-white font-bold flex items-center justify-center shadow-lg transition-transform transform hover:scale-105 focus:outline-none">
+    Try for Free
+  </button>
 </div>
 
 
@@ -265,14 +268,7 @@ renderSpinner(prizeList.slice(0, 30), null, true); // show preview spinner
   `;
 }).join("");
 enablePrizePopups();
-// Add Try for Free button dynamically so it isn't removed by other renders
-const actionButtons = document.getElementById("action-buttons");
-const freeBtn = document.createElement("button");
-freeBtn.id = "try-free-button";
-freeBtn.className = "px-6 py-3 rounded-full bg-gray-700 text-white font-bold flex items-center justify-center shadow-lg transition-transform transform hover:scale-105 focus:outline-none";
-freeBtn.textContent = "Try for Free";
-actionButtons.appendChild(freeBtn);
-
+const freeBtn = document.getElementById("try-free-button");
 freeBtn.addEventListener("click", () => {
   freeBtn.disabled = true;
   freeBtn.classList.add("cursor-not-allowed", "opacity-60");

--- a/case.html
+++ b/case.html
@@ -85,16 +85,13 @@
     <div id="rarity-bar" class="h-full w-full bg-lime-500 transition-colors duration-300"></div>
   </div>
 </div>
-    <div class="flex justify-center mt-6 gap-4">
+    <div id="action-buttons" class="flex justify-center mt-6 gap-4">
   <button id="open-case-button" class="shining-button relative px-6 py-3 rounded-full bg-gradient-to-r from-yellow-400 via-pink-500 to-purple-500 text-white font-extrabold flex items-center justify-center gap-2 shadow-lg transition-transform transform hover:scale-105 animate-pulse focus:outline-none overflow-hidden">
         <span class="relative z-10 flex items-center gap-2">
       Open for
       <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-5 h-5" />
       <span id="button-price">...</span>
     </span>
-  </button>
-  <button id="try-free-button" class="px-6 py-3 rounded-full bg-gray-700 text-white font-bold flex items-center justify-center shadow-lg transition-transform transform hover:scale-105 focus:outline-none">
-    Try for Free
   </button>
 </div>
 
@@ -268,13 +265,18 @@ renderSpinner(prizeList.slice(0, 30), null, true); // show preview spinner
   `;
 }).join("");
 enablePrizePopups();
+// Add Try for Free button dynamically so it isn't removed by other renders
+const actionButtons = document.getElementById("action-buttons");
+const freeBtn = document.createElement("button");
+freeBtn.id = "try-free-button";
+freeBtn.className = "px-6 py-3 rounded-full bg-gray-700 text-white font-bold flex items-center justify-center shadow-lg transition-transform transform hover:scale-105 focus:outline-none";
+freeBtn.textContent = "Try for Free";
+actionButtons.appendChild(freeBtn);
 
-
-document.getElementById("try-free-button").addEventListener("click", () => {
-  const btn = document.getElementById("try-free-button");
-  btn.disabled = true;
-  btn.classList.add("cursor-not-allowed", "opacity-60");
-  btn.innerHTML = `<span class="relative z-10 flex items-center gap-2 animate-pulse">Spinning...</span>`;
+freeBtn.addEventListener("click", () => {
+  freeBtn.disabled = true;
+  freeBtn.classList.add("cursor-not-allowed", "opacity-60");
+  freeBtn.innerHTML = '<span class="relative z-10 flex items-center gap-2 animate-pulse">Spinning...</span>';
 
   const spinnerPrizes = [];
   const winningPrize = prizeList[Math.floor(Math.random() * prizeList.length)];
@@ -289,9 +291,9 @@ document.getElementById("try-free-button").addEventListener("click", () => {
     spinToPrize(() => {
       document.getElementById("win-popup").classList.add("hidden");
       renderSpinner(prizeList.slice(0, 30), null, true);
-      btn.disabled = false;
-      btn.classList.remove("cursor-not-allowed", "opacity-60");
-      btn.textContent = "Try for Free";
+      freeBtn.disabled = false;
+      freeBtn.classList.remove("cursor-not-allowed", "opacity-60");
+      freeBtn.textContent = "Try for Free";
     });
   }, 150);
 });

--- a/case.html
+++ b/case.html
@@ -85,13 +85,16 @@
     <div id="rarity-bar" class="h-full w-full bg-lime-500 transition-colors duration-300"></div>
   </div>
 </div>
-    <div class="flex justify-center mt-6">
+    <div class="flex justify-center mt-6 gap-4">
   <button id="open-case-button" class="shining-button relative px-6 py-3 rounded-full bg-gradient-to-r from-yellow-400 via-pink-500 to-purple-500 text-white font-extrabold flex items-center justify-center gap-2 shadow-lg transition-transform transform hover:scale-105 animate-pulse focus:outline-none overflow-hidden">
         <span class="relative z-10 flex items-center gap-2">
       Open for
       <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-5 h-5" />
       <span id="button-price">...</span>
     </span>
+  </button>
+  <button id="try-free-button" class="px-6 py-3 rounded-full bg-gray-700 text-white font-bold flex items-center justify-center shadow-lg transition-transform transform hover:scale-105 focus:outline-none">
+    Try for Free
   </button>
 </div>
 
@@ -266,6 +269,32 @@ renderSpinner(prizeList.slice(0, 30), null, true); // show preview spinner
 }).join("");
 enablePrizePopups();
 
+
+document.getElementById("try-free-button").addEventListener("click", () => {
+  const btn = document.getElementById("try-free-button");
+  btn.disabled = true;
+  btn.classList.add("cursor-not-allowed", "opacity-60");
+  btn.innerHTML = `<span class="relative z-10 flex items-center gap-2 animate-pulse">Spinning...</span>`;
+
+  const spinnerPrizes = [];
+  const winningPrize = prizeList[Math.floor(Math.random() * prizeList.length)];
+  for (let i = 0; i < 30; i++) {
+    const randomPrize = prizeList[Math.floor(Math.random() * prizeList.length)];
+    spinnerPrizes.push(randomPrize);
+  }
+  spinnerPrizes[15] = winningPrize;
+
+  renderSpinner(spinnerPrizes, winningPrize);
+  setTimeout(() => {
+    spinToPrize(() => {
+      document.getElementById("win-popup").classList.add("hidden");
+      renderSpinner(prizeList.slice(0, 30), null, true);
+      btn.disabled = false;
+      btn.classList.remove("cursor-not-allowed", "opacity-60");
+      btn.textContent = "Try for Free";
+    });
+  }, 150);
+});
 
 document.getElementById("open-case-button").addEventListener("click", async () => {
 


### PR DESCRIPTION
## Summary
- add "Try for Free" button to case opening page
- allow demo spin that doesn't affect balance or inventory

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fe0cc88fc83209cc33d3219197fc6