### PR TITLE
Add animations for menus and balance updates

### DIFF
--- a/scripts/header.js
+++ b/scripts/header.js
@@ -62,6 +62,7 @@ document.addEventListener("DOMContentLoaded", () => {
     if (!user) return;
     const db = firebase.database();
     const userRef = db.ref("users/" + user.uid);
+    let prevBalance = null;
 
     userRef.on("value", (snapshot) => {
       const data = snapshot.val() || {};
@@ -76,9 +77,25 @@ document.addEventListener("DOMContentLoaded", () => {
       const mobileAuth = document.getElementById("mobile-auth-button");
       const inventoryLink = document.getElementById("inventory-link");
 
-      if (balanceDesktop) balanceDesktop.innerText = parseInt(balance, 10).toLocaleString();
-      if (balanceMobile) balanceMobile.innerText = parseInt(balance, 10).toLocaleString();
+      const formatted = parseInt(balance, 10).toLocaleString();
+      if (balanceDesktop) balanceDesktop.innerText = formatted;
+      if (balanceMobile) balanceMobile.innerText = formatted;
       if (userBalanceDiv) userBalanceDiv.classList.remove("hidden");
+
+      if (prevBalance !== balance) {
+        const userBalanceMobileDiv = document.getElementById("user-balance-mobile");
+        [userBalanceDiv, userBalanceMobileDiv].forEach((el) => {
+          if (el) {
+            el.classList.add("pulse-balance");
+            el.addEventListener(
+              "animationend",
+              () => el.classList.remove("pulse-balance"),
+              { once: true }
+            );
+          }
+        });
+        prevBalance = balance;
+      }
       if (usernameDisplay) usernameDisplay.innerText = user.displayName || data.username || user.email || "User";
       if (signinDesktop) signinDesktop.classList.add("hidden");
       if (logoutDesktop) logoutDesktop.classList.remove("hidden");

--- a/scripts/navbar.js
+++ b/scripts/navbar.js
@@ -94,10 +94,31 @@ waitForElement("#topup-button", () => {
   waitForElement("#dropdown-toggle", () => {
     const dropdownToggle = document.getElementById("dropdown-toggle");
     const userDropdown = document.getElementById("user-dropdown");
+    const openDropdown = () => {
+      userDropdown.classList.remove("hidden", "fade-out");
+      userDropdown.classList.add("fade-in");
+    };
+
+    const closeDropdown = () => {
+      userDropdown.classList.remove("fade-in");
+      userDropdown.classList.add("fade-out");
+      userDropdown.addEventListener(
+        "animationend",
+        () => {
+          userDropdown.classList.add("hidden");
+          userDropdown.classList.remove("fade-out");
+        },
+        { once: true }
+      );
+    };
 
     dropdownToggle.addEventListener("click", (e) => {
       e.stopPropagation();
-      userDropdown.classList.toggle("hidden");
+      if (userDropdown.classList.contains("hidden")) {
+        openDropdown();
+      } else {
+        closeDropdown();
+      }
     });
 
     document.addEventListener("click", (e) => {
@@ -106,7 +127,7 @@ waitForElement("#topup-button", () => {
         !userDropdown.contains(e.target) &&
         !dropdownToggle.contains(e.target)
       ) {
-        userDropdown.classList.add("hidden");
+        closeDropdown();
       }
     });
   });
@@ -115,10 +136,44 @@ waitForElement("#topup-button", () => {
   waitForElement("#menu-toggle", () => {
     const menuToggle = document.getElementById("menu-toggle");
     const mobileDropdown = document.getElementById("mobile-dropdown");
+    const menuIcon = menuToggle.querySelector("i");
+    menuToggle.classList.add("transition-transform", "duration-200");
+
+    const openMenu = () => {
+      mobileDropdown.classList.remove("hidden", "fade-out");
+      mobileDropdown.classList.add("fade-in");
+      menuToggle.classList.add("rotate-90");
+      if (menuIcon) {
+        menuIcon.classList.remove("fa-bars");
+        menuIcon.classList.add("fa-times");
+      }
+    };
+
+    const closeMenu = () => {
+      mobileDropdown.classList.remove("fade-in");
+      mobileDropdown.classList.add("fade-out");
+      mobileDropdown.addEventListener(
+        "animationend",
+        () => {
+          mobileDropdown.classList.add("hidden");
+          mobileDropdown.classList.remove("fade-out");
+        },
+        { once: true }
+      );
+      menuToggle.classList.remove("rotate-90");
+      if (menuIcon) {
+        menuIcon.classList.remove("fa-times");
+        menuIcon.classList.add("fa-bars");
+      }
+    };
 
     menuToggle.addEventListener("click", (e) => {
       e.stopPropagation();
-      mobileDropdown.classList.toggle("hidden");
+      if (mobileDropdown.classList.contains("hidden")) {
+        openMenu();
+      } else {
+        closeMenu();
+      }
     });
 
     document.addEventListener("click", (event) => {
@@ -127,7 +182,7 @@ waitForElement("#topup-button", () => {
         !mobileDropdown.contains(event.target) &&
         !menuToggle.contains(event.target)
       ) {
-        mobileDropdown.classList.add("hidden");
+        closeMenu();
       }
     });
   });

--- a/styles/main.css
+++ b/styles/main.css
@@ -784,3 +784,33 @@ html {
   background: -webkit-linear-gradient(left, #9333ea, #ec4899);
   background: linear-gradient(to right, #9333ea, #ec4899);
 }
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(-5px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fade-out {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-5px);
+  }
+}
+
+.fade-in {
+  animation: fade-in 0.2s ease forwards;
+}
+
+.fade-out {
+  animation: fade-out 0.2s ease forwards;
+}


### PR DESCRIPTION
## Summary
- animate dropdown and hamburger menu with fade effects and menu icon rotation
- pulse coin balance in header when balance changes
- add reusable fade-in/out CSS animations

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68910e2a1e8083208adc2bf013a38f01