### PR TITLE
Format coin balance with thousands separators

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -93,8 +93,11 @@
     const snapshot = await userRef.once('value');
     const data = snapshot.val() || {};
     const balance = data.balance || 0;
+    const balanceFormatted = Number(balance).toLocaleString();
 
-    document.getElementById('balance-amount').innerText = balance;
+    document.getElementById('balance-amount').innerText = balanceFormatted;
+    const balanceMobile = document.getElementById('balance-amount-mobile');
+    if (balanceMobile) balanceMobile.innerText = balanceFormatted;
     document.getElementById('user-balance').classList.remove('hidden');
     document.getElementById('username-display').innerText = data.username || user.displayName || user.email || 'User';
     document.getElementById('signin-desktop').classList.add('hidden');

--- a/scripts/auth.js
+++ b/scripts/auth.js
@@ -29,9 +29,11 @@ window.addEventListener('DOMContentLoaded', () => {
       }
 
       // Show balances
-      if (balanceAmount) balanceAmount.innerText = userData.balance || 0;
-      if (balanceMobile) balanceMobile.innerText = userData.balance || 0;
-      if (popupBalance) popupBalance.innerText = `${userData.balance || 0} coins`;
+      const balance = userData.balance || 0;
+      const balanceFormatted = Number(balance).toLocaleString();
+      if (balanceAmount) balanceAmount.innerText = balanceFormatted;
+      if (balanceMobile) balanceMobile.innerText = balanceFormatted;
+      if (popupBalance) popupBalance.innerText = `${balanceFormatted} coins`;
       if (userBalanceWrapper) userBalanceWrapper.classList.remove('hidden');
 
       // Set username if it exists

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -13,8 +13,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     userRef.once('value').then(snapshot => {
       const data = snapshot.val();
-const balanceEl = document.getElementById('balance-amount');
-if (balanceEl) balanceEl.innerText = data.balance || 0;
+      const balanceEl = document.getElementById('balance-amount');
+      if (balanceEl) balanceEl.innerText = Number(data.balance || 0).toLocaleString();
       document.getElementById('username-display').innerText = user.displayName || user.email;
     });
 

--- a/scripts/navbar.js
+++ b/scripts/navbar.js
@@ -31,11 +31,12 @@ document.addEventListener("DOMContentLoaded", () => {
           const data = snap.val() || {};
           const balance = data.balance || 0;
           const username = user.displayName || data.username || user.email;
+          const balanceFormatted = Number(balance).toLocaleString();
 
           usernameEl.innerText = username;
-          balanceEl.innerText = balance;
-          if (balanceMobile) balanceMobile.innerText = balance;
-          if (popupBalance) popupBalance.innerText = `${balance} coins`;
+          balanceEl.innerText = balanceFormatted;
+          if (balanceMobile) balanceMobile.innerText = balanceFormatted;
+          if (popupBalance) popupBalance.innerText = `${balanceFormatted} coins`;
 
           if (logoutBtn) {
             logoutBtn.style.display = "block";

--- a/scripts/topup.js
+++ b/scripts/topup.js
@@ -111,11 +111,12 @@ firebase.auth().onAuthStateChanged(async (user) => {
 
               await userRef.update({ balance: newBalance });
 
-              document.getElementById("balance-amount").innerText = newBalance;
-              document.getElementById("balance-amount-mobile").innerText = newBalance;
+              const formattedBalance = newBalance.toLocaleString();
+              document.getElementById("balance-amount").innerText = formattedBalance;
+              document.getElementById("balance-amount-mobile").innerText = formattedBalance;
 
               const popupBalance = document.getElementById("popup-balance");
-              if (popupBalance) popupBalance.innerText = `${newBalance} coins`;
+              if (popupBalance) popupBalance.innerText = `${formattedBalance} coins`;
 
               await change.doc.ref.update({ processed: true });
             }

--- a/termsandconditions.html
+++ b/termsandconditions.html
@@ -100,8 +100,11 @@
     const snapshot = await userRef.once('value');
     const data = snapshot.val() || {};
     const balance = data.balance || 0;
+    const balanceFormatted = Number(balance).toLocaleString();
 
-    document.getElementById('balance-amount').innerText = balance;
+    document.getElementById('balance-amount').innerText = balanceFormatted;
+    const balanceMobile = document.getElementById('balance-amount-mobile');
+    if (balanceMobile) balanceMobile.innerText = balanceFormatted;
     document.getElementById('user-balance').classList.remove('hidden');
     document.getElementById('username-display').innerText = data.username || user.displayName || user.email || 'User';
     document.getElementById('signin-desktop').classList.add('hidden');


### PR DESCRIPTION
## Summary
- Display coin balances with locale-aware commas in navbar and auth flows.
- Update top-up and inventory scripts to keep header totals formatted across interactions.
- Ensure FAQ and Terms pages show formatted balances on both desktop and mobile views.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890cd97e4108320a2793dbec8eabc31