### PR TITLE
Align try-free demo odds with real case spins

### DIFF
--- a/case.html
+++ b/case.html
@@ -461,7 +461,20 @@ setTimeout(() => {
           </span>
         `;
 
-        const demoPrize = prizeList[Math.floor(Math.random() * prizeList.length)];
+        const prizes = Object.values(caseData.prizes || {}).sort((a, b) => a.odds - b.odds);
+        const totalOdds = prizes.reduce((sum, p) => sum + (p.odds || 0), 0);
+        const rand = Math.random() * totalOdds;
+
+        let cumulative = 0;
+        let demoPrize = prizes[prizes.length - 1];
+        for (let p of prizes) {
+          cumulative += p.odds || 0;
+          if (rand < cumulative) {
+            demoPrize = p;
+            break;
+          }
+        }
+
         const spinnerPrizes = [];
         for (let i = 0; i < 30; i++) {
           const randomPrize = prizeList[Math.floor(Math.random() * prizeList.length)];
@@ -475,20 +488,10 @@ setTimeout(() => {
           spinToPrize(() => {
             btn.disabled = false;
             btn.classList.remove("cursor-not-allowed", "opacity-60");
-              // Reset button text without using a template literal to avoid stray tokens
-              btn.innerHTML = '<span class="relative z-10">Try for Free</span>';
+            btn.innerHTML = '<span class="relative z-10">Try for Free</span>';
             playRaritySound(demoPrize.rarity);
             showToast(`You would have won ${demoPrize.name}!`, "bg-blue-600");
           }, false);
-          spinToPrize(() => {
-            btn.disabled = false;
-            btn.classList.remove("cursor-not-allowed", "opacity-60");
-            btn.innerHTML = `<span class="relative z-10">Try for Free</span>`;
-            playRaritySound(demoPrize.rarity);
-            showToast(`You would have won ${demoPrize.name}!`, "bg-blue-600");
-          }, false);
-
-          });
         }, 150);
       });
   document.getElementById("pf-info").addEventListener("click", async () => {


### PR DESCRIPTION
## Summary
- Align "Try for Free" demo spins with real case odds
- Simplify demo spin flow to a single spin and proper reset

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68921f3480a88320b2a2d9e31940c50c