### PR TITLE
Simplify authentication to email/password only

### DIFF
--- a/auth.html
+++ b/auth.html
@@ -19,8 +19,8 @@
 
   <div class="bg-gray-900/80 backdrop-blur-sm p-10 rounded-xl shadow-2xl w-full max-w-md border border-gray-700">
     <h2 id="form-title" class="mb-8 text-center">
-  <img src="https://firebasestorage.googleapis.com/v0/b/cases-e5b4e.firebasestorage.app/o/Untitled%20design%20(29).png?alt=media&token=51dc030a-b05d-46ec-b1ab-c2fd1824d74e" alt="Logo" style="height: 60px; display: inline-block;">
-</h2>
+      <img src="https://firebasestorage.googleapis.com/v0/b/cases-e5b4e.firebasestorage.app/o/Untitled%20design%20(29).png?alt=media&token=51dc030a-b05d-46ec-b1ab-c2fd1824d74e" alt="Logo" style="height: 60px; display: inline-block;">
+    </h2>
 
     <!-- Login Form -->
     <form id="login-form" class="space-y-4">
@@ -54,26 +54,11 @@
         <input type="email" id="register-email" class="w-full p-3 rounded bg-gray-800 focus:outline-none focus:ring-2 focus:ring-pink-500" required />
       </div>
       <div>
-        <label class="text-sm">Phone Number</label>
-        <input type="tel" id="register-phone" class="w-full p-3 rounded bg-gray-800 focus:outline-none focus:ring-2 focus:ring-pink-500" required value="+1" />
-      </div>
-      <div>
         <label class="text-sm">Password</label>
         <input type="password" id="register-password" class="w-full p-3 rounded bg-gray-800 focus:outline-none focus:ring-2 focus:ring-pink-500" required />
       </div>
       <button type="submit" class="w-full bg-pink-600 hover:bg-pink-700 px-4 py-2 rounded transition-colors">Register</button>
     </form>
-
-    <div id="register-send" class="hidden mt-4 space-y-4">
-      <div id="recaptcha-container"></div>
-      <p>Verify your phone number to complete registration.</p>
-      <button type="button" onclick="sendRegisterCode()" class="w-full bg-green-600 hover:bg-green-700 px-4 py-2 rounded transition-colors">Send Code</button>
-    </div>
-
-    <div id="register-verify" class="hidden mt-4 space-y-2">
-      <input type="text" id="register-verification-code" placeholder="Enter verification code" class="w-full p-3 rounded bg-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500" />
-      <button type="button" onclick="verifyRegisterCode()" class="w-full bg-blue-600 hover:bg-blue-700 px-4 py-2 rounded transition-colors">Confirm Phone</button>
-    </div>
 
     <p id="switch-text" class="mt-4 text-sm text-center">
       Don't have an account? <button onclick="toggleForms()" class="text-purple-400 underline">Register</button>
@@ -94,37 +79,6 @@ const firebaseConfig = {
 firebase.initializeApp(firebaseConfig);
 const auth = firebase.auth();
 const db = firebase.database();
-const recaptchaVerifier = new firebase.auth.RecaptchaVerifier('recaptcha-container', { size: 'invisible' });
-let confirmationResult, pendingPhone;
-
-function formatPhone(number) {
-  const digits = number.replace(/\D/g, '');
-  if (digits.length === 10) {
-    return '+1' + digits; // assume US if 10 digits
-  }
-  if (digits.length >= 11 && digits[0] !== '0') {
-    return '+' + digits; // keep provided country code
-  }
-  return null; // invalid
-}
-
-const phoneInput = document.getElementById('register-phone');
-function enforcePrefix() {
-  const digits = phoneInput.value.replace(/\D/g, '');
-  phoneInput.value = digits ? '+' + digits : '+1';
-}
-enforcePrefix();
-phoneInput.addEventListener('input', enforcePrefix);
-phoneInput.addEventListener('focus', enforcePrefix);
-phoneInput.addEventListener('keydown', e => {
-  if (e.key === 'Backspace' && phoneInput.selectionStart <= 1) {
-    e.preventDefault();
-  }
-});
-phoneInput.addEventListener('blur', () => {
-  const formatted = formatPhone(phoneInput.value);
-  phoneInput.value = formatted || '+1';
-});
 
 const loginForm = document.getElementById('login-form');
 const registerForm = document.getElementById('register-form');
@@ -151,13 +105,7 @@ registerForm.addEventListener('submit', e => {
   const name = document.getElementById('register-name').value;
   const username = document.getElementById('register-username').value;
   const email = document.getElementById('register-email').value;
-  const phone = formatPhone(document.getElementById('register-phone').value);
   const password = document.getElementById('register-password').value;
-
-  if (!phone) {
-    alert('Please enter a valid phone number.');
-    return;
-  }
 
   auth.createUserWithEmailAndPassword(email, password)
     .then(userCredential => {
@@ -167,23 +115,19 @@ registerForm.addEventListener('submit', e => {
           name: name,
           username: username,
           email: email,
-          phone: phone,
           balance: 0,
           role: 'user',
           freeCaseOpened: false
-        }))
-        .then(() => user.reload());
+        }));
     })
     .then(() => {
-      pendingPhone = phone;
-      registerForm.classList.add('hidden');
-      document.getElementById('register-send').classList.remove('hidden');
+      alert('Registration successful!');
+      window.location.href = 'index.html';
     })
     .catch(error => {
       alert('❌ ' + error.message);
     });
 });
-
 
 // Login
 loginForm.addEventListener('submit', e => {
@@ -204,6 +148,7 @@ loginForm.addEventListener('submit', e => {
       alert(error.message);
     });
 });
+
 function forgotPassword() {
   const email = document.getElementById('login-email').value;
   if (!email) {
@@ -216,40 +161,11 @@ function forgotPassword() {
       alert("✅ Password reset email sent! Please check your inbox.");
     })
     .catch(error => {
-         alert("❌ " + error.message);
-    });
-}
-
-function verifyRegisterCode() {
-  const code = document.getElementById('register-verification-code').value;
-  confirmationResult.confirm(code)
-    .then(() => {
-      alert('Registration successful!');
-      window.location.href = 'index.html';
-    })
-    .catch(error => {
-      alert(error.message);
-    });
-}
-
-function sendRegisterCode() {
-  const phone = pendingPhone;
-  if (!formatPhone(phone || '')) {
-    alert('Please enter a valid phone number.');
-    return;
-  }
-  auth.currentUser.linkWithPhoneNumber(phone, recaptchaVerifier)
-    .then(result => {
-      confirmationResult = result;
-      document.getElementById('register-send').classList.add('hidden');
-      document.getElementById('register-verify').classList.remove('hidden');
-      alert('Verification code sent to your phone.');
-    })
-    .catch(error => {
-      alert('❌ ' + error.message);
+      alert("❌ " + error.message);
     });
 }
 </script>
 
 </body>
 </html>
+

--- a/scripts/auth.js
+++ b/scripts/auth.js
@@ -16,12 +16,6 @@ window.addEventListener('DOMContentLoaded', () => {
       const snapshot = await userRef.once('value');
       const userData = snapshot.val() || {};
 
-      if (!userData.phoneVerified) {
-        await firebase.auth().signOut();
-        window.location.href = 'auth.html';
-        return;
-      }
-
       // ✅ Setup Provably Fair if missing
       if (!userData.provablyFair) {
         const serverSeed = generateRandomString(64);


### PR DESCRIPTION
## Summary
- Drop phone-based verification and recaptcha from auth page; registration now collects name, username, email, and password only.
- Remove `phoneVerified` checks so authenticated users stay signed in.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891649e0cbc8320b0de336d5b094f55