### PR TITLE
Add leaderboard and badge milestone system

### DIFF
--- a/case.html
+++ b/case.html
@@ -122,6 +122,7 @@
   <!-- Main logic -->
 <script type="module">
 import { renderSpinner, spinToPrize } from './scripts/spinner.js';
+import { updateMilestones } from './scripts/quests.js';
 let isMuted = false;
 function applyMuteState() {
   document.querySelectorAll('audio').forEach(a => { a.muted = isMuted; });
@@ -398,6 +399,7 @@ setTimeout(() => {
           value: winningPrize.value,
           timestamp: Date.now()
         });
+        await updateMilestones(user.uid, winningPrize.value);
         if (isFreeCase) {
           await firebase.database().ref('users/' + user.uid + '/freeCaseOpened').set(true);
         }

--- a/inventory.html
+++ b/inventory.html
@@ -158,6 +158,7 @@
     <div class="mb-6 text-center">
 <div id="profile-pic" class="w-24 h-24 rounded-full bg-pink-600 text-white text-3xl font-bold flex items-center justify-center mx-auto border-4 border-pink-600 shadow-lg"></div>
 </div>
+<div id="badge-container" class="flex flex-wrap justify-center gap-2 mb-6"></div>
 
 <div class="mb-4 text-center">
   <label class="block text-sm font-medium text-gray-300 mb-1">Username</label>

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Leaderboard | Packly.gg</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
+</head>
+<body class="bg-gray-900 text-white min-h-screen">
+  <header></header>
+  <section class="pt-32 px-4">
+    <div class="max-w-3xl mx-auto bg-gray-800 rounded-2xl p-6 shadow-lg">
+      <h1 class="text-3xl font-bold text-center mb-6 text-yellow-300">Top Players</h1>
+      <table class="w-full text-left">
+        <thead>
+          <tr class="border-b border-gray-700">
+            <th class="py-2 px-2">Rank</th>
+            <th class="py-2 px-2">Player</th>
+            <th class="py-2 px-2">Packs Opened</th>
+            <th class="py-2 px-2">Card Value</th>
+            <th class="py-2 px-2">Badges</th>
+          </tr>
+        </thead>
+        <tbody id="leaderboard-body"></tbody>
+      </table>
+    </div>
+  </section>
+  <footer></footer>
+  <script src="scripts/firebase-config.js"></script>
+  <script src="scripts/header.js"></script>
+  <script src="scripts/navbar.js"></script>
+  <script src="scripts/footer.js"></script>
+  <script src="scripts/leaderboard.js"></script>
+</body>
+</html>

--- a/scripts/header.js
+++ b/scripts/header.js
@@ -13,6 +13,9 @@ document.addEventListener("DOMContentLoaded", () => {
         <a href="rewards.html" class="flex items-center gap-1 text-yellow-400 font-semibold hover:text-yellow-300 transition">
           <i class="fas fa-gift"></i> Rewards
         </a>
+        <a href="leaderboard.html" class="flex items-center gap-1 text-blue-400 font-semibold hover:text-blue-300 transition">
+          <i class="fas fa-trophy"></i> Leaderboard
+        </a>
         <a href="marketplace.html" class="flex items-center gap-1 text-pink-400 font-semibold hover:text-pink-300 transition">
           <i class="fas fa-store"></i> Marketplace
         </a>
@@ -53,6 +56,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <a href="how-it-works.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm"><i class="fas fa-question-circle mr-2"></i> How It Works</a>
       <a href="rewards.html" class="block px-4 py-2 hover:bg-gray-700 text-yellow-400 text-sm"><i class="fas fa-gift mr-2"></i> Rewards</a>
       <a href="marketplace.html" class="block px-4 py-2 hover:bg-gray-700 text-pink-400 text-sm"><i class="fas fa-store mr-2"></i> Marketplace</a>
+      <a href="leaderboard.html" class="block px-4 py-2 hover:bg-gray-700 text-blue-400 text-sm"><i class="fas fa-trophy mr-2"></i> Leaderboard</a>
       <a id="mobile-auth-button" href="auth.html" class="block px-4 py-2 hover:bg-gray-700 text-red-400 text-sm"><i class="fas fa-sign-in-alt mr-2"></i> Sign In</a>
     </div>
   `; // <-- closing backtick and semicolon!

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -18,6 +18,21 @@ document.addEventListener('DOMContentLoaded', () => {
       document.getElementById('username-display').innerText = user.displayName || user.email;
     });
 
+    // Load badges from Firestore
+    firebase.firestore().collection('leaderboard').doc(user.uid).get().then(doc => {
+      const badgeData = doc.data() || {};
+      const badges = badgeData.badges || [];
+      const container = document.getElementById('badge-container');
+      if (!container) return;
+      if (badges.length === 0) {
+        container.innerHTML = '<p class="text-sm text-gray-400">No badges yet.</p>';
+      } else {
+        container.innerHTML = badges
+          .map(b => `<span class="bg-purple-600 text-white text-xs px-2 py-1 rounded-full">${b}</span>`)
+          .join(' ');
+      }
+    });
+
     const inventoryRef = db.ref('users/' + user.uid + '/inventory');
     inventoryRef.once('value').then(snap => {
       if (!snap.exists()) {

--- a/scripts/leaderboard.js
+++ b/scripts/leaderboard.js
@@ -1,0 +1,30 @@
+// scripts/leaderboard.js
+// Fetch top players from Firestore and render leaderboard
+
+document.addEventListener('DOMContentLoaded', () => {
+  const tbody = document.getElementById('leaderboard-body');
+  if (!tbody) return;
+
+  const db = firebase.firestore();
+  db.collection('leaderboard')
+    .orderBy('cardValue', 'desc')
+    .limit(10)
+    .get()
+    .then((snap) => {
+      let rank = 1;
+      snap.forEach((doc) => {
+        const data = doc.data();
+        const badges = (data.badges || [])
+          .map((b) => `<span class="bg-purple-600 text-white text-xs px-2 py-1 rounded-full mr-1">${b}</span>`) 
+          .join('');
+        tbody.innerHTML += `
+          <tr class="border-b border-gray-700">
+            <td class="py-2 px-2 text-center">${rank++}</td>
+            <td class="py-2 px-2">${data.username || 'Anonymous'}</td>
+            <td class="py-2 px-2 text-center">${data.packsOpened || 0}</td>
+            <td class="py-2 px-2 text-center">${(data.cardValue || 0).toLocaleString()}</td>
+            <td class="py-2 px-2">${badges}</td>
+          </tr>`;
+      });
+    });
+});


### PR DESCRIPTION
## Summary
- track pack-opening milestones and card-value totals in Firestore, awarding badges via `updateMilestones`
- show badges in inventory profiles and add navigation links to a new leaderboard
- render top players on a dedicated leaderboard page with pack counts, card values, and badges

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68911180b48c83209eb3d80d4c2499a6