### PR TITLE
refactor: redesign weekly quests table

### DIFF
--- a/scripts/quests.js
+++ b/scripts/quests.js
@@ -59,8 +59,20 @@ export async function renderWeeklyQuests(containerId = "quest-container") {
   container.innerHTML = `
     <div class="bg-gradient-to-br from-[#1f1f2b] to-[#12121b] rounded-2xl p-6 sm:p-8 shadow-xl text-white w-full max-w-3xl mx-auto">
       <h2 class="text-3xl font-bold text-center mb-2 text-yellow-300 tracking-tight">🎯 Weekly Tasks</h2>
-      <p id="quest-reset-timer" class="text-sm text-gray-400 text-center mb-4"></p>
-      <ul id="quest-list" class="space-y-4"></ul>
+      <p id="quest-reset-timer" class="text-sm text-gray-400 text-center mb-6"></p>
+      <div class="overflow-x-auto">
+        <table class="w-full text-left text-sm">
+          <thead>
+            <tr class="text-gray-400 border-b border-gray-700">
+              <th class="py-2 font-medium">Task</th>
+              <th class="py-2 font-medium w-40">Progress</th>
+              <th class="py-2 font-medium w-24">Reward</th>
+              <th class="py-2 font-medium text-right w-28">Action</th>
+            </tr>
+          </thead>
+          <tbody id="quest-table-body" class="divide-y divide-gray-700"></tbody>
+        </table>
+      </div>
     </div>`;
 
   const timerEl = document.getElementById("quest-reset-timer");
@@ -81,31 +93,40 @@ export async function renderWeeklyQuests(containerId = "quest-container") {
     }
   }, 1000);
 
-  const listEl = document.getElementById("quest-list");
+  const listEl = document.getElementById("quest-table-body");
 
   questList.forEach(quest => {
     const percent = quest.goal > 0 ? Math.min(100, Math.floor((quest.progress / quest.goal) * 100)) : 0;
     const completed = quest.progress >= quest.goal;
 
-    const li = document.createElement("li");
-    li.className = `bg-gray-900 border border-yellow-500 rounded-xl px-6 py-4 shadow-lg hover:scale-[1.01] transition-transform ${completed ? "opacity-100" : "opacity-60"}`;
-
-    li.innerHTML = `
-      <div class="flex items-center justify-between mb-2">
+    const row = document.createElement("tr");
+    row.className = completed ? "opacity-100" : "opacity-60";
+    row.innerHTML = `
+      <td class="py-3">
         <div class="flex items-center gap-3">
           <i class="${quest.icon} text-yellow-400 text-lg"></i>
           <span class="text-white font-medium">${quest.label}</span>
-          <span class="ml-3 text-yellow-300 text-sm">+${quest.reward} coins</span>
         </div>
-        <button class="quest-claim-btn bg-yellow-400 hover:bg-yellow-300 text-black font-bold py-1.5 px-5 rounded-full text-sm transition" ${(!completed || quest.claimed) ? "disabled" : ""}>
+      </td>
+      <td class="py-3">
+        <div class="w-full bg-gray-800 rounded-full h-2 mb-1">
+          <div class="bg-yellow-400 h-2 rounded-full" style="width: ${percent}%"></div>
+        </div>
+        <span class="text-xs text-gray-400">${quest.progress}/${quest.goal}</span>
+      </td>
+      <td class="py-3 text-yellow-300 font-medium">
+        <div class="flex items-center gap-1">
+          +${quest.reward}
+          <i class="fas fa-coins"></i>
+        </div>
+      </td>
+      <td class="py-3 text-right">
+        <button class="quest-claim-btn bg-yellow-400 hover:bg-yellow-300 text-black font-bold py-1 px-4 rounded-full text-xs transition ${(!completed || quest.claimed) ? "opacity-50 cursor-not-allowed" : ""}" ${(!completed || quest.claimed) ? "disabled" : ""}>
           ${quest.claimed ? "Claimed" : completed ? "Claim" : "Incomplete"}
         </button>
-      </div>
-      <div class="w-full bg-gray-800 rounded-full h-2.5">
-        <div class="bg-yellow-400 h-2.5 rounded-full" style="width: ${percent}%"></div>
-      </div>`;
+      </td>`;
 
-    const claimBtn = li.querySelector(".quest-claim-btn");
+    const claimBtn = row.querySelector(".quest-claim-btn");
 
     claimBtn.onclick = async () => {
       const questRef = userRef.child(`weeklyQuests/${quest.id}`);
@@ -130,7 +151,7 @@ export async function renderWeeklyQuests(containerId = "quest-container") {
       setTimeout(() => toast.remove(), 3000);
     };
 
-    listEl.appendChild(li);
+    listEl.appendChild(row);
   });
 }
 


### PR DESCRIPTION
## Summary
- modernize weekly tasks UI with responsive table layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68911e1b76688320b29e37b853052823