### PR TITLE
feat: show coin balance on mobile menu

### DIFF
--- a/components/header.html
+++ b/components/header.html
@@ -47,8 +47,13 @@
     </div>
   </div>
 
-  <!-- Mobile Hamburger -->
-  <div class="sm:hidden">
+  <!-- Mobile Coin Balance and Menu Toggle -->
+  <div class="sm:hidden flex items-center gap-2">
+    <div id="user-balance-mobile-header" class="flex items-center gap-1 bg-gray-800 text-white px-3 py-1 rounded-full text-sm">
+      <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" />
+      <span id="balance-amount-mobile">0</span>
+      <span>coins</span>
+    </div>
     <button id="menu-toggle" class="text-white text-2xl">
       <i class="fas fa-bars"></i>
     </button>
@@ -58,7 +63,7 @@
 <!-- Mobile Dropdown -->
 <div id="mobile-dropdown" class="hidden mt-2 bg-gray-800 border border-gray-700 rounded-lg w-48 py-2 fixed right-4 top-[72px] z-[9999] shadow-lg sm:hidden">
   <div id="user-balance-mobile" class="flex items-center justify-between px-4 py-2 text-sm text-white border-b border-gray-700">
-    <span><img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="inline w-4 h-4 mr-1"> <span id="balance-amount-mobile">0</span> coins</span>
+    <span><img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="inline w-4 h-4 mr-1"> <span id="balance-amount-mobile-dropdown">0</span> coins</span>
     <button id="topup-button-mobile" class="text-green-400 text-lg font-bold hover:text-green-500">+</button>
   </div>
   <a id="inventory-link" href="inventory.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm">Inventory</a>

--- a/components/nav.html
+++ b/components/nav.html
@@ -34,7 +34,12 @@
       </div>
     </div>
   </div>
-  <div class="sm:hidden">
+  <div class="sm:hidden flex items-center gap-2">
+    <div id="user-balance-mobile-header" class="flex items-center gap-1 bg-gray-800 text-white px-3 py-1 rounded-full text-sm">
+      <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" />
+      <span id="balance-amount-mobile">0</span>
+      <span>coins</span>
+    </div>
     <button id="menu-toggle" class="text-white text-2xl">
       <i class="fas fa-bars"></i>
     </button>
@@ -42,7 +47,7 @@
 </nav>
 <div id="mobile-dropdown" class="hidden mt-2 bg-gray-800 border border-gray-700 rounded-lg w-48 py-2 fixed right-4 top-[72px] z-[9999] shadow-lg sm:hidden">
   <div id="user-balance-mobile" class="flex items-center justify-between px-4 py-2 text-sm text-white border-b border-gray-700">
-    <span><img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="inline w-4 h-4 mr-1"> <span id="balance-amount-mobile">0</span> coins</span>
+    <span><img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="inline w-4 h-4 mr-1"> <span id="balance-amount-mobile-dropdown">0</span> coins</span>
     <button id="topup-button-mobile" class="text-green-400 text-lg font-bold hover:text-green-500">+</button>
   </div>
   <a id="inventory-link" href="inventory.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm hidden">Inventory</a>

--- a/faq.html
+++ b/faq.html
@@ -100,7 +100,9 @@
 
     document.getElementById('balance-amount').innerText = balanceFormatted;
     const balanceMobile = document.getElementById('balance-amount-mobile');
+    const balanceDropdown = document.getElementById('balance-amount-mobile-dropdown');
     if (balanceMobile) balanceMobile.innerText = balanceFormatted;
+    if (balanceDropdown) balanceDropdown.innerText = balanceFormatted;
     document.getElementById('user-balance').classList.remove('hidden');
     document.getElementById('username-display').innerText = data.username || user.displayName || user.email || 'User';
     document.getElementById('signin-desktop').classList.add('hidden');

--- a/scripts/auth.js
+++ b/scripts/auth.js
@@ -7,6 +7,7 @@ window.addEventListener('DOMContentLoaded', () => {
   firebase.auth().onAuthStateChanged(async (user) => {
     const balanceAmount = document.getElementById('balance-amount');
     const balanceMobile = document.getElementById('balance-amount-mobile');
+    const balanceDropdown = document.getElementById('balance-amount-mobile-dropdown');
     const popupBalance = document.getElementById('popup-balance');
     const userBalanceWrapper = document.getElementById('user-balance');
     const usernameDisplay = document.getElementById('username-display');
@@ -33,6 +34,7 @@ window.addEventListener('DOMContentLoaded', () => {
       const balanceFormatted = Number(balance).toLocaleString();
       if (balanceAmount) balanceAmount.innerText = balanceFormatted;
       if (balanceMobile) balanceMobile.innerText = balanceFormatted;
+      if (balanceDropdown) balanceDropdown.innerText = balanceFormatted;
       if (popupBalance) popupBalance.innerText = `${balanceFormatted} coins`;
       if (userBalanceWrapper) userBalanceWrapper.classList.remove('hidden');
 
@@ -69,6 +71,7 @@ window.addEventListener('DOMContentLoaded', () => {
       // Signed out state
       if (userBalanceWrapper) userBalanceWrapper.classList.add('hidden');
       if (balanceAmount) balanceAmount.innerText = '0';
+      if (balanceDropdown) balanceDropdown.innerText = '0';
       if (usernameDisplay) usernameDisplay.innerText = "User";
 
       if (inventoryLink) inventoryLink.classList.add('hidden');

--- a/scripts/header.js
+++ b/scripts/header.js
@@ -41,7 +41,12 @@ document.addEventListener("DOMContentLoaded", () => {
           </div>
         </div>
       </div>
-      <div class="sm:hidden">
+      <div class="sm:hidden flex items-center gap-2">
+        <div id="user-balance-mobile-header" class="flex items-center gap-1 bg-gray-800 text-white px-3 py-1 rounded-full text-sm">
+          <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" />
+          <span id="balance-amount-mobile">0</span>
+          <span>coins</span>
+        </div>
         <button id="menu-toggle" class="text-white text-2xl">
           <i class="fas fa-bars"></i>
         </button>
@@ -49,7 +54,7 @@ document.addEventListener("DOMContentLoaded", () => {
     </nav>
     <div id="mobile-dropdown" class="hidden mt-2 bg-gray-800 border border-gray-700 rounded-lg w-48 py-2 fixed right-4 top-[72px] z-[9999] shadow-lg sm:hidden">
       <div id="user-balance-mobile" class="flex items-center justify-between px-4 py-2 text-sm text-white border-b border-gray-700">
-        <span><img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="inline w-4 h-4 mr-1"> <span id="balance-amount-mobile">0</span> coins</span>
+        <span><img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="inline w-4 h-4 mr-1"> <span id="balance-amount-mobile-dropdown">0</span> coins</span>
         <button id="topup-button-mobile" class="text-green-400 text-lg font-bold hover:text-green-500">+</button>
       </div>
       <a href="index.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm"><i class="fas fa-cube mr-2"></i> Open Packs</a>
@@ -76,7 +81,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
       const balanceDesktop = document.getElementById("balance-amount");
       const balanceMobile = document.getElementById("balance-amount-mobile");
+      const balanceDropdown = document.getElementById("balance-amount-mobile-dropdown");
       const userBalanceDiv = document.getElementById("user-balance");
+      const userBalanceMobileHeader = document.getElementById("user-balance-mobile-header");
       const usernameDisplay = document.getElementById("username-display");
       const signinDesktop = document.getElementById("signin-desktop");
       const logoutDesktop = document.getElementById("logout-desktop");
@@ -87,11 +94,12 @@ document.addEventListener("DOMContentLoaded", () => {
       const formatted = parseInt(balance, 10).toLocaleString();
       if (balanceDesktop) balanceDesktop.innerText = formatted;
       if (balanceMobile) balanceMobile.innerText = formatted;
+      if (balanceDropdown) balanceDropdown.innerText = formatted;
       if (userBalanceDiv) userBalanceDiv.classList.remove("hidden");
 
       if (prevBalance !== balance) {
         const userBalanceMobileDiv = document.getElementById("user-balance-mobile");
-        [userBalanceDiv, userBalanceMobileDiv].forEach((el) => {
+        [userBalanceDiv, userBalanceMobileHeader, userBalanceMobileDiv].forEach((el) => {
           if (el) {
             el.classList.add("pulse-balance");
             el.addEventListener(

--- a/scripts/navbar.js
+++ b/scripts/navbar.js
@@ -18,6 +18,7 @@ document.addEventListener("DOMContentLoaded", () => {
       const usernameEl = document.getElementById("username-display");
       const balanceEl = document.getElementById("balance-amount");
       const balanceMobile = document.getElementById("balance-amount-mobile");
+      const balanceDropdown = document.getElementById("balance-amount-mobile-dropdown");
       const popupBalance = document.getElementById("popup-balance");
       const mobileAuthBtn = document.getElementById("mobile-auth-button");
       const logoutBtn = document.getElementById("logout-desktop");
@@ -36,6 +37,7 @@ document.addEventListener("DOMContentLoaded", () => {
           usernameEl.innerText = username;
           balanceEl.innerText = balanceFormatted;
           if (balanceMobile) balanceMobile.innerText = balanceFormatted;
+          if (balanceDropdown) balanceDropdown.innerText = balanceFormatted;
           if (popupBalance) popupBalance.innerText = `${balanceFormatted} coins`;
 
           if (logoutBtn) {
@@ -61,6 +63,7 @@ document.addEventListener("DOMContentLoaded", () => {
         usernameEl.innerText = "User";
         balanceEl.innerText = "0";
         if (balanceMobile) balanceMobile.innerText = "0";
+        if (balanceDropdown) balanceDropdown.innerText = "0";
         if (popupBalance) popupBalance.innerText = "0 coins";
 
         if (logoutBtn) logoutBtn.style.display = "none";
@@ -136,17 +139,10 @@ waitForElement("#topup-button", () => {
   waitForElement("#menu-toggle", () => {
     const menuToggle = document.getElementById("menu-toggle");
     const mobileDropdown = document.getElementById("mobile-dropdown");
-    const menuIcon = menuToggle.querySelector("i");
-    menuToggle.classList.add("transition-transform", "duration-200");
 
     const openMenu = () => {
       mobileDropdown.classList.remove("hidden", "fade-out");
       mobileDropdown.classList.add("fade-in");
-      menuToggle.classList.add("rotate-90");
-      if (menuIcon) {
-        menuIcon.classList.remove("fa-bars");
-        menuIcon.classList.add("fa-times");
-      }
     };
 
     const closeMenu = () => {
@@ -160,11 +156,6 @@ waitForElement("#topup-button", () => {
         },
         { once: true }
       );
-      menuToggle.classList.remove("rotate-90");
-      if (menuIcon) {
-        menuIcon.classList.remove("fa-times");
-        menuIcon.classList.add("fa-bars");
-      }
     };
 
     menuToggle.addEventListener("click", (e) => {

--- a/scripts/topup.js
+++ b/scripts/topup.js
@@ -113,7 +113,10 @@ firebase.auth().onAuthStateChanged(async (user) => {
 
               const formattedBalance = newBalance.toLocaleString();
               document.getElementById("balance-amount").innerText = formattedBalance;
-              document.getElementById("balance-amount-mobile").innerText = formattedBalance;
+              const mobileBalance = document.getElementById("balance-amount-mobile");
+              const mobileDropdownBalance = document.getElementById("balance-amount-mobile-dropdown");
+              if (mobileBalance) mobileBalance.innerText = formattedBalance;
+              if (mobileDropdownBalance) mobileDropdownBalance.innerText = formattedBalance;
 
               const popupBalance = document.getElementById("popup-balance");
               if (popupBalance) popupBalance.innerText = `${formattedBalance} coins`;

--- a/termsandconditions.html
+++ b/termsandconditions.html
@@ -105,7 +105,9 @@
 
     document.getElementById('balance-amount').innerText = balanceFormatted;
     const balanceMobile = document.getElementById('balance-amount-mobile');
+    const balanceDropdown = document.getElementById('balance-amount-mobile-dropdown');
     if (balanceMobile) balanceMobile.innerText = balanceFormatted;
+    if (balanceDropdown) balanceDropdown.innerText = balanceFormatted;
     document.getElementById('user-balance').classList.remove('hidden');
     document.getElementById('username-display').innerText = data.username || user.displayName || user.email || 'User';
     document.getElementById('signin-desktop').classList.add('hidden');


### PR DESCRIPTION
## Summary
- Replace mobile hamburger button with coin balance display
- Sync header and dropdown coin balances across auth, top-ups, and navbar logic
- Restore hamburger toggle alongside mobile coin display

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892732f21448320ae0a6858ab8544a4