### PR TITLE
feat: enable mobile click toggle for wins cards

### DIFF
--- a/scripts/wins.js
+++ b/scripts/wins.js
@@ -41,11 +41,12 @@
         prizeImg.classList.toggle('opacity-0', !showingPack);
       };
 
-      const prefersTouch = window.matchMedia('(hover: none)').matches;
+      const prefersTouch =
+        window.matchMedia('(hover: none)').matches || navigator.maxTouchPoints > 0;
 
-      if (prefersTouch) {
-        imgWrapper.addEventListener('click', toggle);
-      } else {
+      imgWrapper.addEventListener('click', toggle);
+
+      if (!prefersTouch) {
         imgWrapper.addEventListener('mouseenter', toggle);
         imgWrapper.addEventListener('mouseleave', toggle);
       }


### PR DESCRIPTION
## Summary
- ensure wins carousel toggles between card and pack images on tap for mobile
- broaden touch detection and always register click handler

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/cases/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_689115af2df88320b903e071426c84b4