### PR TITLE
feat: improve inventory layout with orders tab

### DIFF
--- a/case.html
+++ b/case.html
@@ -359,13 +359,15 @@ setTimeout(() => {
 
 
         await firebase.database().ref('users/' + user.uid + '/balance').set(balance - price);
-        await firebase.database().ref('users/' + user.uid + '/inventory').push({
+        const prizeData = {
           name: winningPrize.name,
           image: winningPrize.image,
           rarity: winningPrize.rarity,
           value: winningPrize.value,
           timestamp: Date.now()
-        });
+        };
+        await firebase.database().ref('users/' + user.uid + '/inventory').push(prizeData);
+        await firebase.database().ref('users/' + user.uid + '/pulls').push(prizeData);
         await firebase.database().ref('users/' + user.uid + '/provablyFair').update({ nonce: nonce + 1 });
         updateUserBalance();
       });

--- a/case.html
+++ b/case.html
@@ -368,6 +368,9 @@ setTimeout(() => {
         };
         await firebase.database().ref('users/' + user.uid + '/inventory').push(prizeData);
         await firebase.database().ref('users/' + user.uid + '/pulls').push(prizeData);
+        const pullHistory = JSON.parse(localStorage.getItem('pullHistory') || '[]');
+        pullHistory.push(prizeData);
+        localStorage.setItem('pullHistory', JSON.stringify(pullHistory));
         await firebase.database().ref('users/' + user.uid + '/provablyFair').update({ nonce: nonce + 1 });
         updateUserBalance();
       });

--- a/case.html
+++ b/case.html
@@ -367,10 +367,6 @@ setTimeout(() => {
           timestamp: Date.now()
         };
         await firebase.database().ref('users/' + user.uid + '/inventory').push(prizeData);
-        await firebase.database().ref('users/' + user.uid + '/pulls').push(prizeData);
-        const pullHistory = JSON.parse(localStorage.getItem('pullHistory') || '[]');
-        pullHistory.push(prizeData);
-        localStorage.setItem('pullHistory', JSON.stringify(pullHistory));
         await firebase.database().ref('users/' + user.uid + '/provablyFair').update({ nonce: nonce + 1 });
         updateUserBalance();
       });

--- a/inventory.html
+++ b/inventory.html
@@ -50,27 +50,6 @@
       font-size: 1.125rem;
     }
 
-    .showcase-hero {
-      background: linear-gradient(to right, rgba(14,165,233,0.6), rgba(168,85,247,0.6));
-      border: 1px solid rgba(255,255,255,0.1);
-      border-radius: 1.5rem;
-      padding: 2rem;
-      margin: 2rem 1.5rem;
-      box-shadow: 0 10px 30px rgba(0,0,0,0.2);
-      text-align: center;
-    }
-
-    .showcase-hero h1 {
-      font-size: 2.5rem;
-      font-weight: 800;
-      color: #fff;
-    }
-
-    .showcase-hero p {
-      color: #cbd5e1;
-      margin-top: 0.5rem;
-      font-size: 1.125rem;
-    }
 
     .item-card {
       background-color: #1f1f2b;
@@ -121,7 +100,6 @@
   <div class="flex space-x-4 bg-gray-800 p-2 rounded-xl shadow-md">
       <button onclick="showTab('inventory-section')" data-tab="inventory" class="tab-button px-4 py-2 text-white bg-pink-600 rounded-full">Inventory</button>
       <button onclick="showTab('orders-section')" data-tab="orders" class="tab-button px-4 py-2 text-white hover:bg-pink-600 rounded-full">Orders</button>
-      <button onclick="showTab('showcase-section')" data-tab="showcase" class="tab-button px-4 py-2 text-white hover:bg-pink-600 rounded-full">Showcase</button>
       <button onclick="showTab('profile-section')" data-tab="profile" class="tab-button px-4 py-2 text-white hover:bg-pink-600 rounded-full">Profile</button>
     </div>
   </div>
@@ -177,13 +155,6 @@
     <p>Below are your previous shipment requests and their current status.</p>
   </section>
   <div id="orders-container" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6"></div>
-</div>
-<div id="showcase-section" class="tab-content hidden p-6">
-  <section class="showcase-hero">
-    <h1><i class="fas fa-star mr-2"></i>Your Top Pulls</h1>
-    <p>Highlighting your most valuable collectibles.</p>
-  </section>
-  <div id="showcase-container" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6"></div>
 </div>
 <!-- Profile Section -->
 <div id="profile-section" class="tab-content hidden px-6 py-8">

--- a/inventory.html
+++ b/inventory.html
@@ -28,23 +28,23 @@
       z-index: 50;
     }
 
-    .inventory-hero {
+    .orders-hero {
       background: linear-gradient(to right, rgba(76,29,149,0.6), rgba(190,24,93,0.6));
       border: 1px solid rgba(255,255,255,0.1);
       border-radius: 1.5rem;
       padding: 2rem;
-      margin: 120px 1.5rem 2rem;
+      margin: 2rem 1.5rem;
       box-shadow: 0 10px 30px rgba(0,0,0,0.2);
       text-align: center;
     }
 
-    .inventory-hero h1 {
+    .orders-hero h1 {
       font-size: 2.5rem;
       font-weight: 800;
       color: #fff;
     }
 
-    .inventory-hero p {
+    .orders-hero p {
       color: #cbd5e1;
       margin-top: 0.5rem;
       font-size: 1.125rem;
@@ -52,6 +52,8 @@
 
     .item-card {
       background-color: #1f1f2b;
+      border: 1px solid rgba(255,255,255,0.1);
+      border-radius: 0.75rem;
       transition: transform 0.3s ease, box-shadow 0.3s ease;
       box-shadow: 0 4px 14px rgba(0,0,0,0.3);
     }
@@ -95,8 +97,9 @@
 <!-- Profile Tabs -->
 <div class="w-full flex justify-center mt-6">
   <div class="flex space-x-4 bg-gray-800 p-2 rounded-xl shadow-md">
-<button onclick="showTab('inventory-section')" data-tab="inventory" class="tab-button px-4 py-2 text-white bg-pink-600 rounded-full">Inventory</button>
-<button onclick="showTab('profile-section')" data-tab="profile" class="tab-button px-4 py-2 text-white hover:bg-pink-600 rounded-full">Profile</button>
+    <button onclick="showTab('inventory-section')" data-tab="inventory" class="tab-button px-4 py-2 text-white bg-pink-600 rounded-full">Inventory</button>
+    <button onclick="showTab('orders-section')" data-tab="orders" class="tab-button px-4 py-2 text-white hover:bg-pink-600 rounded-full">Orders</button>
+    <button onclick="showTab('profile-section')" data-tab="profile" class="tab-button px-4 py-2 text-white hover:bg-pink-600 rounded-full">Profile</button>
   </div>
 </div>
 <div id="inventory-section" class="tab-content">
@@ -126,12 +129,6 @@
 
     <div id="inventory-container" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6"></div>
 
-<section class="inventory-hero">
-  <h1><i class="fas fa-truck mr-2"></i>Your Recent Orders</h1>
-  <p>Below are your previous shipment requests and their current status.</p>
-</section>
-    <div id="orders-container" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6"></div>
-
     <!-- Ship Popup -->
     <div id="shipment-popup" class="fixed inset-0 bg-black bg-opacity-80 hidden flex justify-center items-center z-50">
       <div class="bg-gray-800 p-6 rounded-lg w-full max-w-md">
@@ -151,7 +148,14 @@
     </div>
   </main>
 </div>
-  <!-- Profile Section -->
+<div id="orders-section" class="tab-content hidden p-6">
+  <section class="orders-hero">
+    <h1><i class="fas fa-truck mr-2"></i>Your Recent Orders</h1>
+    <p>Below are your previous shipment requests and their current status.</p>
+  </section>
+  <div id="orders-container" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6"></div>
+</div>
+<!-- Profile Section -->
 <div id="profile-section" class="tab-content hidden px-6 py-8">
   <div class="max-w-lg mx-auto bg-gray-900 rounded-2xl p-6 shadow-lg">
     <h2 class="text-xl font-bold mb-4 text-white">Your Profile</h2>
@@ -223,41 +227,34 @@
   </script>
   <script>
     function showTab(tabId) {
-  // Hide all tabs
-  document.querySelectorAll(".tab-content").forEach(tab => tab.classList.add("hidden"));
+      // Hide all tabs
+      document.querySelectorAll(".tab-content").forEach(tab => tab.classList.add("hidden"));
 
-  // Show selected tab
-  document.getElementById(tabId).classList.remove("hidden");
+      // Show selected tab
+      document.getElementById(tabId).classList.remove("hidden");
 
-  // Reset all buttons
-  document.querySelectorAll(".tab-button").forEach(btn => {
-    btn.classList.remove("bg-pink-600");
-    btn.classList.add("hover:bg-pink-600");
-  });
+      // Reset all buttons
+      document.querySelectorAll(".tab-button").forEach(btn => {
+        btn.classList.remove("bg-pink-600");
+        btn.classList.add("hover:bg-pink-600");
+      });
 
-  // Highlight clicked button
-  const clickedButton = [...document.querySelectorAll(".tab-button")].find(btn =>
-    btn.getAttribute("onclick").includes(tabId)
-  );
-  if (clickedButton) {
-    clickedButton.classList.add("bg-pink-600");
-    clickedButton.classList.remove("hover:bg-pink-600");
-  }
-}
+      // Highlight clicked button
+      const clickedButton = [...document.querySelectorAll(".tab-button")].find(btn =>
+        btn.getAttribute("onclick").includes(tabId)
+      );
+      if (clickedButton) {
+        clickedButton.classList.add("bg-pink-600");
+        clickedButton.classList.remove("hover:bg-pink-600");
+      }
+    }
+
+    document.addEventListener("DOMContentLoaded", () => showTab('inventory-section'));
   </script>
-<script>
-function showTab(tabId) {
-  document.querySelectorAll(".tab-content").forEach(tab => tab.classList.add("hidden"));
-  document.getElementById(tabId).classList.remove("hidden");
 
-  document.querySelectorAll(".tab-button").forEach(btn => btn.classList.remove("bg-pink-600"));
-  event.target.classList.add("bg-pink-600");
-}
-
-
-// Load profile data
-// Load profile data
-firebase.auth().onAuthStateChanged(user => {
+  <script>
+  // Load profile data
+  firebase.auth().onAuthStateChanged(user => {
   if (user) {
     const uid = user.uid;
     const userRef = firebase.database().ref('users/' + uid);

--- a/inventory.html
+++ b/inventory.html
@@ -50,6 +50,28 @@
       font-size: 1.125rem;
     }
 
+    .showcase-hero {
+      background: linear-gradient(to right, rgba(14,165,233,0.6), rgba(168,85,247,0.6));
+      border: 1px solid rgba(255,255,255,0.1);
+      border-radius: 1.5rem;
+      padding: 2rem;
+      margin: 2rem 1.5rem;
+      box-shadow: 0 10px 30px rgba(0,0,0,0.2);
+      text-align: center;
+    }
+
+    .showcase-hero h1 {
+      font-size: 2.5rem;
+      font-weight: 800;
+      color: #fff;
+    }
+
+    .showcase-hero p {
+      color: #cbd5e1;
+      margin-top: 0.5rem;
+      font-size: 1.125rem;
+    }
+
     .item-card {
       background-color: #1f1f2b;
       border: 1px solid rgba(255,255,255,0.1);
@@ -97,12 +119,13 @@
 <!-- Profile Tabs -->
 <div class="w-full flex justify-center mt-6">
   <div class="flex space-x-4 bg-gray-800 p-2 rounded-xl shadow-md">
-    <button onclick="showTab('inventory-section')" data-tab="inventory" class="tab-button px-4 py-2 text-white bg-pink-600 rounded-full">Inventory</button>
-    <button onclick="showTab('orders-section')" data-tab="orders" class="tab-button px-4 py-2 text-white hover:bg-pink-600 rounded-full">Orders</button>
-    <button onclick="showTab('profile-section')" data-tab="profile" class="tab-button px-4 py-2 text-white hover:bg-pink-600 rounded-full">Profile</button>
+      <button onclick="showTab('inventory-section')" data-tab="inventory" class="tab-button px-4 py-2 text-white bg-pink-600 rounded-full">Inventory</button>
+      <button onclick="showTab('orders-section')" data-tab="orders" class="tab-button px-4 py-2 text-white hover:bg-pink-600 rounded-full">Orders</button>
+      <button onclick="showTab('showcase-section')" data-tab="showcase" class="tab-button px-4 py-2 text-white hover:bg-pink-600 rounded-full">Showcase</button>
+      <button onclick="showTab('profile-section')" data-tab="profile" class="tab-button px-4 py-2 text-white hover:bg-pink-600 rounded-full">Profile</button>
+    </div>
   </div>
-</div>
-<div id="inventory-section" class="tab-content">
+  <div id="inventory-section" class="tab-content">
 
   <!-- Inventory -->
   <main class="p-6">
@@ -154,6 +177,13 @@
     <p>Below are your previous shipment requests and their current status.</p>
   </section>
   <div id="orders-container" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6"></div>
+</div>
+<div id="showcase-section" class="tab-content hidden p-6">
+  <section class="showcase-hero">
+    <h1><i class="fas fa-star mr-2"></i>Your Top Pulls</h1>
+    <p>Highlighting your most valuable collectibles.</p>
+  </section>
+  <div id="showcase-container" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6"></div>
 </div>
 <!-- Profile Section -->
 <div id="profile-section" class="tab-content hidden px-6 py-8">

--- a/marketplace.html
+++ b/marketplace.html
@@ -150,10 +150,6 @@
             timestamp: Date.now()
           };
           await firebase.database().ref("users/" + firebase.auth().currentUser.uid + "/inventory").push(cardData);
-          await firebase.database().ref("users/" + firebase.auth().currentUser.uid + "/pulls").push(cardData);
-          const pullHistory = JSON.parse(localStorage.getItem('pullHistory') || '[]');
-          pullHistory.push(cardData);
-          localStorage.setItem('pullHistory', JSON.stringify(pullHistory));
           document.getElementById("popup-image").src = card.image;
           document.getElementById("popup-name").textContent = card.name;
           document.getElementById("popup-value").textContent = `${card.value.toLocaleString()} coins`;
@@ -196,10 +192,6 @@
         timestamp: Date.now()
       };
       await firebase.database().ref("users/" + user.uid + "/inventory").push(cardData);
-      await firebase.database().ref("users/" + user.uid + "/pulls").push(cardData);
-      const pullHistory = JSON.parse(localStorage.getItem('pullHistory') || '[]');
-      pullHistory.push(cardData);
-      localStorage.setItem('pullHistory', JSON.stringify(pullHistory));
 
       document.getElementById("item-popup").classList.add("hidden");
       document.getElementById("popup-image").src = window.selectedCard.image;

--- a/marketplace.html
+++ b/marketplace.html
@@ -141,14 +141,16 @@
           e.stopPropagation();
           if (userBalance < card.value) return alert("Not enough coins!");
           await firebase.database().ref("users/" + firebase.auth().currentUser.uid + "/balance").set(userBalance - card.value);
-          await firebase.database().ref("users/" + firebase.auth().currentUser.uid + "/inventory").push({
+          const cardData = {
             name: card.name,
             image: card.image,
             value: card.value,
             rarity: card.rarity,
             fromMarketplace: true,
             timestamp: Date.now()
-          });
+          };
+          await firebase.database().ref("users/" + firebase.auth().currentUser.uid + "/inventory").push(cardData);
+          await firebase.database().ref("users/" + firebase.auth().currentUser.uid + "/pulls").push(cardData);
           document.getElementById("popup-image").src = card.image;
           document.getElementById("popup-name").textContent = card.name;
           document.getElementById("popup-value").textContent = `${card.value.toLocaleString()} coins`;
@@ -182,14 +184,16 @@
       }
 
       await firebase.database().ref("users/" + user.uid + "/balance").set(userBalance - window.selectedCard.value);
-      await firebase.database().ref("users/" + user.uid + "/inventory").push({
+      const cardData = {
         name: window.selectedCard.name,
         image: window.selectedCard.image,
         value: window.selectedCard.value,
         rarity: window.selectedCard.rarity,
         fromMarketplace: true,
         timestamp: Date.now()
-      });
+      };
+      await firebase.database().ref("users/" + user.uid + "/inventory").push(cardData);
+      await firebase.database().ref("users/" + user.uid + "/pulls").push(cardData);
 
       document.getElementById("item-popup").classList.add("hidden");
       document.getElementById("popup-image").src = window.selectedCard.image;

--- a/marketplace.html
+++ b/marketplace.html
@@ -151,6 +151,9 @@
           };
           await firebase.database().ref("users/" + firebase.auth().currentUser.uid + "/inventory").push(cardData);
           await firebase.database().ref("users/" + firebase.auth().currentUser.uid + "/pulls").push(cardData);
+          const pullHistory = JSON.parse(localStorage.getItem('pullHistory') || '[]');
+          pullHistory.push(cardData);
+          localStorage.setItem('pullHistory', JSON.stringify(pullHistory));
           document.getElementById("popup-image").src = card.image;
           document.getElementById("popup-name").textContent = card.name;
           document.getElementById("popup-value").textContent = `${card.value.toLocaleString()} coins`;
@@ -194,6 +197,9 @@
       };
       await firebase.database().ref("users/" + user.uid + "/inventory").push(cardData);
       await firebase.database().ref("users/" + user.uid + "/pulls").push(cardData);
+      const pullHistory = JSON.parse(localStorage.getItem('pullHistory') || '[]');
+      pullHistory.push(cardData);
+      localStorage.setItem('pullHistory', JSON.stringify(pullHistory));
 
       document.getElementById("item-popup").classList.add("hidden");
       document.getElementById("popup-image").src = window.selectedCard.image;

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -35,6 +35,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
       sortItems('rarity');
       renderItems(currentItems);
+
+      const topThree = [...currentItems].sort((a, b) => (b.value || 0) - (a.value || 0)).slice(0, 3);
+      renderShowcase(topThree);
     });
 
     const ordersRef = db.ref('shipments').orderByChild('userId').equalTo(user.uid);
@@ -120,6 +123,26 @@ function renderItems(items) {
           </button>
           <button onclick="shipItem('${item.key}')" ${item.shipped || item.requested ? 'disabled class="px-4 py-2 bg-gray-600 cursor-not-allowed rounded-full"' : 'class="px-4 py-2 bg-green-600 hover:bg-green-700 rounded-full"'}>Ship</button>
         </div>
+      </div>`;
+  });
+}
+
+function renderShowcase(items) {
+  const container = document.getElementById('showcase-container');
+  if (!container) return;
+  container.innerHTML = '';
+
+  if (items.length === 0) {
+    container.innerHTML = '<p class="text-center text-gray-400 col-span-full">No pulls to showcase yet.</p>';
+    return;
+  }
+
+  items.forEach(item => {
+    container.innerHTML += `
+      <div class="item-card rounded-lg p-6 text-center transform hover:scale-105 transition">
+        <img src="${item.image}" class="mx-auto mb-4 h-32 object-contain rounded shadow-lg" />
+        <h2 class="font-bold text-xl text-pink-400">${item.name}</h2>
+        <p class="text-sm text-gray-300 mt-1">Value: ${item.value || 0} coins</p>
       </div>`;
   });
 }

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -15,7 +15,9 @@ document.addEventListener('DOMContentLoaded', () => {
       const data = snapshot.val();
       const balanceEl = document.getElementById('balance-amount');
       if (balanceEl) balanceEl.innerText = Number(data.balance || 0).toLocaleString();
-      document.getElementById('username-display').innerText = user.displayName || user.email;
+
+      const usernameEl = document.getElementById('username-display');
+      if (usernameEl) usernameEl.innerText = user.displayName || user.email;
     });
 
     const inventoryRef = db.ref('users/' + user.uid + '/inventory');

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -127,12 +127,23 @@ function renderItems(items) {
 
 function loadShowcase(uid) {
   const pullsRef = firebase.database().ref('users/' + uid + '/pulls');
-  pullsRef.once('value').then(snap => {
+  pullsRef.on('value', snap => {
     const pulls = [];
     snap.forEach(child => pulls.push(child.val()));
-    const source = pulls.length ? pulls : currentItems;
-    const topThree = [...source].sort((a, b) => (b.value || 0) - (a.value || 0)).slice(0, 3);
-    renderShowcase(topThree);
+    if (pulls.length) {
+      localStorage.setItem('pullHistory', JSON.stringify(pulls));
+      const topThree = [...pulls]
+        .sort((a, b) => (b.value || 0) - (a.value || 0))
+        .slice(0, 3);
+      renderShowcase(topThree);
+    } else {
+      const localPulls = JSON.parse(localStorage.getItem('pullHistory') || '[]');
+      const source = localPulls.length ? localPulls : currentItems;
+      const topThree = [...source]
+        .sort((a, b) => (b.value || 0) - (a.value || 0))
+        .slice(0, 3);
+      renderShowcase(topThree);
+    }
   });
 }
 

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -37,7 +37,6 @@ document.addEventListener('DOMContentLoaded', () => {
         renderItems(currentItems);
       }
 
-      loadShowcase(user.uid);
     });
 
     const ordersRef = db.ref('shipments').orderByChild('userId').equalTo(user.uid);
@@ -127,47 +126,6 @@ function renderItems(items) {
   });
 }
 
-function loadShowcase(uid) {
-  const pullsRef = firebase.database().ref('users/' + uid + '/pulls');
-  pullsRef.on('value', snap => {
-    const pulls = [];
-    snap.forEach(child => pulls.push(child.val()));
-    if (pulls.length) {
-      localStorage.setItem('pullHistory', JSON.stringify(pulls));
-      const topThree = [...pulls]
-        .sort((a, b) => (b.value || 0) - (a.value || 0))
-        .slice(0, 3);
-      renderShowcase(topThree);
-    } else {
-      const localPulls = JSON.parse(localStorage.getItem('pullHistory') || '[]');
-      const source = localPulls.length ? localPulls : currentItems;
-      const topThree = [...source]
-        .sort((a, b) => (b.value || 0) - (a.value || 0))
-        .slice(0, 3);
-      renderShowcase(topThree);
-    }
-  });
-}
-
-function renderShowcase(items) {
-  const container = document.getElementById('showcase-container');
-  if (!container) return;
-  container.innerHTML = '';
-
-  if (items.length === 0) {
-    container.innerHTML = '<p class="text-center text-gray-400 col-span-full">No pulls to showcase yet.</p>';
-    return;
-  }
-
-  items.forEach(item => {
-    container.innerHTML += `
-      <div class="item-card rounded-lg p-6 text-center transform hover:scale-105 transition">
-        <img src="${item.image}" class="mx-auto mb-4 h-32 object-contain rounded shadow-lg" />
-        <h2 class="font-bold text-xl text-pink-400">${item.name}</h2>
-        <p class="text-sm text-gray-300 mt-1">Value: ${item.value || 0} coins</p>
-      </div>`;
-  });
-}
 
 function sellBack(key, value) {
   const user = firebase.auth().currentUser;


### PR DESCRIPTION
## Summary
- add dedicated Orders tab on the inventory page
- move recent orders into its own section for cleaner navigation
- streamline tab switching logic and enhance card styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890dad372d48320bbef785d99b10a8d