### PR TITLE
Add Firestore chat widget

### DIFF
--- a/case.html
+++ b/case.html
@@ -658,5 +658,16 @@ document.getElementById("close-prize-popup").addEventListener("click", () => {
     <audio id="sell-sound" src="https://firebasestorage.googleapis.com/v0/b/cases-e5b4e.firebasestorage.app/o/coin-drops-and-spins-272429.mp3?alt=media&token=e867f5db-1646-4548-8403-6d1fce220c71"></audio>
     <!-- Toast Notification -->
 <div id="toast" class="fixed bottom-6 left-1/2 transform -translate-x-1/2 px-5 py-3 rounded-xl text-white font-bold text-sm z-[9999] bg-red-600 shadow-lg hidden transition-all duration-300 opacity-0"></div>
+<!-- Chat Widget -->
+<div id="chat-widget" class="fixed bottom-4 right-4 w-80 max-h-96 text-sm shadow-lg">
+  <div id="chat-messages" class="p-3 overflow-y-auto flex-1 space-y-2"></div>
+  <div id="chat-login-notice" class="p-3 text-center text-gray-400 text-xs hidden">Please sign in to join the chat.</div>
+  <form id="chat-form" class="flex p-3 border-t border-white/10">
+    <input id="chat-input" type="text" class="flex-1 bg-transparent focus:outline-none" placeholder="Type a message..." disabled />
+    <button type="submit" class="ml-2 px-3 py-1 rounded text-white font-bold bg-gradient-to-r from-yellow-400 via-pink-500 to-purple-500 disabled:opacity-50">Send</button>
+  </form>
+</div>
+<script type="module" src="scripts/auth.js"></script>
+<script type="module" src="scripts/chat.js"></script>
 </body>
 </html>

--- a/scripts/auth.js
+++ b/scripts/auth.js
@@ -10,6 +10,8 @@ window.addEventListener('DOMContentLoaded', () => {
     const popupBalance = document.getElementById('popup-balance');
     const userBalanceWrapper = document.getElementById('user-balance');
     const usernameDisplay = document.getElementById('username-display');
+    const chatInput = document.getElementById('chat-input');
+    const chatNotice = document.getElementById('chat-login-notice');
 
     if (user) {
       const userRef = firebase.database().ref('users/' + user.uid);
@@ -65,6 +67,9 @@ window.addEventListener('DOMContentLoaded', () => {
         };
       }
 
+      if (chatInput) chatInput.disabled = false;
+      if (chatNotice) chatNotice.classList.add('hidden');
+
     } else {
       // Signed out state
       if (userBalanceWrapper) userBalanceWrapper.classList.add('hidden');
@@ -80,6 +85,9 @@ window.addEventListener('DOMContentLoaded', () => {
         mobileAuthButton.href = "auth.html";
         mobileAuthButton.onclick = null;
       }
+
+      if (chatInput) chatInput.disabled = true;
+      if (chatNotice) chatNotice.classList.remove('hidden');
     }
   });
 });

--- a/scripts/chat.js
+++ b/scripts/chat.js
@@ -1,0 +1,55 @@
+const params = new URLSearchParams(window.location.search);
+const caseId = params.get('id');
+
+const db = firebase.firestore();
+const auth = firebase.auth();
+
+const messagesEl = document.getElementById('chat-messages');
+const form = document.getElementById('chat-form');
+const input = document.getElementById('chat-input');
+
+function addMessage(data) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'chat-message';
+
+  const author = document.createElement('span');
+  author.className = 'author';
+  author.textContent = data.username || 'Anon';
+
+  const text = document.createElement('span');
+  text.textContent = data.message;
+
+  wrapper.appendChild(author);
+  wrapper.appendChild(text);
+  messagesEl.appendChild(wrapper);
+  messagesEl.scrollTop = messagesEl.scrollHeight;
+}
+
+if (caseId) {
+  db.collection('cases').doc(caseId).collection('chat')
+    .orderBy('timestamp')
+    .onSnapshot(snapshot => {
+      snapshot.docChanges().forEach(change => {
+        if (change.type === 'added') {
+          addMessage(change.doc.data());
+        }
+      });
+    });
+}
+
+if (form) {
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const user = auth.currentUser;
+    if (!user) return;
+    const message = input.value.trim();
+    if (!message) return;
+    await db.collection('cases').doc(caseId).collection('chat').add({
+      uid: user.uid,
+      username: user.displayName || user.email || 'User',
+      message,
+      timestamp: firebase.firestore.FieldValue.serverTimestamp()
+    });
+    input.value = '';
+  });
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -814,3 +814,23 @@ html {
 .fade-out {
   animation: fade-out 0.2s ease forwards;
 }
+
+/* Chat widget styling */
+#chat-widget {
+  background-color: rgba(17, 24, 39, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0.75rem;
+  display: flex;
+  flex-direction: column;
+}
+
+#chat-widget .chat-message {
+  padding: 0.25rem 0.5rem;
+  display: flex;
+  gap: 0.25rem;
+}
+
+#chat-widget .chat-message .author {
+  font-weight: 600;
+  color: #ec4899;
+}


### PR DESCRIPTION
## Summary
- integrate realtime chat widget on case page
- style chat widget and gate sending via auth state

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891116f962083208cbcb85f298ee5b5