### PR TITLE
fix: prevent horizontal scroll on case page

### DIFF
--- a/case.html
+++ b/case.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="overflow-x-hidden">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -64,7 +64,7 @@
   </style>
 
 </head>
-  <body class="bg-gradient-to-br from-gray-900 via-purple-900 to-black text-white">
+  <body class="bg-gradient-to-br from-gray-900 via-purple-900 to-black text-white overflow-x-hidden">
       <canvas id="particle-canvas"></canvas>
       <header></header>
 <section id="case-content" class="relative pt-32 pb-10 px-4 max-w-5xl mx-auto">


### PR DESCRIPTION
## Summary
- hide horizontal overflow in case.html to stop left/right scrolling on mobile

## Testing
- `npm test` *(fails: ENOENT because package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68927a65488c83209c4b15982f85f376