### PR TITLE
feat: move profile to dedicated page

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -178,14 +178,16 @@
 
 <section id="milestones-section" class="hidden">
   <h1 class="text-3xl font-bold mb-6">Milestones</h1>
-  <form id="milestone-config-form" class="space-y-4 max-w-xl bg-gray-800 p-6 rounded-lg">
+  <form id="milestone-config-form" class="space-y-6 max-w-xl bg-gray-800 p-6 rounded-lg">
     <div>
-      <label class="block mb-1">Badge Config (JSON Array)</label>
-      <textarea id="badge-config" class="w-full p-2 rounded h-32"></textarea>
+      <h2 class="text-2xl mb-4">Badges</h2>
+      <div id="badge-list" class="space-y-4"></div>
+      <button type="button" onclick="addBadge()" class="mt-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded">+ Add Badge</button>
     </div>
     <div>
-      <label class="block mb-1">Level Requirements (JSON Array of pack thresholds)</label>
-      <textarea id="level-config" class="w-full p-2 rounded h-32"></textarea>
+      <h2 class="text-2xl mb-4">Level Requirements</h2>
+      <div id="level-list" class="space-y-4"></div>
+      <button type="button" onclick="addLevel()" class="mt-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded">+ Add Level</button>
     </div>
     <button type="submit" class="px-6 py-2 bg-green-600 hover:bg-green-700 rounded">Save</button>
   </form>
@@ -765,21 +767,59 @@ document.getElementById('quest-config-form').addEventListener('submit', e => {
   firebase.database().ref('questConfig').set(config).then(() => showToast('✅ Quest config saved'));
 });
 
+function addBadge(badge = {}) {
+  const div = document.createElement('div');
+  div.className = 'flex gap-2 items-center';
+  div.innerHTML = `
+    <input type="text" placeholder="Badge Name" class="badge-name w-full p-2 rounded" value="${badge.name || ''}">
+    <input type="number" placeholder="Pack Threshold" class="badge-threshold w-32 p-2 rounded" value="${badge.threshold || ''}">
+    <button type="button" class="text-red-400 hover:text-red-600" onclick="this.parentElement.remove()">Remove</button>
+  `;
+  document.getElementById('badge-list').appendChild(div);
+}
+
+function addLevel(value = '') {
+  const div = document.createElement('div');
+  div.className = 'flex gap-2 items-center';
+  div.innerHTML = `
+    <input type="number" placeholder="Pack Threshold" class="level-value w-full p-2 rounded" value="${value}">
+    <button type="button" class="text-red-400 hover:text-red-600" onclick="this.parentElement.remove()">Remove</button>
+  `;
+  document.getElementById('level-list').appendChild(div);
+}
+
 function loadMilestoneConfig() {
   const ref = firebase.database().ref('milestoneConfig');
   ref.once('value').then(snap => {
     const cfg = snap.val() || {};
-    document.getElementById('badge-config').value = JSON.stringify(cfg.badges || [], null, 2);
-    document.getElementById('level-config').value = JSON.stringify(cfg.levels || [], null, 2);
+    const badges = cfg.badges || [];
+    const levels = cfg.levels || [];
+    if (badges.length) {
+      badges.forEach(b => addBadge(b));
+    } else {
+      addBadge();
+    }
+    if (levels.length) {
+      levels.forEach(l => addLevel(l));
+    } else {
+      addLevel();
+    }
   });
 }
 
 document.getElementById('milestone-config-form').addEventListener('submit', e => {
   e.preventDefault();
-  let badges = [];
-  let levels = [];
-  try { badges = JSON.parse(document.getElementById('badge-config').value || '[]'); } catch (err) {}
-  try { levels = JSON.parse(document.getElementById('level-config').value || '[]'); } catch (err) {}
+  const badges = [];
+  document.querySelectorAll('#badge-list > div').forEach(div => {
+    const name = div.querySelector('.badge-name').value.trim();
+    const threshold = parseInt(div.querySelector('.badge-threshold').value) || 0;
+    if (name) badges.push({ name, threshold });
+  });
+  const levels = [];
+  document.querySelectorAll('#level-list .level-value').forEach(input => {
+    const val = parseInt(input.value);
+    if (!isNaN(val)) levels.push(val);
+  });
   firebase.database().ref('milestoneConfig').set({ badges, levels }).then(() => showToast('✅ Milestone config saved'));
 });
 

--- a/admin.html
+++ b/admin.html
@@ -53,6 +53,7 @@
       <a href="#" class="text-sm text-white hover:text-pink-400" onclick="showSection('users')">Users</a>
       <a href="#" class="text-sm text-white hover:text-pink-400" onclick="showSection('marketplace')">Marketplace</a>
       <a href="#" class="text-sm text-white hover:text-pink-400" onclick="showSection('quests')">Quests</a>
+      <a href="#" class="text-sm text-white hover:text-pink-400" onclick="showSection('milestones')">Milestones</a>
     </div>
   </nav>
 
@@ -175,6 +176,22 @@
 </section>
 
 
+<section id="milestones-section" class="hidden">
+  <h1 class="text-3xl font-bold mb-6">Milestones</h1>
+  <form id="milestone-config-form" class="space-y-4 max-w-xl bg-gray-800 p-6 rounded-lg">
+    <div>
+      <label class="block mb-1">Badge Config (JSON Array)</label>
+      <textarea id="badge-config" class="w-full p-2 rounded h-32"></textarea>
+    </div>
+    <div>
+      <label class="block mb-1">Level Requirements (JSON Array of pack thresholds)</label>
+      <textarea id="level-config" class="w-full p-2 rounded h-32"></textarea>
+    </div>
+    <button type="submit" class="px-6 py-2 bg-green-600 hover:bg-green-700 rounded">Save</button>
+  </form>
+</section>
+
+
     <!-- Shipment Management Section -->
     <section id="shipments-section" class="hidden">
       <h1 class="text-3xl font-bold mb-6">Manage Shipments</h1>
@@ -211,8 +228,8 @@
       setTimeout(() => { toast.style.display = 'none'; }, 3000);
     }
 
-    function showSection(id) {
-  const sections = ['cases', 'shipments', 'support', 'users', 'marketplace', 'quests'];
+  function showSection(id) {
+  const sections = ['cases', 'shipments', 'support', 'users', 'marketplace', 'quests', 'milestones'];
   sections.forEach(section => {
     document.getElementById(section + '-section').classList.add('hidden');
   });
@@ -641,6 +658,7 @@ firebase.auth().onAuthStateChanged(user => {
   loadSupportForms();
   loadMarketplaceItems();
   loadQuestConfig();
+  loadMilestoneConfig();
 });
 
 
@@ -745,6 +763,24 @@ document.getElementById('quest-config-form').addEventListener('submit', e => {
     }
   };
   firebase.database().ref('questConfig').set(config).then(() => showToast('✅ Quest config saved'));
+});
+
+function loadMilestoneConfig() {
+  const ref = firebase.database().ref('milestoneConfig');
+  ref.once('value').then(snap => {
+    const cfg = snap.val() || {};
+    document.getElementById('badge-config').value = JSON.stringify(cfg.badges || [], null, 2);
+    document.getElementById('level-config').value = JSON.stringify(cfg.levels || [], null, 2);
+  });
+}
+
+document.getElementById('milestone-config-form').addEventListener('submit', e => {
+  e.preventDefault();
+  let badges = [];
+  let levels = [];
+  try { badges = JSON.parse(document.getElementById('badge-config').value || '[]'); } catch (err) {}
+  try { levels = JSON.parse(document.getElementById('level-config').value || '[]'); } catch (err) {}
+  firebase.database().ref('milestoneConfig').set({ badges, levels }).then(() => showToast('✅ Milestone config saved'));
 });
 
   </script>

--- a/admin.html
+++ b/admin.html
@@ -773,6 +773,7 @@ function addBadge(badge = {}) {
   div.innerHTML = `
     <input type="text" placeholder="Badge Name" class="badge-name w-full p-2 rounded" value="${badge.name || ''}">
     <input type="number" placeholder="Pack Threshold" class="badge-threshold w-32 p-2 rounded" value="${badge.threshold || ''}">
+    <input type="color" class="badge-color w-16 h-10 rounded" value="${badge.color || '#9333ea'}">
     <button type="button" class="text-red-400 hover:text-red-600" onclick="this.parentElement.remove()">Remove</button>
   `;
   document.getElementById('badge-list').appendChild(div);
@@ -813,7 +814,8 @@ document.getElementById('milestone-config-form').addEventListener('submit', e =>
   document.querySelectorAll('#badge-list > div').forEach(div => {
     const name = div.querySelector('.badge-name').value.trim();
     const threshold = parseInt(div.querySelector('.badge-threshold').value) || 0;
-    if (name) badges.push({ name, threshold });
+    const color = div.querySelector('.badge-color').value || '#9333ea';
+    if (name) badges.push({ name, threshold, color });
   });
   const levels = [];
   document.querySelectorAll('#level-list .level-value').forEach(input => {

--- a/inventory.html
+++ b/inventory.html
@@ -93,17 +93,8 @@
 </section>
 
 
-<!-- Profile Tabs -->
-<div class="w-full flex justify-center mt-6">
-  <div class="flex space-x-4 bg-gray-800 p-2 rounded-xl shadow-md">
-<button onclick="showTab('inventory-section')" data-tab="inventory" class="tab-button px-4 py-2 text-white bg-pink-600 rounded-full">Inventory</button>
-<button onclick="showTab('profile-section')" data-tab="profile" class="tab-button px-4 py-2 text-white hover:bg-pink-600 rounded-full">Profile</button>
-  </div>
-</div>
-<div id="inventory-section" class="tab-content">
-
   <!-- Inventory -->
-  <main class="p-6">
+  <main class="p-6 mt-6">
     <div class="flex flex-col sm:flex-row justify-between items-center mb-6 gap-4">
       <div class="flex items-center gap-3 text-sm">
         <label><input type="checkbox" id="select-all-checkbox" class="mr-1"> Select All</label>
@@ -151,45 +142,6 @@
       </div>
     </div>
   </main>
-</div>
-  <!-- Profile Section -->
-<div id="profile-section" class="tab-content hidden px-6 py-8">
-  <div class="max-w-lg mx-auto bg-gray-900 rounded-2xl p-6 shadow-lg">
-    <h2 class="text-xl font-bold mb-4 text-white">Your Profile</h2>
-    <div class="mb-6 text-center">
-<div id="profile-pic" class="w-24 h-24 rounded-full bg-pink-600 text-white text-3xl font-bold flex items-center justify-center mx-auto border-4 border-pink-600 shadow-lg"></div>
-</div>
-<div id="badge-container" class="flex flex-wrap justify-center gap-2 mb-6"></div>
-
-<div class="mb-4 text-center">
-  <label class="block text-sm font-medium text-gray-300 mb-1">Username</label>
-  <input id="username-input" type="text" class="w-full px-4 py-2 rounded bg-gray-800 text-white border border-gray-600 text-center" />
-</div>
-
-<button onclick="updateProfile()" class="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-full transition">
-  Save Changes
-</button>
-
-
-    <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-300 mb-1">Email</label>
-      <input id="email" type="text" class="w-full px-4 py-2 rounded bg-gray-800 text-white border border-gray-600" disabled />
-    </div>
-
-    <div class="mb-4">
-  <label class="block text-sm font-medium text-gray-300 mb-1">Current Password</label>
-  <input id="current-password" type="password" placeholder="Enter current password" class="w-full px-4 py-2 rounded bg-gray-800 text-white border border-gray-600" />
-</div>
-    <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-300 mb-1">New Password</label>
-      <input id="new-password" type="password" placeholder="Enter new password" class="w-full px-4 py-2 rounded bg-gray-800 text-white border border-gray-600" />
-    </div>
-
-    <button onclick="changePassword()" class="w-full bg-pink-600 hover:bg-pink-700 text-white font-bold py-2 px-4 rounded-full transition">
-      Change Password
-    </button>
-  </div>
-</div>
 
   <!-- Dynamic Footer -->
   <footer></footer>
@@ -223,123 +175,6 @@
         document.getElementById("topup-popup-container").innerHTML = html;
       });
   </script>
-  <script>
-    function showTab(tabId) {
-  // Hide all tabs
-  document.querySelectorAll(".tab-content").forEach(tab => tab.classList.add("hidden"));
-
-  // Show selected tab
-  document.getElementById(tabId).classList.remove("hidden");
-
-  // Reset all buttons
-  document.querySelectorAll(".tab-button").forEach(btn => {
-    btn.classList.remove("bg-pink-600");
-    btn.classList.add("hover:bg-pink-600");
-  });
-
-  // Highlight clicked button
-  const clickedButton = [...document.querySelectorAll(".tab-button")].find(btn =>
-    btn.getAttribute("onclick").includes(tabId)
-  );
-  if (clickedButton) {
-    clickedButton.classList.add("bg-pink-600");
-    clickedButton.classList.remove("hover:bg-pink-600");
-  }
-}
-  </script>
-<script>
-function showTab(tabId) {
-  document.querySelectorAll(".tab-content").forEach(tab => tab.classList.add("hidden"));
-  document.getElementById(tabId).classList.remove("hidden");
-
-  document.querySelectorAll(".tab-button").forEach(btn => btn.classList.remove("bg-pink-600"));
-  event.target.classList.add("bg-pink-600");
-}
-
-
-// Load profile data
-// Load profile data
-firebase.auth().onAuthStateChanged(user => {
-  if (user) {
-    const uid = user.uid;
-    const userRef = firebase.database().ref('users/' + uid);
-
-    userRef.once('value').then(snapshot => {
-      const userData = snapshot.val();
-
-      // Set email
-      document.getElementById("email").value = user.email;
-
-      // Set profile username input
-      if (userData.username) {
-        document.getElementById("username-input").value = userData.username;
-      }
-
-      // Set profile pic initials
-      const emailInitials = user.email ? user.email.substring(0, 2).toUpperCase() : "??";
-      document.getElementById("profile-pic").textContent = emailInitials;
-
-      // Set shipment popup username (if exists)
-      const shipUsernameInput = document.getElementById("ship-username");
-      if (shipUsernameInput && userData.username) {
-        shipUsernameInput.value = userData.username;
-      }
-    });
-  }
-});
-
-
-// Password update function
-function changePassword() {
-  const currentPassword = document.getElementById("current-password").value;
-  const newPassword = document.getElementById("new-password").value;
-  const user = firebase.auth().currentUser;
-
-  if (!currentPassword || !newPassword) {
-    alert("Please fill out both password fields.");
-    return;
-  }
-
-  const credential = firebase.auth.EmailAuthProvider.credential(user.email, currentPassword);
-
-  user.reauthenticateWithCredential(credential)
-    .then(() => {
-      return user.updatePassword(newPassword);
-    })
-    .then(() => {
-      alert("✅ Password updated successfully.");
-      document.getElementById("current-password").value = "";
-      document.getElementById("new-password").value = "";
-    })
-    .catch(error => {
-      alert("❌ " + error.message);
-    });
-}
-</script>
-<script>
-function updateProfile() {
-  const user = firebase.auth().currentUser;
-  if (!user) return;
-
-  const newUsername = document.getElementById("username-input").value;
-
-  // 1. Update display name (auth)
-  user.updateProfile({ displayName: newUsername })
-    .then(() => {
-      // 2. Update Realtime Database
-      return firebase.database().ref('users/' + user.uid).update({
-        username: newUsername
-      });
-    })
-    .then(() => {
-      alert("✅ Username updated!");
-      location.reload(); // Refresh so you see the updated username
-    })
-    .catch(err => {
-      alert("❌ Error: " + err.message);
-    });
-}
-</script>
 
 
 </body>

--- a/profile.html
+++ b/profile.html
@@ -33,8 +33,12 @@
   <header></header>
 
   <section class="mt-20 px-4">
+    <div class="max-w-lg mx-auto mb-6">
+      <input id="user-search" type="text" placeholder="Search users..." class="w-full px-4 py-2 rounded bg-gray-800 text-white border border-gray-600" />
+      <ul id="user-list" class="mt-2 bg-gray-900 rounded-lg divide-y divide-gray-700"></ul>
+    </div>
     <div class="max-w-lg mx-auto bg-gray-900 rounded-2xl p-6 shadow-lg">
-      <h2 class="text-xl font-bold mb-4 text-white text-center">Your Profile</h2>
+      <h2 id="profile-title" class="text-xl font-bold mb-4 text-white text-center">Your Profile</h2>
       <div class="mb-6 text-center">
         <div id="profile-pic" class="w-24 h-24 rounded-full bg-pink-600 text-white text-3xl font-bold flex items-center justify-center mx-auto border-4 border-pink-600 shadow-lg"></div>
       </div>

--- a/profile.html
+++ b/profile.html
@@ -52,11 +52,16 @@
         <div id="profile-pic" class="w-28 h-28 rounded-full bg-gradient-to-br from-pink-500 to-purple-600 text-white text-3xl font-bold flex items-center justify-center mx-auto border-4 border-purple-400 shadow-2xl"></div>
       </div>
 
-      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-8 text-center">
+      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mb-8 text-center">
         <div class="bg-gradient-to-br from-purple-700/40 to-pink-700/40 backdrop-blur-md p-4 rounded-xl border border-purple-500/30 shadow-lg">
           <i class="fa-solid fa-star text-pink-300 text-2xl mb-1"></i>
           <p class="text-sm text-pink-200">Level</p>
           <p id="level-number" class="text-2xl font-bold">1</p>
+        </div>
+        <div class="bg-gradient-to-br from-purple-700/40 to-pink-700/40 backdrop-blur-md p-4 rounded-xl border border-purple-500/30 shadow-lg">
+          <i class="fa-solid fa-box-open text-pink-300 text-2xl mb-1"></i>
+          <p class="text-sm text-pink-200">Packs Opened</p>
+          <p id="packs-opened" class="text-2xl font-bold">0</p>
         </div>
         <div class="bg-gradient-to-br from-purple-700/40 to-pink-700/40 backdrop-blur-md p-4 rounded-xl border border-purple-500/30 shadow-lg">
           <i class="fa-solid fa-coins text-pink-300 text-2xl mb-1"></i>
@@ -68,11 +73,24 @@
           <p class="text-sm text-pink-200">Total Won</p>
           <p id="total-won" class="text-2xl font-bold">0</p>
         </div>
-        <div class="bg-gradient-to-br from-purple-700/40 to-pink-700/40 backdrop-blur-md p-4 rounded-xl border border-purple-500/30 shadow-lg">
+        <div class="bg-gradient-to-br from-purple-700/40 to-pink-700/40 backdrop-blur-md p-4 rounded-xl border border-purple-500/30 shadow-lg sm:col-span-2 md:col-span-1">
           <i class="fa-solid fa-gem text-pink-300 text-2xl mb-1"></i>
           <p class="text-sm text-pink-200">Rarest Pull</p>
           <div id="rarest-pull" class="text-sm text-gray-200"></div>
         </div>
+      </div>
+
+      <div class="mb-8">
+        <p class="text-sm text-center text-pink-200 mb-1">Progress to Next Level</p>
+        <div class="w-full bg-gray-700 rounded-full h-4">
+          <div id="level-progress" class="bg-pink-500 h-4 rounded-full" style="width:0%"></div>
+        </div>
+        <p id="progress-text" class="text-xs text-center text-gray-400 mt-1"></p>
+      </div>
+
+      <div class="mb-8">
+        <h3 class="text-lg font-semibold text-center text-pink-300 mb-2">Recent Pulls</h3>
+        <ul id="recent-pulls" class="bg-gray-900/60 rounded-lg divide-y divide-gray-700"></ul>
       </div>
 
       <div id="badge-container" class="flex flex-wrap justify-center gap-2 mb-8"></div>

--- a/profile.html
+++ b/profile.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Profile | Packly.gg</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-database-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-storage-compat.js"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+      font-family: 'Poppins', sans-serif;
+      background-color: #0f0f12;
+      color: white;
+    }
+    header {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      z-index: 50;
+    }
+  </style>
+</head>
+<body class="min-h-screen">
+  <header></header>
+
+  <section class="mt-20 px-4">
+    <div class="max-w-lg mx-auto bg-gray-900 rounded-2xl p-6 shadow-lg">
+      <h2 class="text-xl font-bold mb-4 text-white text-center">Your Profile</h2>
+      <div class="mb-6 text-center">
+        <div id="profile-pic" class="w-24 h-24 rounded-full bg-pink-600 text-white text-3xl font-bold flex items-center justify-center mx-auto border-4 border-pink-600 shadow-lg"></div>
+      </div>
+
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6 text-center">
+        <div class="bg-gray-800 p-4 rounded-lg">
+          <p class="text-sm text-gray-400">Level</p>
+          <p id="level-number" class="text-2xl font-bold">1</p>
+        </div>
+        <div class="bg-gray-800 p-4 rounded-lg">
+          <p class="text-sm text-gray-400">Total Spent</p>
+          <p id="total-spent" class="text-2xl font-bold">0</p>
+        </div>
+        <div class="bg-gray-800 p-4 rounded-lg">
+          <p class="text-sm text-gray-400">Total Won</p>
+          <p id="total-won" class="text-2xl font-bold">0</p>
+        </div>
+        <div class="bg-gray-800 p-4 rounded-lg">
+          <p class="text-sm text-gray-400">Rarest Pull</p>
+          <div id="rarest-pull" class="text-sm text-gray-300"></div>
+        </div>
+      </div>
+
+      <div id="badge-container" class="flex flex-wrap justify-center gap-2 mb-6"></div>
+
+      <div class="mb-4 text-center">
+        <label class="block text-sm font-medium text-gray-300 mb-1">Username</label>
+        <input id="username-input" type="text" class="w-full px-4 py-2 rounded bg-gray-800 text-white border border-gray-600 text-center" />
+      </div>
+
+      <button onclick="updateProfile()" class="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-full transition mb-4">
+        Save Changes
+      </button>
+
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-300 mb-1">Email</label>
+        <input id="email" type="text" class="w-full px-4 py-2 rounded bg-gray-800 text-white border border-gray-600" disabled />
+      </div>
+
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-300 mb-1">Current Password</label>
+        <input id="current-password" type="password" placeholder="Enter current password" class="w-full px-4 py-2 rounded bg-gray-800 text-white border border-gray-600" />
+      </div>
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-300 mb-1">New Password</label>
+        <input id="new-password" type="password" placeholder="Enter new password" class="w-full px-4 py-2 rounded bg-gray-800 text-white border border-gray-600" />
+      </div>
+
+      <button onclick="changePassword()" class="w-full bg-pink-600 hover:bg-pink-700 text-white font-bold py-2 px-4 rounded-full transition">
+        Change Password
+      </button>
+    </div>
+  </section>
+
+  <footer></footer>
+
+  <!-- Firebase Config -->
+  <script>
+    const firebaseConfig = {
+      apiKey: "AIzaSyCyRm6dWH-fAmfWy83zLTrPFVi9Ny8gyxE",
+      authDomain: "cases-e5b4e.firebaseapp.com",
+      databaseURL: "https://cases-e5b4e-default-rtdb.firebaseio.com",
+      projectId: "cases-e5b4e",
+      storageBucket: "cases-e5b4e.appspot.com",
+      messagingSenderId: "22502548396",
+      appId: "1:22502548396:web:aac335672c21f07524d009"
+    };
+    firebase.initializeApp(firebaseConfig);
+  </script>
+
+  <!-- Scripts -->
+  <script src="scripts/header.js"></script>
+  <script src="scripts/navbar.js"></script>
+  <script src="scripts/footer.js"></script>
+  <script src="https://js.stripe.com/v3/"></script>
+  <script src="scripts/topup.js"></script>
+  <script src="scripts/profile.js"></script>
+</body>
+</html>
+

--- a/profile.html
+++ b/profile.html
@@ -17,8 +17,9 @@
       margin: 0;
       padding: 0;
       font-family: 'Poppins', sans-serif;
-      background-color: #0f0f12;
+      background: linear-gradient(135deg, #1e1e2f 0%, #3b0764 100%);
       color: white;
+      overflow-x: hidden;
     }
     header {
       position: fixed;
@@ -29,68 +30,77 @@
     }
   </style>
 </head>
-<body class="min-h-screen">
+<body class="min-h-screen relative">
   <header></header>
 
-  <section class="mt-20 px-4">
-    <div id="find-users-section" class="max-w-lg mx-auto mb-6 bg-gray-900 rounded-2xl p-6 shadow-lg">
-      <h2 class="text-xl font-bold mb-4 text-white text-center">Find Other Users</h2>
-      <input id="user-search" type="text" placeholder="Search users..." class="w-full px-4 py-2 rounded bg-gray-800 text-white border border-gray-600" />
-      <ul id="user-list" class="mt-2 bg-gray-800 rounded-lg divide-y divide-gray-700"></ul>
-      <h3 id="top-users-title" class="text-lg font-semibold mt-4 text-white text-center">Top Users</h3>
-      <ul id="top-users" class="mt-2 bg-gray-800 rounded-lg divide-y divide-gray-700"></ul>
+  <!-- Decorative pack images -->
+  <img src="https://source.unsplash.com/300x400/?pokemon,pack" alt="pack" class="hidden lg:block absolute -top-10 -left-10 w-40 opacity-20 -rotate-12 pointer-events-none" />
+  <img src="https://source.unsplash.com/300x400/?trading-card,pack" alt="pack" class="hidden lg:block absolute bottom-0 -right-10 w-40 opacity-20 rotate-12 pointer-events-none" />
+
+  <section class="mt-20 px-4 relative z-10">
+    <div id="find-users-section" class="max-w-lg mx-auto mb-8 bg-gradient-to-br from-gray-900/80 via-gray-800/80 to-gray-900/80 backdrop-blur-xl rounded-3xl p-6 shadow-2xl border border-purple-600/30">
+      <h2 class="text-xl font-bold mb-4 text-center bg-gradient-to-r from-pink-400 to-purple-500 bg-clip-text text-transparent">Find Other Users</h2>
+      <input id="user-search" type="text" placeholder="Search users..." class="w-full px-4 py-2 rounded bg-gray-900/60 text-white border border-purple-600/40 focus:outline-none" />
+      <ul id="user-list" class="mt-2 bg-gray-900/60 rounded-lg divide-y divide-gray-700"></ul>
+      <h3 id="top-users-title" class="text-lg font-semibold mt-4 text-center text-pink-300">Top Users</h3>
+      <ul id="top-users" class="mt-2 bg-gray-900/60 rounded-lg divide-y divide-gray-700"></ul>
     </div>
-    <div class="max-w-lg mx-auto bg-gray-900 rounded-2xl p-6 shadow-lg">
-      <h2 id="profile-title" class="text-xl font-bold mb-4 text-white text-center">Your Profile</h2>
-      <div class="mb-6 text-center">
-        <div id="profile-pic" class="w-24 h-24 rounded-full bg-pink-600 text-white text-3xl font-bold flex items-center justify-center mx-auto border-4 border-pink-600 shadow-lg"></div>
+
+    <div class="max-w-lg mx-auto bg-gradient-to-br from-gray-900/80 via-gray-800/80 to-gray-900/80 backdrop-blur-xl rounded-3xl p-6 shadow-2xl border border-purple-600/30">
+      <h2 id="profile-title" class="text-3xl font-extrabold mb-6 text-center bg-gradient-to-r from-pink-400 to-purple-500 bg-clip-text text-transparent">Your Profile</h2>
+      <div class="mb-8 text-center">
+        <div id="profile-pic" class="w-28 h-28 rounded-full bg-gradient-to-br from-pink-500 to-purple-600 text-white text-3xl font-bold flex items-center justify-center mx-auto border-4 border-purple-400 shadow-2xl"></div>
       </div>
 
-      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6 text-center">
-        <div class="bg-gray-800 p-4 rounded-lg">
-          <p class="text-sm text-gray-400">Level</p>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-8 text-center">
+        <div class="bg-gradient-to-br from-purple-700/40 to-pink-700/40 backdrop-blur-md p-4 rounded-xl border border-purple-500/30 shadow-lg">
+          <i class="fa-solid fa-star text-pink-300 text-2xl mb-1"></i>
+          <p class="text-sm text-pink-200">Level</p>
           <p id="level-number" class="text-2xl font-bold">1</p>
         </div>
-        <div class="bg-gray-800 p-4 rounded-lg">
-          <p class="text-sm text-gray-400">Total Spent</p>
+        <div class="bg-gradient-to-br from-purple-700/40 to-pink-700/40 backdrop-blur-md p-4 rounded-xl border border-purple-500/30 shadow-lg">
+          <i class="fa-solid fa-coins text-pink-300 text-2xl mb-1"></i>
+          <p class="text-sm text-pink-200">Total Spent</p>
           <p id="total-spent" class="text-2xl font-bold">0</p>
         </div>
-        <div class="bg-gray-800 p-4 rounded-lg">
-          <p class="text-sm text-gray-400">Total Won</p>
+        <div class="bg-gradient-to-br from-purple-700/40 to-pink-700/40 backdrop-blur-md p-4 rounded-xl border border-purple-500/30 shadow-lg">
+          <i class="fa-solid fa-trophy text-pink-300 text-2xl mb-1"></i>
+          <p class="text-sm text-pink-200">Total Won</p>
           <p id="total-won" class="text-2xl font-bold">0</p>
         </div>
-        <div class="bg-gray-800 p-4 rounded-lg">
-          <p class="text-sm text-gray-400">Rarest Pull</p>
-          <div id="rarest-pull" class="text-sm text-gray-300"></div>
+        <div class="bg-gradient-to-br from-purple-700/40 to-pink-700/40 backdrop-blur-md p-4 rounded-xl border border-purple-500/30 shadow-lg">
+          <i class="fa-solid fa-gem text-pink-300 text-2xl mb-1"></i>
+          <p class="text-sm text-pink-200">Rarest Pull</p>
+          <div id="rarest-pull" class="text-sm text-gray-200"></div>
         </div>
       </div>
 
-      <div id="badge-container" class="flex flex-wrap justify-center gap-2 mb-6"></div>
+      <div id="badge-container" class="flex flex-wrap justify-center gap-2 mb-8"></div>
 
       <div class="mb-4 text-center">
-        <label class="block text-sm font-medium text-gray-300 mb-1">Username</label>
-        <input id="username-input" type="text" class="w-full px-4 py-2 rounded bg-gray-800 text-white border border-gray-600 text-center" />
+        <label class="block text-sm font-medium text-gray-200 mb-1">Username</label>
+        <input id="username-input" type="text" class="w-full px-4 py-2 rounded bg-gray-900/60 text-white border border-purple-600/40 text-center focus:outline-none" />
       </div>
 
-      <button onclick="updateProfile()" class="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-full transition mb-4">
+      <button onclick="updateProfile()" class="w-full bg-gradient-to-r from-purple-500 via-pink-500 to-indigo-500 hover:from-purple-600 hover:via-pink-600 hover:to-indigo-600 text-white font-bold py-2 px-4 rounded-full transition transform hover:scale-105 mb-4">
         Save Changes
       </button>
 
       <div class="mb-4">
-        <label class="block text-sm font-medium text-gray-300 mb-1">Email</label>
-        <input id="email" type="text" class="w-full px-4 py-2 rounded bg-gray-800 text-white border border-gray-600" disabled />
+        <label class="block text-sm font-medium text-gray-200 mb-1">Email</label>
+        <input id="email" type="text" class="w-full px-4 py-2 rounded bg-gray-900/60 text-white border border-purple-600/40" disabled />
       </div>
 
       <div class="mb-4">
-        <label class="block text-sm font-medium text-gray-300 mb-1">Current Password</label>
-        <input id="current-password" type="password" placeholder="Enter current password" class="w-full px-4 py-2 rounded bg-gray-800 text-white border border-gray-600" />
+        <label class="block text-sm font-medium text-gray-200 mb-1">Current Password</label>
+        <input id="current-password" type="password" placeholder="Enter current password" class="w-full px-4 py-2 rounded bg-gray-900/60 text-white border border-purple-600/40" />
       </div>
-      <div class="mb-4">
-        <label class="block text-sm font-medium text-gray-300 mb-1">New Password</label>
-        <input id="new-password" type="password" placeholder="Enter new password" class="w-full px-4 py-2 rounded bg-gray-800 text-white border border-gray-600" />
+      <div class="mb-6">
+        <label class="block text-sm font-medium text-gray-200 mb-1">New Password</label>
+        <input id="new-password" type="password" placeholder="Enter new password" class="w-full px-4 py-2 rounded bg-gray-900/60 text-white border border-purple-600/40" />
       </div>
 
-      <button onclick="changePassword()" class="w-full bg-pink-600 hover:bg-pink-700 text-white font-bold py-2 px-4 rounded-full transition">
+      <button onclick="changePassword()" class="w-full bg-gradient-to-r from-pink-500 to-purple-500 hover:from-pink-600 hover:to-purple-600 text-white font-bold py-2 px-4 rounded-full transition transform hover:scale-105">
         Change Password
       </button>
     </div>

--- a/profile.html
+++ b/profile.html
@@ -33,9 +33,12 @@
   <header></header>
 
   <section class="mt-20 px-4">
-    <div class="max-w-lg mx-auto mb-6">
+    <div id="find-users-section" class="max-w-lg mx-auto mb-6 bg-gray-900 rounded-2xl p-6 shadow-lg">
+      <h2 class="text-xl font-bold mb-4 text-white text-center">Find Other Users</h2>
       <input id="user-search" type="text" placeholder="Search users..." class="w-full px-4 py-2 rounded bg-gray-800 text-white border border-gray-600" />
-      <ul id="user-list" class="mt-2 bg-gray-900 rounded-lg divide-y divide-gray-700"></ul>
+      <ul id="user-list" class="mt-2 bg-gray-800 rounded-lg divide-y divide-gray-700"></ul>
+      <h3 id="top-users-title" class="text-lg font-semibold mt-4 text-white text-center">Top Users</h3>
+      <ul id="top-users" class="mt-2 bg-gray-800 rounded-lg divide-y divide-gray-700"></ul>
     </div>
     <div class="max-w-lg mx-auto bg-gray-900 rounded-2xl p-6 shadow-lg">
       <h2 id="profile-title" class="text-xl font-bold mb-4 text-white text-center">Your Profile</h2>

--- a/scripts/header.js
+++ b/scripts/header.js
@@ -34,6 +34,7 @@ document.addEventListener("DOMContentLoaded", () => {
           <div id="user-dropdown" class="absolute right-0 mt-2 w-48 bg-gray-800 border border-gray-700 rounded-lg shadow-lg hidden z-50">
             <a href="index.html" class="block px-4 py-2 text-sm text-white hover:bg-gray-700"><i class="fas fa-cube mr-2"></i> Open Packs</a>
             <a href="inventory.html" class="block px-4 py-2 text-sm text-white hover:bg-gray-700"><i class="fas fa-box-open mr-2"></i> Inventory</a>
+            <a href="profile.html" class="block px-4 py-2 text-sm text-white hover:bg-gray-700"><i class="fas fa-user mr-2"></i> Profile</a>
             <a href="how-it-works.html" class="block px-4 py-2 text-sm text-white hover:bg-gray-700"><i class="fas fa-question-circle mr-2"></i> How It Works</a>
             <a id="signin-desktop" href="auth.html" class="block px-4 py-2 text-sm text-green-400 hover:bg-gray-700"><i class="fas fa-sign-in-alt mr-2"></i> Sign In</a>
             <a id="logout-desktop" href="#" class="block px-4 py-2 text-sm text-red-400 hover:bg-gray-700"><i class="fas fa-sign-out-alt mr-2"></i> Logout</a>
@@ -53,6 +54,7 @@ document.addEventListener("DOMContentLoaded", () => {
       </div>
       <a href="index.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm"><i class="fas fa-cube mr-2"></i> Open Packs</a>
       <a id="inventory-link" href="inventory.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm hidden"><i class="fas fa-box-open mr-2"></i> Inventory</a>
+      <a id="profile-link" href="profile.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm hidden"><i class="fas fa-user mr-2"></i> Profile</a>
       <a href="how-it-works.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm"><i class="fas fa-question-circle mr-2"></i> How It Works</a>
       <a href="rewards.html" class="block px-4 py-2 hover:bg-gray-700 text-yellow-400 text-sm"><i class="fas fa-gift mr-2"></i> Rewards</a>
       <a href="marketplace.html" class="block px-4 py-2 hover:bg-gray-700 text-pink-400 text-sm"><i class="fas fa-store mr-2"></i> Marketplace</a>
@@ -80,6 +82,7 @@ document.addEventListener("DOMContentLoaded", () => {
       const logoutDesktop = document.getElementById("logout-desktop");
       const mobileAuth = document.getElementById("mobile-auth-button");
       const inventoryLink = document.getElementById("inventory-link");
+      const profileLink = document.getElementById("profile-link");
 
       const formatted = parseInt(balance, 10).toLocaleString();
       if (balanceDesktop) balanceDesktop.innerText = formatted;
@@ -104,6 +107,7 @@ document.addEventListener("DOMContentLoaded", () => {
       if (signinDesktop) signinDesktop.classList.add("hidden");
       if (logoutDesktop) logoutDesktop.classList.remove("hidden");
       if (inventoryLink) inventoryLink.classList.remove("hidden");
+      if (profileLink) profileLink.classList.remove("hidden");
 
       if (logoutDesktop) {
         logoutDesktop.onclick = (e) => {

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -16,6 +16,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const balanceEl = document.getElementById('balance-amount');
       if (balanceEl) balanceEl.innerText = Number(data.balance || 0).toLocaleString();
       document.getElementById('username-display').innerText = user.displayName || user.email;
+      const shipUsernameInput = document.getElementById('ship-username');
+      if (shipUsernameInput && data.username) shipUsernameInput.value = data.username;
     });
 
     // Load badges from Firestore

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -8,6 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const targetUid = params.get('uid') || currentUid;
     loadProfile(targetUid, currentUid);
     setupSearch();
+    loadTopUsers();
   });
 });
 
@@ -98,11 +99,17 @@ function setupSearch() {
   searchInput.addEventListener('input', async e => {
     const q = e.target.value.trim();
     const list = document.getElementById('user-list');
+    const topTitle = document.getElementById('top-users-title');
+    const topList = document.getElementById('top-users');
     if (!list) return;
     if (!q) {
       list.innerHTML = '';
+      if (topTitle) topTitle.classList.remove('hidden');
+      if (topList) topList.classList.remove('hidden');
       return;
     }
+    if (topTitle) topTitle.classList.add('hidden');
+    if (topList) topList.classList.add('hidden');
     const snap = await firebase.firestore().collection('leaderboard')
       .orderBy('username')
       .startAt(q)
@@ -117,6 +124,24 @@ function setupSearch() {
       li.onclick = () => { window.location.href = `profile.html?uid=${doc.id}`; };
       list.appendChild(li);
     });
+  });
+}
+
+async function loadTopUsers() {
+  const list = document.getElementById('top-users');
+  if (!list) return;
+  const snap = await firebase.firestore().collection('leaderboard')
+    .orderBy('cardValue', 'desc')
+    .limit(5)
+    .get();
+  list.innerHTML = '';
+  snap.forEach(doc => {
+    const li = document.createElement('li');
+    li.className = 'p-2 hover:bg-gray-700 cursor-pointer flex justify-between';
+    const data = doc.data();
+    li.innerHTML = `<span>${data.username || 'Anonymous'}</span><span>${(data.cardValue || 0).toLocaleString()}</span>`;
+    li.onclick = () => { window.location.href = `profile.html?uid=${doc.id}`; };
+    list.appendChild(li);
   });
 }
 

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -32,12 +32,10 @@ document.addEventListener('DOMContentLoaded', () => {
     firebase.database().ref('users/' + uid + '/unboxHistory').once('value').then(snap => {
       let totalSpent = 0;
       let rarest = null;
-      const order = ['common','uncommon','rare','ultra rare','legendary'];
       snap.forEach(child => {
         const d = child.val();
         totalSpent += Math.max(0, (d.balanceBefore || 0) - (d.balanceAfter || 0));
-        const rarityIndex = order.indexOf((d.rarity || '').toLowerCase());
-        if (!rarest || rarityIndex > order.indexOf((rarest.rarity || '').toLowerCase())) {
+        if (!rarest || (d.value || 0) > (rarest.value || 0)) {
           rarest = d;
         }
       });

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -1,0 +1,86 @@
+// scripts/profile.js
+
+document.addEventListener('DOMContentLoaded', () => {
+  firebase.auth().onAuthStateChanged(user => {
+    if (!user) return (window.location.href = 'auth.html');
+    const uid = user.uid;
+
+    const userRef = firebase.database().ref('users/' + uid);
+    userRef.once('value').then(snap => {
+      const data = snap.val() || {};
+      document.getElementById('email').value = user.email;
+      const usernameInput = document.getElementById('username-input');
+      if (usernameInput && data.username) usernameInput.value = data.username;
+      const initials = user.email ? user.email.substring(0,2).toUpperCase() : '??';
+      document.getElementById('profile-pic').textContent = initials;
+    });
+
+    firebase.firestore().collection('leaderboard').doc(uid).get().then(doc => {
+      const data = doc.data() || {};
+      const badges = data.badges || [];
+      const badgeContainer = document.getElementById('badge-container');
+      if (badges.length === 0) {
+        badgeContainer.innerHTML = '<p class="text-sm text-gray-400">No badges yet.</p>';
+      } else {
+        badgeContainer.innerHTML = badges.map(b => `<span class="bg-purple-600 text-white text-xs px-2 py-1 rounded-full">${b}</span>`).join(' ');
+      }
+      const level = Math.floor((data.packsOpened || 0) / 10) + 1;
+      document.getElementById('level-number').innerText = level;
+      document.getElementById('total-won').innerText = (data.cardValue || 0).toLocaleString();
+    });
+
+    firebase.database().ref('users/' + uid + '/unboxHistory').once('value').then(snap => {
+      let totalSpent = 0;
+      let rarest = null;
+      const order = ['common','uncommon','rare','ultra rare','legendary'];
+      snap.forEach(child => {
+        const d = child.val();
+        totalSpent += Math.max(0, (d.balanceBefore || 0) - (d.balanceAfter || 0));
+        const rarityIndex = order.indexOf((d.rarity || '').toLowerCase());
+        if (!rarest || rarityIndex > order.indexOf((rarest.rarity || '').toLowerCase())) {
+          rarest = d;
+        }
+      });
+      document.getElementById('total-spent').innerText = totalSpent.toLocaleString();
+      const rareEl = document.getElementById('rarest-pull');
+      if (rarest) {
+        rareEl.innerHTML = `<img src="${rarest.image}" class="h-16 mx-auto mb-2"><p>${rarest.name} (${rarest.rarity})</p>`;
+      } else {
+        rareEl.textContent = 'No pulls yet.';
+      }
+    });
+  });
+});
+
+function updateProfile() {
+  const user = firebase.auth().currentUser;
+  if (!user) return;
+  const newUsername = document.getElementById('username-input').value;
+  user.updateProfile({ displayName: newUsername })
+    .then(() => firebase.database().ref('users/' + user.uid).update({ username: newUsername }))
+    .then(() => {
+      alert('✅ Username updated!');
+      location.reload();
+    })
+    .catch(err => alert('❌ Error: ' + err.message));
+}
+
+function changePassword() {
+  const currentPassword = document.getElementById('current-password').value;
+  const newPassword = document.getElementById('new-password').value;
+  const user = firebase.auth().currentUser;
+  if (!currentPassword || !newPassword) {
+    alert('Please fill out both password fields.');
+    return;
+  }
+  const credential = firebase.auth.EmailAuthProvider.credential(user.email, currentPassword);
+  user.reauthenticateWithCredential(credential)
+    .then(() => user.updatePassword(newPassword))
+    .then(() => {
+      alert('✅ Password updated successfully.');
+      document.getElementById('current-password').value = '';
+      document.getElementById('new-password').value = '';
+    })
+    .catch(error => alert('❌ ' + error.message));
+}
+


### PR DESCRIPTION
## Summary
- remove profile tab from inventory and create standalone profile page
- add profile stats such as level, total spent/won and rarest pull
- expose profile link in header for desktop and mobile nav

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689167b6d54c83208cdd2d1203a7c9a7