### PR TITLE
Remove showcase option from inventory page

### DIFF
--- a/inventory.html
+++ b/inventory.html
@@ -118,9 +118,6 @@
       <button onclick="sellSelected()" class="px-6 py-2 rounded-full font-semibold bg-gradient-to-r from-pink-500 to-fuchsia-600 hover:from-pink-600 hover:to-fuchsia-700 transition btn">
   Sell Selected
       </button>
-<button onclick="shipSelected()" class="px-6 py-2 rounded-full font-semibold bg-gradient-to-r from-pink-500 to-fuchsia-600 hover:from-pink-600 hover:to-fuchsia-700 transition btn">
-  Ship Selected
-</button>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- remove showcase/ship option from the inventory toolbar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890f29d2b608320bdd7dc3c1c75cfe3