### PR TITLE
feat: enhance auth page with remember me

### DIFF
--- a/auth.html
+++ b/auth.html
@@ -12,66 +12,67 @@
   <style>
     body { background-color: #0f0f12; color: white; font-family: 'Poppins', sans-serif; }
     .hidden { display: none; }
-    input { color: black; }
+    input { color: white; }
   </style>
 </head>
-<body class="flex items-center justify-center h-screen px-4">
+<body class="flex items-center justify-center min-h-screen px-4 bg-gradient-to-br from-gray-900 via-purple-900 to-black">
 
-  <div class="bg-gray-900 p-8 rounded shadow-md w-full max-w-md">
-    <h2 id="form-title" class="mb-6 text-center">
+  <div class="bg-gray-900/80 backdrop-blur-sm p-10 rounded-xl shadow-2xl w-full max-w-md border border-gray-700">
+    <h2 id="form-title" class="mb-8 text-center">
   <img src="https://firebasestorage.googleapis.com/v0/b/cases-e5b4e.firebasestorage.app/o/Untitled%20design%20(29).png?alt=media&token=51dc030a-b05d-46ec-b1ab-c2fd1824d74e" alt="Logo" style="height: 60px; display: inline-block;">
 </h2>
 
     <!-- Login Form -->
     <form id="login-form" class="space-y-4">
       <div>
-        <label>Email</label>
-        <input type="email" id="login-email" class="w-full p-2 rounded bg-gray-700" required />
+        <label class="text-sm">Email</label>
+        <input type="email" id="login-email" class="w-full p-3 rounded bg-gray-800 focus:outline-none focus:ring-2 focus:ring-purple-500" required />
       </div>
       <div>
-        <label>Password</label>
-        <input type="password" id="login-password" class="w-full p-2 rounded bg-gray-700" required />
+        <label class="text-sm">Password</label>
+        <input type="password" id="login-password" class="w-full p-3 rounded bg-gray-800 focus:outline-none focus:ring-2 focus:ring-purple-500" required />
       </div>
-      <div class="text-right text-sm">
-  <button type="button" onclick="forgotPassword()" class="text-purple-300 hover:underline">Forgot Password?</button>
-</div>
-      <button type="submit" class="w-full bg-purple-600 hover:bg-purple-700 px-4 py-2 rounded">Login</button>
+      <div class="flex items-center justify-between text-sm">
+        <label class="inline-flex items-center"><input type="checkbox" id="remember-me" class="mr-2">Remember me</label>
+        <button type="button" onclick="forgotPassword()" class="text-purple-300 hover:underline">Forgot Password?</button>
+      </div>
+      <button type="submit" class="w-full bg-purple-600 hover:bg-purple-700 px-4 py-2 rounded transition-colors">Login</button>
     </form>
 
     <!-- Register Form -->
     <form id="register-form" class="space-y-4 hidden">
       <div>
-        <label>Name</label>
-        <input type="text" id="register-name" class="w-full p-2 rounded bg-gray-700" required />
+        <label class="text-sm">Name</label>
+        <input type="text" id="register-name" class="w-full p-3 rounded bg-gray-800 focus:outline-none focus:ring-2 focus:ring-pink-500" required />
       </div>
       <div>
-        <label>Username</label>
-        <input type="text" id="register-username" class="w-full p-2 rounded bg-gray-700" required />
+        <label class="text-sm">Username</label>
+        <input type="text" id="register-username" class="w-full p-3 rounded bg-gray-800 focus:outline-none focus:ring-2 focus:ring-pink-500" required />
       </div>
       <div>
-        <label>Email</label>
-        <input type="email" id="register-email" class="w-full p-2 rounded bg-gray-700" required />
+        <label class="text-sm">Email</label>
+        <input type="email" id="register-email" class="w-full p-3 rounded bg-gray-800 focus:outline-none focus:ring-2 focus:ring-pink-500" required />
       </div>
       <div>
-        <label>Phone Number</label>
-        <input type="tel" id="register-phone" class="w-full p-2 rounded bg-gray-700" required value="+1" />
+        <label class="text-sm">Phone Number</label>
+        <input type="tel" id="register-phone" class="w-full p-3 rounded bg-gray-800 focus:outline-none focus:ring-2 focus:ring-pink-500" required value="+1" />
       </div>
       <div>
-        <label>Password</label>
-        <input type="password" id="register-password" class="w-full p-2 rounded bg-gray-700" required />
+        <label class="text-sm">Password</label>
+        <input type="password" id="register-password" class="w-full p-3 rounded bg-gray-800 focus:outline-none focus:ring-2 focus:ring-pink-500" required />
       </div>
-      <button type="submit" class="w-full bg-pink-600 hover:bg-pink-700 px-4 py-2 rounded">Register</button>
+      <button type="submit" class="w-full bg-pink-600 hover:bg-pink-700 px-4 py-2 rounded transition-colors">Register</button>
     </form>
 
     <div id="register-send" class="hidden mt-4 space-y-4">
       <div id="recaptcha-container"></div>
       <p>Verify your phone number to complete registration.</p>
-      <button type="button" onclick="sendRegisterCode()" class="w-full bg-green-600 hover:bg-green-700 px-4 py-2 rounded">Send Code</button>
+      <button type="button" onclick="sendRegisterCode()" class="w-full bg-green-600 hover:bg-green-700 px-4 py-2 rounded transition-colors">Send Code</button>
     </div>
 
     <div id="register-verify" class="hidden mt-4 space-y-2">
-      <input type="text" id="register-verification-code" placeholder="Enter verification code" class="w-full p-2 rounded bg-gray-700" />
-      <button type="button" onclick="verifyRegisterCode()" class="w-full bg-blue-600 hover:bg-blue-700 px-4 py-2 rounded">Confirm Phone</button>
+      <input type="text" id="register-verification-code" placeholder="Enter verification code" class="w-full p-3 rounded bg-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+      <button type="button" onclick="verifyRegisterCode()" class="w-full bg-blue-600 hover:bg-blue-700 px-4 py-2 rounded transition-colors">Confirm Phone</button>
     </div>
 
     <p id="switch-text" class="mt-4 text-sm text-center">
@@ -190,7 +191,11 @@ loginForm.addEventListener('submit', e => {
   const email = document.getElementById('login-email').value;
   const password = document.getElementById('login-password').value;
 
-  auth.signInWithEmailAndPassword(email, password)
+  const remember = document.getElementById('remember-me').checked;
+  const persistence = remember ? firebase.auth.Auth.Persistence.LOCAL : firebase.auth.Auth.Persistence.SESSION;
+
+  auth.setPersistence(persistence)
+    .then(() => auth.signInWithEmailAndPassword(email, password))
     .then(() => {
       alert('Login successful!');
       window.location.href = 'index.html';


### PR DESCRIPTION
## Summary
- revamp login/register page with gradient styling and refined inputs
- add remember me option using Firebase persistence

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891505d3d80832085732d65533dfd8a