### PR TITLE
Refine mobile hero design with animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,8 +43,8 @@
 <section id="hero" class="relative overflow-hidden bg-gradient-to-b from-gray-900 via-purple-900 to-gray-900">
   <div class="container mx-auto max-w-6xl px-6 pt-20 pb-16 flex flex-col gap-8">
 
-    <!-- Updates Bar -->
-    <div class="w-full bg-gradient-to-r from-yellow-500 via-pink-500 to-purple-600 text-white py-2 overflow-hidden rounded-xl shadow-md">
+    <!-- Updates Bar (hidden on mobile for cleaner hero) -->
+    <div class="hidden md:block w-full bg-gradient-to-r from-yellow-500 via-pink-500 to-purple-600 text-white py-2 overflow-hidden rounded-xl shadow-md">
       <div class="animate-marquee whitespace-nowrap text-sm font-medium flex items-center gap-12 px-4">
         <span>📦 All cards are near mint unless specified otherwise</span>
         <span class="flex items-center gap-1">
@@ -63,13 +63,13 @@
         <p class="text-md md:text-lg text-gray-300 mb-6 leading-relaxed opacity-0 animate-fade-up">
           Open digital packs. Win real cards. Start ripping in seconds. Packly.gg.
         </p>
-        <a href="#cases" class="inline-block px-6 py-3 bg-yellow-400 text-black rounded-full font-semibold border border-yellow-500 hover:bg-yellow-300 transition-all duration-200 shadow-md hover:scale-105 opacity-0 animate-fade-up">
+        <a href="#cases" class="inline-block w-full md:w-auto px-6 py-3 bg-yellow-400 text-black rounded-full font-semibold border border-yellow-500 hover:bg-yellow-300 transition-all duration-200 shadow-md hover:scale-105 opacity-0 animate-fade-up">
           Grab A Pack
         </a>
       </div>
 
       <!-- Pack Animation -->
-      <div class="flex-1 relative w-full h-64 md:h-80">
+      <div id="hero-pack-wrapper" class="flex-1 relative w-full h-64 md:h-80 opacity-0 animate-fade-up">
         <div id="hero-pack-carousel" class="absolute inset-0"></div>
       </div>
     </div>

--- a/scripts/hero.js
+++ b/scripts/hero.js
@@ -2,10 +2,12 @@ window.addEventListener('DOMContentLoaded', () => {
   const title = document.querySelector('h1.animate-fade-up');
   const paragraph = document.querySelector('p.animate-fade-up');
   const cta = document.querySelector('#hero a.animate-fade-up');
+  const packWrapper = document.getElementById('hero-pack-wrapper');
 
   if (title) setTimeout(() => title.classList.remove('opacity-0'), 200);
   if (paragraph) setTimeout(() => paragraph.classList.remove('opacity-0'), 400);
   if (cta) setTimeout(() => cta.classList.remove('opacity-0'), 600);
+  if (packWrapper) setTimeout(() => packWrapper.classList.remove('opacity-0'), 800);
 
   const carousel = document.getElementById('hero-pack-carousel');
   const casesContainer = document.getElementById('cases-container');

--- a/styles/main.css
+++ b/styles/main.css
@@ -216,6 +216,22 @@ body {
   transform: translate(-50%, -50%) scale(1);
 }
 
+@keyframes mobile-float {
+  0%, 100% {
+    transform: translate(-50%, -50%) scale(1);
+  }
+  50% {
+    transform: translate(-50%, -55%) scale(1);
+  }
+}
+
+@media (max-width: 768px) {
+  /* floating animation for hero pack on mobile */
+  .hero-pack-img.active {
+    animation: mobile-float 6s ease-in-out infinite;
+  }
+}
+
 .flip-card {
   perspective: 1000px;
 }


### PR DESCRIPTION
## Summary
- Simplify mobile hero by hiding marquee, widening CTA, and adding animated pack carousel
- Add mobile-only floating animation for hero pack images

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892d7cd37248320b18764f26f1123c3