### PR TITLE
Add tower game page and re-entry token management

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -54,6 +54,7 @@
       <a href="#" class="text-sm text-white hover:text-pink-400" onclick="showSection('marketplace')">Marketplace</a>
       <a href="#" class="text-sm text-white hover:text-pink-400" onclick="showSection('quests')">Quests</a>
       <a href="#" class="text-sm text-white hover:text-pink-400" onclick="showSection('milestones')">Milestones</a>
+      <a href="#" class="text-sm text-white hover:text-pink-400" onclick="showSection('tower')">Tower</a>
     </div>
   </nav>
 
@@ -194,6 +195,22 @@
 </section>
 
 
+<section id="tower-section" class="hidden">
+  <h1 class="text-3xl font-bold mb-6">Tower Settings</h1>
+  <form id="tower-config-form" class="space-y-4 max-w-xl bg-gray-800 p-6 rounded-lg">
+    <div>
+      <label class="block mb-1">Re-entry Token Cost (coins):</label>
+      <input type="number" id="reentry-cost" class="w-full p-2 rounded" />
+    </div>
+    <div>
+      <label class="block mb-1">Daily Attempt Limit:</label>
+      <input type="number" id="daily-limit" class="w-full p-2 rounded" />
+    </div>
+    <button type="submit" class="px-6 py-2 bg-purple-600 hover:bg-purple-700 rounded">Save</button>
+  </form>
+</section>
+
+
     <!-- Shipment Management Section -->
     <section id="shipments-section" class="hidden">
       <h1 class="text-3xl font-bold mb-6">Manage Shipments</h1>
@@ -231,7 +248,7 @@
     }
 
   function showSection(id) {
-  const sections = ['cases', 'shipments', 'support', 'users', 'marketplace', 'quests', 'milestones'];
+  const sections = ['cases', 'shipments', 'support', 'users', 'marketplace', 'quests', 'milestones', 'tower'];
   sections.forEach(section => {
     document.getElementById(section + '-section').classList.add('hidden');
   });
@@ -661,6 +678,7 @@ firebase.auth().onAuthStateChanged(user => {
   loadMarketplaceItems();
   loadQuestConfig();
   loadMilestoneConfig();
+  loadTowerConfig();
 });
 
 
@@ -823,6 +841,24 @@ document.getElementById('milestone-config-form').addEventListener('submit', e =>
     if (!isNaN(val)) levels.push(val);
   });
   firebase.database().ref('milestoneConfig').set({ badges, levels }).then(() => showToast('✅ Milestone config saved'));
+});
+
+function loadTowerConfig() {
+  const ref = firebase.database().ref('towerConfig');
+  ref.once('value').then(snap => {
+    const cfg = snap.val() || {};
+    document.getElementById('reentry-cost').value = cfg.reentryCost || 0;
+    document.getElementById('daily-limit').value = cfg.dailyLimit || 1;
+  });
+}
+
+document.getElementById('tower-config-form').addEventListener('submit', e => {
+  e.preventDefault();
+  const config = {
+    reentryCost: parseInt(document.getElementById('reentry-cost').value) || 0,
+    dailyLimit: parseInt(document.getElementById('daily-limit').value) || 1
+  };
+  firebase.database().ref('towerConfig').set(config).then(() => showToast('✅ Tower config saved'));
 });
 
   </script>

--- a/scripts/tower.js
+++ b/scripts/tower.js
@@ -1,0 +1,90 @@
+// Simple Tower game logic
+const floors = [
+  { name: 'Floor 1', prizes: [10, 20, 30] },
+  { name: 'Floor 2', prizes: [20, 40, 60] },
+  { name: 'Floor 3', prizes: [40, 80, 120] },
+  { name: 'Floor 4', prizes: [80, 160, 240] },
+  { name: 'Floor 5', prizes: [160, 320, 480] },
+  { name: 'Floor 6', prizes: [320, 640, 960] },
+  { name: 'Floor 7', prizes: [640, 1280, 1920] },
+  { name: 'Floor 8', prizes: [1280, 2560, 3840] },
+  { name: 'Floor 9', prizes: [2560, 5120, 7680] },
+  { name: 'Floor 10', prizes: [5000, 10000, 15000] },
+];
+
+let currentFloor = 1;
+let winnings = 0;
+let lastPrize = 0;
+
+const towerEl = document.getElementById('tower');
+const statusEl = document.getElementById('status');
+const openBtn = document.getElementById('open-btn');
+const climbBtn = document.getElementById('climb-btn');
+const cashoutBtn = document.getElementById('cashout-btn');
+
+function renderTower() {
+  towerEl.innerHTML = '';
+  floors.slice().reverse().forEach((floor, idx) => {
+    const level = floors.length - idx;
+    const div = document.createElement('div');
+    div.className = 'h-14 flex items-center justify-center border-b border-gray-700';
+    if (level === currentFloor) {
+      div.classList.add('bg-gradient-to-r', 'from-purple-600', 'to-pink-500', 'font-bold');
+    }
+    div.textContent = floor.name;
+    towerEl.appendChild(div);
+  });
+}
+
+function openPack() {
+  const floor = floors[currentFloor - 1];
+  lastPrize = floor.prizes[Math.floor(Math.random() * floor.prizes.length)];
+  winnings += lastPrize;
+  statusEl.textContent = `You pulled a card worth ${lastPrize} coins! Total: ${winnings}`;
+  openBtn.disabled = true;
+  climbBtn.disabled = false;
+  cashoutBtn.disabled = false;
+}
+
+function climb() {
+  if (currentFloor >= 3) {
+    const failChance = (currentFloor - 2) * 0.1; // increases per floor
+    if (Math.random() < failChance) {
+      statusEl.textContent = 'You fell from the tower and lost everything!';
+      resetGame();
+      return;
+    }
+  }
+  if (currentFloor === floors.length) {
+    statusEl.textContent = `Top floor reached! You win ${winnings} coins!`;
+    resetGame();
+    return;
+  }
+  currentFloor++;
+  statusEl.textContent = `Climbed to Floor ${currentFloor}. Open your next pack.`;
+  openBtn.disabled = false;
+  climbBtn.disabled = true;
+  cashoutBtn.disabled = true;
+  renderTower();
+}
+
+function cashOut() {
+  statusEl.textContent = `You cashed out with ${winnings} coins.`;
+  resetGame();
+}
+
+function resetGame() {
+  currentFloor = 1;
+  winnings = 0;
+  lastPrize = 0;
+  openBtn.disabled = false;
+  climbBtn.disabled = true;
+  cashoutBtn.disabled = true;
+  renderTower();
+}
+
+openBtn.addEventListener('click', openPack);
+climbBtn.addEventListener('click', climb);
+cashoutBtn.addEventListener('click', cashOut);
+
+renderTower();

--- a/tower.html
+++ b/tower.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>PrimePull.gg | Tower</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-database-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
+  <script src="scripts/firebase-config.js"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+</head>
+<body class="bg-gray-900 text-white font-[Poppins]">
+  <header></header>
+  <main class="pt-24 flex flex-col items-center p-4">
+    <h1 class="text-3xl font-bold mb-4">Tower of Packs</h1>
+    <div id="tower" class="relative w-full max-w-xs border border-gray-700 rounded-lg overflow-hidden">
+      <!-- Floors inserted here -->
+    </div>
+    <div id="controls" class="mt-6 flex gap-2">
+      <button id="open-btn" class="px-4 py-2 bg-blue-600 rounded hover:bg-blue-700">Open Pack</button>
+      <button id="climb-btn" class="px-4 py-2 bg-green-600 rounded hover:bg-green-700" disabled>Climb</button>
+      <button id="cashout-btn" class="px-4 py-2 bg-yellow-500 rounded hover:bg-yellow-600" disabled>Cash Out</button>
+    </div>
+    <div id="status" class="mt-4 text-center min-h-[2rem]"></div>
+  </main>
+  <script src="scripts/header.js"></script>
+  <script src="scripts/tower.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Tower link to admin panel navigation
- allow configuring Tower re-entry token cost and daily limit
- load and save Tower settings via Firebase
- create interactive Tower of Packs page with climb and cash out mechanics

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689181a54f6c83208ce604f7733ac2ba