### PR TITLE
Redesign hero section with animated pack display

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,8 +39,8 @@
 <header></header>
 
 <!-- Hero -->
-<section id="hero" class="pt-20 pb-12 px-6 bg-gradient-to-br from-gray-900 via-purple-900 to-gray-900">
-  <div class="container mx-auto max-w-6xl flex flex-col gap-6">
+<section id="hero" class="relative overflow-hidden bg-gradient-to-b from-gray-900 via-purple-900 to-gray-900">
+  <div class="container mx-auto max-w-6xl px-6 pt-20 pb-16 flex flex-col gap-8">
 
     <!-- Updates Bar -->
     <div class="w-full bg-gradient-to-r from-yellow-500 via-pink-500 to-purple-600 text-white py-2 overflow-hidden rounded-xl shadow-md">
@@ -53,25 +53,23 @@
       </div>
     </div>
 
-    <!-- Hero Content -->
-    <div class="flex justify-center">
-      <div class="bg-black/30 border border-white/10 rounded-2xl p-8 text-center shadow-xl backdrop-blur-md max-w-3xl w-full">
-        <h1 class="text-4xl md:text-5xl font-extrabold mb-4 text-white tracking-tight leading-tight">
+    <div class="flex flex-col md:flex-row items-center gap-12">
+      <!-- Text -->
+      <div class="flex-1 text-center md:text-left">
+        <h1 class="text-4xl md:text-5xl font-extrabold mb-4 text-white tracking-tight leading-tight opacity-0 animate-fade-up">
           Virtual packs,<br>real cards. <span class="emoji-sparkle">✨</span>
         </h1>
-        <p class="text-md md:text-lg text-gray-300 mb-6 leading-relaxed">
+        <p class="text-md md:text-lg text-gray-300 mb-6 leading-relaxed opacity-0 animate-fade-up">
           Open digital packs. Win real cards. Start ripping in seconds. Packly.gg.
         </p>
-        <a href="#cases" class="inline-block px-6 py-2 bg-yellow-400 text-black rounded-full font-semibold border border-yellow-500 hover:bg-yellow-300 transition-all duration-200 shadow-md hover:scale-105 mb-6">
+        <a href="#cases" class="inline-block px-6 py-3 bg-yellow-400 text-black rounded-full font-semibold border border-yellow-500 hover:bg-yellow-300 transition-all duration-200 shadow-md hover:scale-105 opacity-0 animate-fade-up">
           Grab A Pack
         </a>
+      </div>
 
-        <!-- Dynamic Hero Pack Carousel -->
-        <div class="flex justify-center mt-4">
-          <div class="w-40 md:w-56 overflow-hidden">
-            <div id="hero-pack-carousel" class="flex transition-transform duration-500"></div>
-          </div>
-        </div>
+      <!-- Pack Animation -->
+      <div class="flex-1 relative w-full h-64 md:h-80">
+        <div id="hero-pack-carousel" class="absolute inset-0"></div>
       </div>
     </div>
 

--- a/scripts/hero.js
+++ b/scripts/hero.js
@@ -1,18 +1,11 @@
 window.addEventListener('DOMContentLoaded', () => {
   const title = document.querySelector('h1.animate-fade-up');
   const paragraph = document.querySelector('p.animate-fade-up');
+  const cta = document.querySelector('#hero a.animate-fade-up');
 
-  if (title) {
-    setTimeout(() => {
-      title.classList.remove('opacity-0');
-    }, 200);
-  }
-
-  if (paragraph) {
-    setTimeout(() => {
-      paragraph.classList.remove('opacity-0');
-    }, 600);
-  }
+  if (title) setTimeout(() => title.classList.remove('opacity-0'), 200);
+  if (paragraph) setTimeout(() => paragraph.classList.remove('opacity-0'), 400);
+  if (cta) setTimeout(() => cta.classList.remove('opacity-0'), 600);
 
   const carousel = document.getElementById('hero-pack-carousel');
   const casesContainer = document.getElementById('cases-container');
@@ -21,11 +14,12 @@ window.addEventListener('DOMContentLoaded', () => {
     const packImgs = casesContainer?.querySelectorAll('.case-card-img') || [];
     if (!packImgs.length || !carousel) return;
 
-    Array.from(packImgs).slice(0, 5).forEach(img => {
+    Array.from(packImgs).slice(0, 5).forEach((img, i) => {
       const clone = document.createElement('img');
       clone.src = img.src;
       clone.alt = img.alt || 'Pack';
-      clone.className = 'w-40 md:w-56 h-auto object-contain flex-shrink-0 rounded-lg shadow-lg transition-transform duration-300';
+      clone.className = 'hero-pack-img';
+      if (i === 0) clone.classList.add('active');
       carousel.appendChild(clone);
     });
 
@@ -33,18 +27,15 @@ window.addEventListener('DOMContentLoaded', () => {
   }
 
   function startCarousel() {
-    if (!carousel || carousel.children.length <= 1) return;
+    const slides = carousel?.querySelectorAll('img') || [];
+    if (slides.length <= 1) return;
 
     let index = 0;
-    const slides = Array.from(carousel.children);
-    slides[0].classList.add('scale-105');
-
     setInterval(() => {
-      const width = slides[0].clientWidth;
+      slides[index].classList.remove('active');
       index = (index + 1) % slides.length;
-      carousel.style.transform = `translateX(-${index * width}px)`;
-      slides.forEach((img, i) => img.classList.toggle('scale-105', i === index));
-    }, 2500);
+      slides[index].classList.add('active');
+    }, 3000);
   }
 
   if (casesContainer) {

--- a/styles/main.css
+++ b/styles/main.css
@@ -198,6 +198,24 @@ body {
   animation: pulse-balance 0.4s ease;
 }
 
+/* Hero pack cross-fade animation */
+.hero-pack-img {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.9);
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  opacity: 0;
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.hero-pack-img.active {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1);
+}
+
 .flip-card {
   perspective: 1000px;
 }


### PR DESCRIPTION
## Summary
- Revamp home hero into a two-column layout with staggered text fade-ins and an animated pack carousel.
- Implement cross-fade pack animation styles for a cleaner, professional look.
- Update hero script to build the carousel dynamically and cycle images smoothly.

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68911101eea4832099de8b1c7ca15ebe