### PR TITLE
feat: add theme toggle

### DIFF
--- a/scripts/header.js
+++ b/scripts/header.js
@@ -16,6 +16,7 @@ document.addEventListener("DOMContentLoaded", () => {
         <a href="marketplace.html" class="flex items-center gap-1 text-pink-400 font-semibold hover:text-pink-300 transition">
           <i class="fas fa-store"></i> Marketplace
         </a>
+        <button id="theme-toggle" class="text-white font-semibold hover:text-gray-300 transition">Theme</button>
         <div id="user-balance" class="flex items-center gap-1 bg-gray-800 text-white px-3 py-1 rounded-full text-sm hidden">
           <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" />
           <span id="balance-amount">0</span>
@@ -51,11 +52,21 @@ document.addEventListener("DOMContentLoaded", () => {
       <a href="index.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm"><i class="fas fa-cube mr-2"></i> Open Packs</a>
       <a id="inventory-link" href="inventory.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm hidden"><i class="fas fa-box-open mr-2"></i> Inventory</a>
       <a href="how-it-works.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm"><i class="fas fa-question-circle mr-2"></i> How It Works</a>
+      <button id="theme-toggle-mobile" class="block w-full text-left px-4 py-2 hover:bg-gray-700 text-white text-sm">Theme</button>
       <a href="rewards.html" class="block px-4 py-2 hover:bg-gray-700 text-yellow-400 text-sm"><i class="fas fa-gift mr-2"></i> Rewards</a>
       <a href="marketplace.html" class="block px-4 py-2 hover:bg-gray-700 text-pink-400 text-sm"><i class="fas fa-store mr-2"></i> Marketplace</a>
       <a id="mobile-auth-button" href="auth.html" class="block px-4 py-2 hover:bg-gray-700 text-red-400 text-sm"><i class="fas fa-sign-in-alt mr-2"></i> Sign In</a>
     </div>
   `; // <-- closing backtick and semicolon!
+
+  const themeButtons = [document.getElementById("theme-toggle"), document.getElementById("theme-toggle-mobile")];
+  themeButtons.forEach((btn) => {
+    if (!btn) return;
+    btn.addEventListener("click", () => {
+      const current = document.documentElement.getAttribute("data-theme");
+      document.documentElement.setAttribute("data-theme", current === "light" ? "dark" : "light");
+    });
+  });
 
   // Firebase auth logic
   firebase.auth().onAuthStateChanged(async (user) => {

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,9 +1,57 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter&display=swap');
 
+:root {
+  --bg-color: #0f0f12;
+  --text-color: #ffffff;
+  --accent-color: #ec4899;
+  --accent-secondary: #9333ea;
+  --accent-solid: #db2777;
+  --coin-box-bg: rgba(255, 255, 255, 0.05);
+  --coin-box-border: rgba(255, 255, 255, 0.1);
+  --accent-glow1: rgba(236, 72, 153, 0.7);
+  --accent-glow2: rgba(147, 51, 234, 0.5);
+  --accent-glow1-hover: rgba(236, 72, 153, 0.9);
+  --accent-glow2-hover: rgba(147, 51, 234, 0.7);
+  --frost-start: rgba(147, 51, 234, 0.4);
+  --frost-end: rgba(236, 72, 153, 0.4);
+  --card-hover-shadow: rgba(255, 255, 255, 0.15);
+  --stardust-color: #ffffff;
+  --stardust-shadow: rgba(255, 255, 255, 0.8);
+  --item-bg: #1c1c1c;
+  --item-shadow: rgba(255,255,255,0.05);
+  --accent-tertiary: #facc15;
+  --pulse-shadow-start: rgba(255, 255, 255, 0.1);
+  --pulse-shadow-end: rgba(255, 255, 255, 0.8);
+}
+
+[data-theme="light"] {
+  --bg-color: #ffffff;
+  --text-color: #000000;
+  --accent-color: #3b82f6;
+  --accent-secondary: #8b5cf6;
+  --accent-solid: #2563eb;
+  --coin-box-bg: rgba(0, 0, 0, 0.05);
+  --coin-box-border: rgba(0, 0, 0, 0.1);
+  --accent-glow1: rgba(59, 130, 246, 0.7);
+  --accent-glow2: rgba(139, 92, 246, 0.5);
+  --accent-glow1-hover: rgba(59, 130, 246, 0.9);
+  --accent-glow2-hover: rgba(139, 92, 246, 0.7);
+  --frost-start: rgba(139, 92, 246, 0.4);
+  --frost-end: rgba(59, 130, 246, 0.4);
+  --card-hover-shadow: rgba(0, 0, 0, 0.15);
+  --stardust-color: #000000;
+  --stardust-shadow: rgba(0, 0, 0, 0.8);
+  --item-bg: #f3f3f3;
+  --item-shadow: rgba(0,0,0,0.05);
+  --accent-tertiary: #facc15;
+  --pulse-shadow-start: rgba(0, 0, 0, 0.1);
+  --pulse-shadow-end: rgba(0, 0, 0, 0.8);
+}
+
 body {
   font-family: 'Inter', sans-serif;
-  background-color: #0f0f12;
-  color: white;
+  background-color: var(--bg-color);
+  color: var(--text-color);
 }
 
 .case-card-img {
@@ -60,18 +108,18 @@ body {
 }
 
 .glow-button {
-  box-shadow: 0 0 10px rgba(236, 72, 153, 0.7), 0 0 20px rgba(147, 51, 234, 0.5);
+  box-shadow: 0 0 10px var(--accent-glow1), 0 0 20px var(--accent-glow2);
   transition: box-shadow 0.3s ease, transform 0.3s ease;
 }
 
 .glow-button:hover {
   transform: scale(1.05);
-  box-shadow: 0 0 15px rgba(236, 72, 153, 0.9), 0 0 30px rgba(147, 51, 234, 0.7);
+  box-shadow: 0 0 15px var(--accent-glow1-hover), 0 0 30px var(--accent-glow2-hover);
 }
 
 .frost-hero {
   backdrop-filter: blur(16px);
-  background: linear-gradient(270deg, rgba(147, 51, 234, 0.4), rgba(236, 72, 153, 0.4));
+  background: linear-gradient(270deg, var(--frost-start), var(--frost-end));
   background-size: 400% 400%;
   animation: gradientMove 15s ease infinite;
 }
@@ -84,12 +132,12 @@ body {
 
 .case-card-img:hover {
   transform: scale(1.03) rotate(-1deg);
-  box-shadow: 0 0 14px rgba(255, 255, 255, 0.15);
+  box-shadow: 0 0 14px var(--card-hover-shadow);
 }
 
 .coin-box {
-  background-color: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  background-color: var(--coin-box-bg);
+  border: 1px solid var(--coin-box-border);
   padding: 6px 12px;
   border-radius: 9999px;
   display: flex;
@@ -165,7 +213,7 @@ body {
 
 .premium-button {
   background: linear-gradient(to right, #d4af37, #b8860b);
-  color: white;
+  color: var(--text-color);
   font-weight: 600;
   border-radius: 12px;
   transition: all 0.3s ease;
@@ -271,10 +319,10 @@ body {
   height: 200%;
   top: -50%;
   left: -50%;
-  background-image: radial-gradient(2px 2px at 20% 30%, #fff, transparent),
-                    radial-gradient(1.5px 1.5px at 60% 70%, #fff, transparent),
-                    radial-gradient(1px 1px at 90% 10%, #fff, transparent),
-                    radial-gradient(2px 2px at 10% 90%, #fff, transparent);
+  background-image: radial-gradient(2px 2px at 20% 30%, var(--stardust-color), transparent),
+                    radial-gradient(1.5px 1.5px at 60% 70%, var(--stardust-color), transparent),
+                    radial-gradient(1px 1px at 90% 10%, var(--stardust-color), transparent),
+                    radial-gradient(2px 2px at 10% 90%, var(--stardust-color), transparent);
   animation: twinkle 30s linear infinite;
   opacity: 0.15;
   pointer-events: none;
@@ -303,7 +351,7 @@ body {
   position: absolute;
   width: 2px;
   height: 2px;
-  background: white;
+  background: var(--stardust-color);
   border-radius: 50%;
   opacity: 0.3;
   animation: drift 10s linear infinite;
@@ -337,10 +385,10 @@ body {
   position: absolute;
   width: 6px;
   height: 6px;
-  background: white;
+  background: var(--stardust-color);
   border-radius: 9999px;
   opacity: 0.6;
-  box-shadow: 0 0 8px rgba(255, 255, 255, 0.8);
+  box-shadow: 0 0 8px var(--stardust-shadow);
   animation: floatUp 8s linear infinite;
 }
 
@@ -422,12 +470,12 @@ html {
   border: 2px solid crimson;
   background: linear-gradient(45deg, crimson, orange);
   box-shadow: 0 0 20px crimson, 0 0 30px orange;
-  color: white;
+  color: var(--text-color);
 }
 .item {
-  background: #1c1c1c;
+  background: var(--item-bg);
   font-weight: bold;
-  box-shadow: 0 0 10px rgba(255,255,255,0.05);
+  box-shadow: 0 0 10px var(--item-shadow);
 }
 @keyframes scroll-preview {
   0% { transform: translateX(0); }
@@ -450,11 +498,11 @@ html {
 <style>
   .glow-card {
     box-shadow:
-      0 0 12px rgba(255, 105, 180, 0.6),
-      0 0 20px rgba(255, 255, 255, 0.3),
-      0 0 25px rgba(255, 105, 180, 0.4);
+      0 0 12px var(--accent-glow1),
+      0 0 20px var(--stardust-shadow),
+      0 0 25px var(--accent-glow1);
     transition: box-shadow 0.4s ease;
-    background-color: rgba(255, 255, 255, 0.05);
+    background-color: var(--coin-box-bg);
   }
 </style>
 
@@ -675,7 +723,7 @@ html {
   right: -4px;
   bottom: -4px;
   border-radius: 9999px;
-  background: conic-gradient(from 0deg, #facc15, #ec4899, #8b5cf6, #facc15);
+  background: conic-gradient(from 0deg, var(--accent-tertiary), var(--accent-color), var(--accent-secondary), var(--accent-tertiary));
   z-index: -1;
   animation: rotate-light 2s linear infinite;
   filter: blur(6px);
@@ -712,10 +760,10 @@ html {
 }
 @keyframes pulseGlow {
   0%, 100% {
-    box-shadow: 0 0 10px rgba(255, 255, 255, 0.1);
+    box-shadow: 0 0 10px var(--pulse-shadow-start);
   }
   50% {
-    box-shadow: 0 0 35px rgba(255, 255, 255, 0.8);
+    box-shadow: 0 0 35px var(--pulse-shadow-end);
   }
 }
 
@@ -745,8 +793,8 @@ html {
   position: absolute;
   top: 0.5rem;
   left: 0.5rem;
-  background-color: #db2777;
-  color: #fff;
+  background-color: var(--accent-solid);
+  color: var(--text-color);
   font-size: 0.75rem;
   padding: 0.25rem 0.5rem;
   border-radius: 9999px;
@@ -777,10 +825,10 @@ html {
   justify-content: center;
   align-items: center;
   gap: 0.5rem;
-  color: #fff;
+  color: var(--text-color);
   font-weight: 600;
   border-radius: 0.5rem;
-  background: #db2777;
-  background: -webkit-linear-gradient(left, #9333ea, #ec4899);
-  background: linear-gradient(to right, #9333ea, #ec4899);
+  background: var(--accent-solid);
+  background: -webkit-linear-gradient(left, var(--accent-secondary), var(--accent-color));
+  background: linear-gradient(to right, var(--accent-secondary), var(--accent-color));
 }


### PR DESCRIPTION
## Summary
- add reusable color variables and light theme overrides
- introduce theme toggle buttons and data-theme switching

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/cases/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_689110e7d7348320abb4d348fbcd663a