### PR TITLE
fix: improve mobile layout for best drops

### DIFF
--- a/scripts/wins.js
+++ b/scripts/wins.js
@@ -35,23 +35,23 @@ function displayLiveWins(prizes) {
     }
 
     card.className = `
-      min-w-[160px] bg-[#12121b] p-3 rounded-xl border ${glowClass}
+      min-w-[120px] md:min-w-[160px] bg-[#12121b] p-3 rounded-xl border ${glowClass}
       text-center flex-shrink-0 mx-2 transform transition duration-200 hover:scale-105
     `;
 
     if (prize.packImage) {
       card.innerHTML = `
-        <div class="relative w-full max-w-[120px] h-[120px] mx-auto group">
-          <img src="${prize.image}" class="absolute inset-0 w-full h-full object-contain rounded-md shadow-md transition-opacity duration-300 group-hover:opacity-0 pointer-events-none" />
-          <img src="${prize.packImage}" class="absolute inset-0 w-full h-full object-contain rounded-md shadow-md opacity-0 transition-opacity duration-300 group-hover:opacity-100 pointer-events-none" />
+        <div class="relative w-full max-w-[90px] h-[90px] md:max-w-[120px] md:h-[120px] mx-auto group overflow-hidden">
+          <img src="${prize.image}" class="absolute inset-0 w-full h-full object-contain rounded-md shadow-md transition-opacity duration-300 md:group-hover:opacity-0 pointer-events-none" />
+          <img src="${prize.packImage}" class="absolute inset-0 w-full h-full object-contain rounded-md shadow-md opacity-0 transition-opacity duration-300 md:group-hover:opacity-100 pointer-events-none" />
         </div>
-        <div class="text-sm text-white text-center leading-tight mt-2 truncate w-full max-w-[120px] mx-auto" title="${prize.name}">${prize.name}</div>
+        <div class="text-sm text-white text-center leading-tight mt-2 truncate w-full max-w-[90px] md:max-w-[120px] mx-auto" title="${prize.name}">${prize.name}</div>
         <div class="text-xs text-gray-400 text-center italic">From: ${prize.caseName || 'Mystery Pack'}</div>
       `;
     } else {
       card.innerHTML = `
-        <img src="${prize.image}" class="w-full max-w-[120px] h-[120px] object-contain mx-auto rounded-md shadow-md mb-2" />
-        <div class="text-sm text-white text-center leading-tight truncate w-full max-w-[120px] mx-auto mt-2" title="${prize.name}">${prize.name}</div>
+        <img src="${prize.image}" class="w-full max-w-[90px] h-[90px] md:max-w-[120px] md:h-[120px] object-contain mx-auto rounded-md shadow-md mb-2" />
+        <div class="text-sm text-white text-center leading-tight truncate w-full max-w-[90px] md:max-w-[120px] mx-auto mt-2" title="${prize.name}">${prize.name}</div>
         <div class="text-xs text-gray-400 text-center italic">From: ${prize.caseName || 'Mystery Pack'}</div>
       `;
     }


### PR DESCRIPTION
## Summary
- make best drops cards responsive on mobile by shrinking card and image sizes
- restrict hover-based pack preview to larger screens and hide overflow to prevent cut-off

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/cases/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6890fe872fc8832097451646edd48170