### PR TITLE
Fix reCAPTCHA verification for phone signup

### DIFF
--- a/auth.html
+++ b/auth.html
@@ -94,6 +94,7 @@ firebase.initializeApp(firebaseConfig);
 const auth = firebase.auth();
 const db = firebase.database();
 const recaptchaVerifier = new firebase.auth.RecaptchaVerifier('recaptcha-container', { size: 'invisible' });
+recaptchaVerifier.render();
 let confirmationResult, pendingPhone;
 
 function formatPhone(number) {
@@ -233,7 +234,8 @@ function sendRegisterCode() {
     alert('Please enter a valid phone number.');
     return;
   }
-  auth.currentUser.linkWithPhoneNumber(phone, recaptchaVerifier)
+  recaptchaVerifier.verify()
+    .then(() => auth.currentUser.linkWithPhoneNumber(phone, recaptchaVerifier))
     .then(result => {
       confirmationResult = result;
       document.getElementById('register-send').classList.add('hidden');


### PR DESCRIPTION
## Summary
- Ensure the invisible reCAPTCHA is rendered before use
- Verify reCAPTCHA before linking a phone number so SMS codes are sent

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/cases/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68914e3e7f808320b4e5db4b6b6e5f83