### PR TITLE
fix: ensure pack labels and button colors render across browsers

### DIFF
--- a/scripts/packs.js
+++ b/scripts/packs.js
@@ -3,20 +3,16 @@ import { setupFilters } from './filters.js';
 let allCases = [];
 function getPepperHTML(spiceLevel) {
   const map = {
-    easy: { color: "text-green-400", label: "Easy 🌶️" },
-    medium: { color: "text-orange-400", label: "Medium 🌶️🌶️" },
-    hard: { color: "text-red-500", label: "Hard 🌶️🌶️🌶️" }
+    easy: { class: "spice-label spice-easy", label: "Easy 🌶️" },
+    medium: { class: "spice-label spice-medium", label: "Medium 🌶️🌶️" },
+    hard: { class: "spice-label spice-hard", label: "Hard 🌶️🌶️🌶️" }
   };
 
   if (!map[spiceLevel]) return "";
 
-  const { color, label } = map[spiceLevel];
+  const { class: cls, label } = map[spiceLevel];
 
-  return `
-    <div class="absolute top-2 right-2 ${color} text-xs font-bold bg-black/50 px-2 py-1 rounded-full z-10">
-      ${label}
-    </div>
-  `;
+  return `<div class="${cls}">${label}</div>`;
 }
 function renderCases(caseList) {
   const casesContainer = document.getElementById("cases-container");
@@ -27,10 +23,8 @@ function renderCases(caseList) {
   const orderedCases = [...freeCases, ...paidCases];
 
   orderedCases.forEach(c => {
-    const tagHTML = c.tag
-      ? `<div class="absolute top-2 left-2 bg-pink-600 text-white text-xs px-2 py-1 rounded-full font-bold z-10">${c.tag}</div>`
-      : "";
-const pepperHTML = getPepperHTML(c.spiceLevel);
+    const tagHTML = c.tag ? `<div class="pack-tag">${c.tag}</div>` : "";
+    const pepperHTML = getPepperHTML(c.spiceLevel);
 
     const price = parseFloat(c.price) || 0;
     const priceLabel = c.isFree ? "Free" : price.toLocaleString();
@@ -49,11 +43,11 @@ const pepperHTML = getPepperHTML(c.spiceLevel);
         ${pepperHTML}
         <img src="${packImg}" id="${imgId}" class="case-card-img mb-2 transition-all duration-300">
         <h3 class="mt-2 font-semibold text-white">${c.name}</h3>
-        <a href="case.html?id=${c.id}" class="mt-2 w-full py-2 bg-pink-600 bg-gradient-to-r from-purple-600 to-pink-500 rounded glow-button enhanced-glow flex justify-center items-center gap-2 text-white font-semibold">
+        <a href="case.html?id=${c.id}" class="open-button glow-button">
     Open for ${priceLabel}
     ${priceIcon}
   </a>
-      </div>`;
+        </div>`;
 
     // Add hover effect after rendering
     setTimeout(() => {

--- a/styles/main.css
+++ b/styles/main.css
@@ -745,3 +745,47 @@ html {
   border-radius: 0.75rem;
 }
 
+/* Cross-browser styles for dynamic pack labels and buttons */
+.pack-tag {
+  position: absolute;
+  top: 0.5rem;
+  left: 0.5rem;
+  background-color: #db2777;
+  color: #fff;
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 9999px;
+  font-weight: 700;
+  z-index: 10;
+}
+
+.spice-label {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background-color: rgba(0, 0, 0, 0.5);
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.25rem 0.5rem;
+  border-radius: 9999px;
+  z-index: 10;
+}
+.spice-easy { color: #4ade80; }
+.spice-medium { color: #fb923c; }
+.spice-hard { color: #ef4444; }
+
+.open-button {
+  margin-top: 0.5rem;
+  width: 100%;
+  padding: 0.5rem 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  color: #fff;
+  font-weight: 600;
+  border-radius: 0.5rem;
+  background: #db2777;
+  background: -webkit-linear-gradient(left, #9333ea, #ec4899);
+  background: linear-gradient(to right, #9333ea, #ec4899);
+}


### PR DESCRIPTION
## Summary
- define cross-browser CSS for dynamic pack labels and "Open for" buttons
- update pack rendering script to use new CSS classes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890fb6043dc832085a2219609fe6e1d