### PR TITLE
feat: add pack image background on case page

### DIFF
--- a/case.html
+++ b/case.html
@@ -68,7 +68,8 @@
       <canvas id="particle-canvas"></canvas>
       <header></header>
 <section id="case-content" class="relative pt-32 pb-10 px-4 max-w-5xl mx-auto">
-  <img id="case-pack-image" class="absolute -top-24 left-1/2 transform -translate-x-1/2 w-64 opacity-20 z-0 pointer-events-none" alt="Case Pack" />
+  <img class="case-pack-image absolute top-1/2 left-0 -translate-x-1/2 -translate-y-1/2 w-64 opacity-20 z-0 pointer-events-none -rotate-12" alt="Case Pack" />
+  <img class="case-pack-image absolute top-1/2 right-0 translate-x-1/2 -translate-y-1/2 w-64 opacity-20 z-0 pointer-events-none rotate-12" alt="Case Pack" />
   <div id="case-container" class="relative z-10 bg-gradient-to-br from-gray-800 to-gray-900 rounded-2xl border border-white/10 p-6 shadow-xl backdrop-blur-md">
    <div class="absolute top-4 left-4 z-10 flex items-center gap-2">
   <!-- Back Button -->
@@ -247,10 +248,11 @@ function showToast(message, color = 'bg-red-600') {
       }
 
       const caseData = snap.val();
-      const packImgEl = document.getElementById("case-pack-image");
-      if (packImgEl && caseData.image) {
-        packImgEl.src = caseData.image;
-        packImgEl.alt = `${caseData.name} pack`;
+      if (caseData.image) {
+        document.querySelectorAll('.case-pack-image').forEach(img => {
+          img.src = caseData.image;
+          img.alt = `${caseData.name} pack`;
+        });
       }
       const isFreeCase = !!caseData.isFree;
       const spiceMap = {


### PR DESCRIPTION
## Summary
- show pack image peeking behind case container for subtle background detail
- set background pack image based on case data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891621e84348320a6f677141ae68c3f