### PR TITLE
Add free signup case and admin controls

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -82,6 +82,9 @@
               <input type="number" id="case-price" class="w-full p-2 rounded">
             </div>
             <div>
+              <label class="inline-flex items-center"><input type="checkbox" id="case-free" class="mr-2"> Free Case (price set to 0)</label>
+            </div>
+            <div>
   <label>Case Tag (e.g. 🔥 Hot, 🆕 New):</label>
   <input type="text" id="case-tag" class="w-full p-2 rounded" placeholder="Optional badge">
 </div>
@@ -231,7 +234,7 @@
             <div class="flex justify-between items-center">
               <div>
                 <p class="font-bold text-lg">${data.name}</p>
-                <p class="text-sm text-gray-400">$${data.price}</p>
+                <p class="text-sm text-gray-400">${data.isFree ? 'Free' : '$' + data.price}</p>
               </div>
               <div class="flex gap-2">
                 <button onclick="editCase('${child.key}')" class="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded">Edit</button>
@@ -352,6 +355,7 @@ function adminReply(event, caseId) {
         document.getElementById('case-image').value = data.image;
         previewImage(data.image);
         document.getElementById('case-price').value = data.price;
+        document.getElementById('case-free').checked = !!data.isFree;
         document.getElementById('case-tag').value = data.tag || '';
         document.getElementById('case-spice').value = data.spiceLevel || '';
         prizesSection.innerHTML = '<h3 class="text-xl">Prizes:</h3><button type="button" onclick="addPrize()" class="mb-2 px-4 py-2 bg-green-600 hover:bg-green-700 rounded">+ Add Prize</button>';
@@ -386,7 +390,8 @@ function adminReply(event, caseId) {
       const id = document.getElementById('case-id').value || db.ref('cases').push().key;
       const name = document.getElementById('case-name').value;
       const image = document.getElementById('case-image').value;
-      const price = parseFloat(document.getElementById('case-price').value) || 0;
+      const isFree = document.getElementById('case-free').checked;
+      const price = isFree ? 0 : parseFloat(document.getElementById('case-price').value) || 0;
       const tag = document.getElementById('case-tag').value.trim();
       const spiceLevel = document.getElementById('case-spice').value.trim();
       const prizesElements = prizesSection.querySelectorAll('div.prize-block');
@@ -400,10 +405,11 @@ function adminReply(event, caseId) {
           odds: parseFloat(div.querySelector('.prize-odds').value) || 0
         };
       });
-     db.ref('cases/' + id).set({ name, image, price, tag, spiceLevel, prizes }).then(() => {
+     db.ref('cases/' + id).set({ name, image, price, tag, spiceLevel, isFree, prizes }).then(() => {
         caseForm.reset();
         previewImage('');
        document.getElementById('case-tag').value = '';
+       document.getElementById('case-free').checked = false;
         prizesSection.innerHTML = '<h3 class="text-xl">Prizes:</h3><button type="button" onclick="addPrize()" class="mb-2 px-4 py-2 bg-green-600 hover:bg-green-700 rounded">+ Add Prize</button>';
         document.getElementById('form-title').innerText = 'Add / Edit Case';
         cancelEditBtn.classList.add('hidden');
@@ -411,14 +417,15 @@ function adminReply(event, caseId) {
       });
     }
 
-    function cancelEdit() {
-      caseForm.reset();
-      previewImage('');
-      document.getElementById('case-tag').value = '';
-      prizesSection.innerHTML = '<h3 class="text-xl">Prizes:</h3><button type="button" onclick="addPrize()" class="mb-2 px-4 py-2 bg-green-600 hover:bg-green-700 rounded">+ Add Prize</button>';
-      document.getElementById('form-title').innerText = 'Add / Edit Case';
-      cancelEditBtn.classList.add('hidden');
-    }
+function cancelEdit() {
+  caseForm.reset();
+  previewImage('');
+  document.getElementById('case-tag').value = '';
+  document.getElementById('case-free').checked = false;
+  prizesSection.innerHTML = '<h3 class="text-xl">Prizes:</h3><button type="button" onclick="addPrize()" class="mb-2 px-4 py-2 bg-green-600 hover:bg-green-700 rounded">+ Add Prize</button>';
+  document.getElementById('form-title').innerText = 'Add / Edit Case';
+  cancelEditBtn.classList.add('hidden');
+}
 
     caseForm.addEventListener('submit', saveCase);
     cancelEditBtn.addEventListener('click', cancelEdit);

--- a/auth.html
+++ b/auth.html
@@ -123,7 +123,8 @@ user.updateProfile({
     email: email,
     phone: phone,
     balance: 0,
-    role: 'user'
+    role: 'user',
+    freeCaseOpened: false
   });
 }).then(() => {
   return user.reload(); // 🔁 Ensures displayName is up-to-date before redirect

--- a/case.html
+++ b/case.html
@@ -223,6 +223,7 @@ function showToast(message, color = 'bg-red-600') {
       }
 
       const caseData = snap.val();
+      const isFreeCase = !!caseData.isFree;
       const spiceMap = {
   easy: { label: "Easy 🌶️", color: "text-green-400" },
   medium: { label: "Medium 🌶️🌶️", color: "text-orange-400" },
@@ -237,7 +238,12 @@ const spiceHTML = spiceData
   : "";
 
 document.getElementById("case-name").innerHTML = `${caseData.name} ${spiceHTML}`;
-document.getElementById("button-price").textContent = formatCoins(caseData.price);
+const openBtn = document.getElementById("open-case-button");
+if (isFreeCase) {
+  openBtn.innerHTML = '<span class="relative z-10">Open for Free</span>';
+} else {
+  document.getElementById("button-price").textContent = formatCoins(caseData.price);
+}
 
 const prizeList = Object.values(caseData.prizes || {}).sort((a, b) => {
   const rarityDiff = (rarityOrder[b.rarity?.toLowerCase()] || 0) - (rarityOrder[a.rarity?.toLowerCase()] || 0);
@@ -289,10 +295,19 @@ btn.innerHTML = `
         if (!user) return alert("Please sign in to open cases.");
 
         const userSnap = await firebase.database().ref('users/' + user.uid).once("value");
-        const balance = parseFloat(userSnap.val()?.balance || 0);
+        const userData = userSnap.val() || {};
+        const balance = parseFloat(userData.balance || 0);
         const price = parseFloat(caseData.price || 0);
 
-if (balance < price) {
+if (isFreeCase && userData.freeCaseOpened) {
+  showToast("Free case already opened!", "bg-red-600");
+  btn.disabled = false;
+  btn.classList.remove("cursor-not-allowed", "opacity-60");
+  btn.innerHTML = '<span class="relative z-10">Open for Free</span>';
+  return;
+}
+
+if (!isFreeCase && balance < price) {
   showToast("Not enough coins!", "bg-red-600");
   btn.disabled = false;
   btn.classList.remove("cursor-not-allowed", "opacity-60");
@@ -343,14 +358,14 @@ setTimeout(() => {
     const btn = document.getElementById("open-case-button");
     btn.disabled = false;
     btn.classList.remove("cursor-not-allowed", "opacity-60");
-    btn.innerHTML = `
-      <div class="absolute inset-0 rounded-full bg-gradient-to-r from-yellow-400 via-pink-500 to-purple-500 blur-xl opacity-50 z-0 animate-spin-slow"></div>
+    btn.innerHTML = isFreeCase
+      ? '<span class="relative z-10">Open for Free</span>'
+      : `<div class="absolute inset-0 rounded-full bg-gradient-to-r from-yellow-400 via-pink-500 to-purple-500 blur-xl opacity-50 z-0 animate-spin-slow"></div>
       <span class="relative z-10 flex items-center gap-2">
         Open for
         <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-5 h-5" />
         <span id="button-price">${formatCoins(caseData.price)}</span>
-      </span>
-    `;
+      </span>`;
 
     playRaritySound(winningPrize.rarity);
   });
@@ -358,7 +373,9 @@ setTimeout(() => {
 
 
 
-        await firebase.database().ref('users/' + user.uid + '/balance').set(balance - price);
+        if (!isFreeCase) {
+          await firebase.database().ref('users/' + user.uid + '/balance').set(balance - price);
+        }
         await firebase.database().ref('users/' + user.uid + '/inventory').push({
           name: winningPrize.name,
           image: winningPrize.image,
@@ -366,6 +383,9 @@ setTimeout(() => {
           value: winningPrize.value,
           timestamp: Date.now()
         });
+        if (isFreeCase) {
+          await firebase.database().ref('users/' + user.uid + '/freeCaseOpened').set(true);
+        }
         await firebase.database().ref('users/' + user.uid + '/provablyFair').update({ nonce: nonce + 1 });
         updateUserBalance();
       });

--- a/scripts/packs.js
+++ b/scripts/packs.js
@@ -29,6 +29,8 @@ function renderCases(caseList) {
 const pepperHTML = getPepperHTML(c.spiceLevel);
 
     const price = parseFloat(c.price) || 0;
+    const priceLabel = c.isFree ? "Free" : price.toLocaleString();
+    const priceIcon = c.isFree ? "" : '<img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" alt="Coin" class="w-4 h-4 inline-block">';
 
     const prizes = Object.values(c.prizes || {});
     const topPrize = prizes.sort((a, b) => (b.value || 0) - (a.value || 0))[0];
@@ -44,9 +46,9 @@ const pepperHTML = getPepperHTML(c.spiceLevel);
         <img src="${packImg}" id="${imgId}" class="case-card-img mb-2 transition-all duration-300">
         <h3 class="mt-2 font-semibold text-white">${c.name}</h3>
         <a href="case.html?id=${c.id}" class="mt-2 w-full py-2 bg-gradient-to-r from-purple-600 to-pink-500 rounded glow-button enhanced-glow flex justify-center items-center gap-2 text-white font-semibold">
-  Open for ${price.toLocaleString()}
-  <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" alt="Coin" class="w-4 h-4 inline-block">
-</a>
+    Open for ${priceLabel}
+    ${priceIcon}
+  </a>
       </div>`;
 
     // Add hover effect after rendering
@@ -70,26 +72,33 @@ const pepperHTML = getPepperHTML(c.spiceLevel);
 }
 
 function loadCases() {
-  const dbRef = firebase.database().ref("cases");
+  firebase.auth().onAuthStateChanged(user => {
+    const dbRef = firebase.database().ref("cases");
+    const freeRef = user
+      ? firebase.database().ref(`users/${user.uid}/freeCaseOpened`).once("value")
+      : Promise.resolve({ val: () => true });
 
-  dbRef.once("value").then(snapshot => {
-    const data = snapshot.val();
-    allCases = [];
+    Promise.all([dbRef.once("value"), freeRef]).then(([snapshot, freeSnap]) => {
+      const data = snapshot.val() || {};
+      const hasOpenedFree = user ? !!freeSnap.val() : true;
+      allCases = [];
 
-    for (const [id, caseData] of Object.entries(data)) {
-      allCases.push({
-        id,
-        ...caseData
-      });
-    }
+      for (const [id, caseData] of Object.entries(data)) {
+        if (caseData.isFree && (hasOpenedFree || !user)) continue;
+        allCases.push({
+          id,
+          ...caseData
+        });
+      }
 
-    renderCases(allCases); // default render
+      renderCases(allCases); // default render
 
-    const getUserBalance = () => {
-      return parseFloat(document.getElementById("balance-amount")?.innerText.replace(/,/g, "")) || 0;
-    };
+      const getUserBalance = () => {
+        return parseFloat(document.getElementById("balance-amount")?.innerText.replace(/,/g, "")) || 0;
+      };
 
-    setupFilters(allCases, renderCases, getUserBalance);
+      setupFilters(allCases, renderCases, getUserBalance);
+    });
   });
 }
 


### PR DESCRIPTION
## Summary
- allow admins to designate a case as free and edit it
- show free case to new users and hide after it is opened once
- track free case usage on account creation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890db323b2083208e5aef1633dacc89