### PR TITLE
feat: add weekly leaderboard reset

### DIFF
--- a/inventory.html
+++ b/inventory.html
@@ -11,6 +11,7 @@
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-storage-compat.js"></script>
+  <script src="scripts/firebase-config.js"></script>
   <style>
     body {
       margin: 0;

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -14,7 +14,8 @@
   <header></header>
   <section class="pt-32 px-4">
     <div class="max-w-3xl mx-auto bg-gray-800 rounded-2xl p-6 shadow-lg">
-      <h1 class="text-3xl font-bold text-center mb-6 text-yellow-300">Top Players</h1>
+      <h1 class="text-3xl font-bold text-center mb-2 text-yellow-300">Weekly Leaderboard</h1>
+      <p id="reset-timer" class="text-center text-sm text-gray-400 mb-4">&nbsp;</p>
       <table class="w-full text-left">
         <thead>
           <tr class="border-b border-gray-700">
@@ -22,7 +23,7 @@
             <th class="py-2 px-2">Player</th>
             <th class="py-2 px-2">Packs Opened</th>
             <th class="py-2 px-2">Card Value</th>
-            <th class="py-2 px-2">Badges</th>
+            <th class="py-2 px-2">Wins</th>
           </tr>
         </thead>
         <tbody id="leaderboard-body"></tbody>

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -7,6 +7,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-database-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
 </head>

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -13,10 +13,17 @@
 </head>
 <body class="bg-gray-900 text-white min-h-screen">
   <header></header>
-  <section class="pt-32 px-4">
+  <section class="pt-32 pb-16 text-center bg-gradient-to-br from-gray-900 via-purple-900 to-gray-900">
+    <div class="max-w-3xl mx-auto">
+      <h1 class="text-4xl md:text-5xl font-extrabold mb-4 text-yellow-300">Weekly Leaderboard</h1>
+      <p class="text-lg text-gray-300 mb-2">Top 3 players each week earn <span class="text-yellow-400 font-semibold">500 coins</span>.</p>
+      <p class="text-gray-400 mb-4">Leaderboard resets every 7 days.</p>
+      <p id="reset-timer" class="text-sm text-gray-400">&nbsp;</p>
+    </div>
+  </section>
+  <section class="px-4 py-12">
     <div class="max-w-3xl mx-auto bg-gray-800 rounded-2xl p-6 shadow-lg">
-      <h1 class="text-3xl font-bold text-center mb-2 text-yellow-300">Weekly Leaderboard</h1>
-      <p id="reset-timer" class="text-center text-sm text-gray-400 mb-4">&nbsp;</p>
+      <h2 class="text-3xl font-bold text-center mb-2 text-yellow-300">Current Standings</h2>
       <table class="w-full text-left">
         <thead>
           <tr class="border-b border-gray-700">

--- a/scripts/leaderboard.js
+++ b/scripts/leaderboard.js
@@ -1,30 +1,115 @@
 // scripts/leaderboard.js
-// Fetch top players from Firestore and render leaderboard
+// Weekly leaderboard with automatic reset and rewards
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
   const tbody = document.getElementById('leaderboard-body');
+  const timerEl = document.getElementById('reset-timer');
   if (!tbody) return;
 
-  const db = firebase.firestore();
-  db.collection('leaderboard')
-    .orderBy('cardValue', 'desc')
-    .limit(10)
-    .get()
-    .then((snap) => {
-      let rank = 1;
-      snap.forEach((doc) => {
-        const data = doc.data();
-        const badges = (data.badges || [])
-          .map((b) => `<span class="bg-purple-600 text-white text-xs px-2 py-1 rounded-full mr-1">${b}</span>`) 
-          .join('');
-        tbody.innerHTML += `
-          <tr class="border-b border-gray-700">
-            <td class="py-2 px-2 text-center">${rank++}</td>
-            <td class="py-2 px-2">${data.username || 'Anonymous'}</td>
-            <td class="py-2 px-2 text-center">${data.packsOpened || 0}</td>
-            <td class="py-2 px-2 text-center">${(data.cardValue || 0).toLocaleString()}</td>
-            <td class="py-2 px-2">${badges}</td>
-          </tr>`;
+  const fs = firebase.firestore();
+  const rtdb = firebase.database();
+
+  // Award top players and reset stats if the week has ended
+  async function handleWeeklyReset() {
+    const metaRef = fs.collection('leaderboardMeta').doc('weekly');
+    const now = new Date();
+    let periodStart = now;
+    const snap = await metaRef.get();
+    if (snap.exists && snap.data().periodStart?.toDate) {
+      periodStart = snap.data().periodStart.toDate();
+    } else if (!snap.exists) {
+      await metaRef.set({ periodStart: firebase.firestore.Timestamp.fromDate(now) });
+    }
+
+    let nextReset = new Date(periodStart.getTime() + 7 * 24 * 60 * 60 * 1000);
+
+    if (now >= nextReset) {
+      // Fetch top three players
+      const topSnap = await fs
+        .collection('leaderboard')
+        .orderBy('cardValue', 'desc')
+        .limit(3)
+        .get();
+
+      for (const doc of topSnap.docs) {
+        const uid = doc.id;
+
+        // Credit 500 coins
+        await rtdb.ref('users/' + uid + '/balance').transaction((bal) => (bal || 0) + 500);
+
+        // Increment win counter
+        await fs.collection('leaderboard').doc(uid).set(
+          { wins: firebase.firestore.FieldValue.increment(1) },
+          { merge: true }
+        );
+      }
+
+      // Reset packs and value for all players but keep win counts
+      const allSnap = await fs.collection('leaderboard').get();
+      const batch = fs.batch();
+      allSnap.forEach((doc) => {
+        batch.set(doc.ref, { packsOpened: 0, cardValue: 0 }, { merge: true });
       });
+      await batch.commit();
+
+      // Start new period
+      await metaRef.set({ periodStart: firebase.firestore.Timestamp.fromDate(now) });
+      nextReset = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+    }
+
+    return nextReset;
+  }
+
+  // Display countdown timer
+  function startTimer(nextReset) {
+    if (!timerEl) return;
+
+    function update() {
+      const diff = nextReset - new Date();
+      if (diff <= 0) {
+        timerEl.textContent = 'Resetting soon...';
+        return;
+      }
+      const days = Math.floor(diff / (24 * 60 * 60 * 1000));
+      const hours = Math.floor((diff % (24 * 60 * 60 * 1000)) / (60 * 60 * 1000));
+      const minutes = Math.floor((diff % (60 * 60 * 1000)) / (60 * 1000));
+      timerEl.textContent = `Resets in ${days}d ${hours}h ${minutes}m`;
+    }
+
+    update();
+    setInterval(update, 60 * 1000); // update every minute
+  }
+
+  // Render leaderboard rows
+  async function loadLeaderboard() {
+    const snap = await fs
+      .collection('leaderboard')
+      .orderBy('cardValue', 'desc')
+      .limit(10)
+      .get();
+
+    let rank = 1;
+    snap.forEach((doc) => {
+      const data = doc.data();
+      const wins = data.wins || 0;
+      let rowStyle = 'border-b border-gray-700';
+      if (rank === 1) rowStyle += ' bg-yellow-900 bg-opacity-40';
+      else if (rank === 2) rowStyle += ' bg-gray-800';
+      else if (rank === 3) rowStyle += ' bg-orange-900 bg-opacity-40';
+
+      tbody.innerHTML += `
+        <tr class="${rowStyle}">
+          <td class="py-2 px-2 text-center">${rank++}</td>
+          <td class="py-2 px-2">${data.username || 'Anonymous'}</td>
+          <td class="py-2 px-2 text-center">${data.packsOpened || 0}</td>
+          <td class="py-2 px-2 text-center">${(data.cardValue || 0).toLocaleString()}</td>
+          <td class="py-2 px-2 text-center">${wins} Win${wins === 1 ? '' : 's'}</td>
+        </tr>`;
     });
+  }
+
+  const nextReset = await handleWeeklyReset();
+  startTimer(nextReset);
+  loadLeaderboard();
 });
+


### PR DESCRIPTION
## Summary
- reset leaderboard weekly and award 500 coins to top three players
- highlight winners and track win counts in leaderboard

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689117c02774832090c26c34542dacf7