### PR TITLE
Refactor mobile menu into drawer with bottom navigation

### DIFF
--- a/components/topup.html
+++ b/components/topup.html
@@ -1,5 +1,5 @@
 <!-- components/topup.html -->
-<div id="topup-popup" class="fixed inset-0 z-50 flex items-center justify-center px-4 py-8 sm:py-12 hidden backdrop-blur-xl bg-black/70 overflow-auto">
+<div id="topup-popup" class="fixed inset-0 z-[200] flex items-center justify-center px-4 py-8 sm:py-12 hidden backdrop-blur-xl bg-black/70 overflow-auto">
  <div class="relative w-full max-w-sm sm:max-w-md bg-gradient-to-br from-gray-900/95 via-gray-800/90 to-gray-900/95 border border-purple-700 p-5 sm:p-6 rounded-2xl shadow-2xl">
     
     <!-- Close Button -->

--- a/scripts/header.js
+++ b/scripts/header.js
@@ -19,12 +19,12 @@ document.addEventListener("DOMContentLoaded", () => {
         <a href="marketplace.html" class="flex items-center gap-1 text-pink-400 font-semibold hover:text-pink-300 transition">
           <i class="fas fa-store"></i> Marketplace
         </a>
-        <div id="user-balance" class="hidden flex items-center gap-2">
-          <div class="flex items-center gap-2 bg-gray-800 text-white px-3 py-1 rounded-full text-sm">
+        <div id="user-balance" class="hidden flex items-center bg-gray-800 rounded-full overflow-hidden text-sm">
+          <div class="flex items-center gap-1 px-3 py-1">
             <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" />
             <span id="balance-amount">0</span>
           </div>
-          <button id="topup-button" class="flex items-center justify-center w-8 h-8 rounded-full bg-gray-800 text-yellow-400 hover:text-yellow-300">
+          <button id="topup-button" class="px-3 py-1 bg-gray-700 text-yellow-400 hover:text-yellow-300 border-l border-gray-700 flex items-center">
             <i class="fas fa-wallet"></i>
           </button>
         </div>
@@ -45,12 +45,12 @@ document.addEventListener("DOMContentLoaded", () => {
         </div>
       </div>
       <div class="sm:hidden flex items-center gap-2">
-        <div id="user-balance-mobile-header" class="hidden flex items-center gap-2">
-          <div class="flex items-center gap-2 bg-gray-800 text-white px-3 py-1 rounded-full text-sm">
+        <div id="user-balance-mobile-header" class="hidden flex items-center bg-gray-800 rounded-full overflow-hidden text-sm">
+          <div class="flex items-center gap-1 px-3 py-1">
             <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" />
             <span id="balance-amount-mobile">0</span>
           </div>
-          <button id="topup-button-mobile-header" class="flex items-center justify-center w-8 h-8 rounded-full bg-gray-800 text-yellow-400 hover:text-yellow-300">
+          <button id="topup-button-mobile-header" class="px-3 py-1 bg-gray-700 text-yellow-400 hover:text-yellow-300 border-l border-gray-700 flex items-center">
             <i class="fas fa-wallet"></i>
           </button>
         </div>

--- a/scripts/header.js
+++ b/scripts/header.js
@@ -63,11 +63,14 @@ document.addEventListener("DOMContentLoaded", () => {
       <div id="drawer-overlay" class="fixed inset-0 bg-black/50 hidden z-40 sm:hidden"></div>
       <aside id="mobile-drawer" class="fixed top-0 left-0 h-full w-64 bg-gray-900 border-r border-gray-800 transform -translate-x-full transition-transform duration-300 z-[100] sm:hidden">
         <div class="p-4 h-full overflow-y-auto pb-24 space-y-4">
-          <div id="drawer-user-info" class="hidden items-center gap-3 text-white">
-            <div id="drawer-badge" class="text-xs px-2 py-1 rounded-full bg-purple-600"></div>
-            <div class="flex flex-col leading-tight">
-              <span id="drawer-username" class="font-semibold"></span>
-              <span class="text-xs text-gray-400">Lvl <span id="drawer-level"></span></span>
+          <div
+            id="drawer-user-info"
+            class="hidden flex flex-col items-center text-center text-white space-y-1 pb-4 border-b border-gray-800"
+          >
+            <span id="drawer-username" class="font-semibold"></span>
+            <div class="flex items-center gap-2 text-xs">
+              <div id="drawer-badge" class="px-2 py-0.5 rounded-full bg-purple-600"></div>
+              <span class="text-gray-400">Lvl <span id="drawer-level"></span></span>
             </div>
           </div>
           <div id="drawer-balance-section" class="flex items-center justify-between text-white">

--- a/scripts/header.js
+++ b/scripts/header.js
@@ -19,11 +19,15 @@ document.addEventListener("DOMContentLoaded", () => {
         <a href="marketplace.html" class="flex items-center gap-1 text-pink-400 font-semibold hover:text-pink-300 transition">
           <i class="fas fa-store"></i> Marketplace
         </a>
-        <div id="user-balance" class="flex items-center gap-1 bg-gray-800 text-white px-3 py-1 rounded-full text-sm hidden">
-          <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" />
-          <span id="balance-amount">0</span>
-          <span>coins</span>
-          <button id="topup-button" class="text-green-400 font-bold ml-1">+</button>
+        <div id="user-balance" class="hidden items-center gap-2">
+          <div class="flex items-center gap-1 bg-gray-800 text-white px-3 py-1 rounded-full text-sm">
+            <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" />
+            <span id="balance-amount">0</span>
+            <span>coins</span>
+          </div>
+          <button id="topup-button" class="flex items-center justify-center w-8 h-8 rounded-full bg-green-600 text-white">
+            <i class="fas fa-wallet"></i>
+          </button>
         </div>
         <div class="relative">
           <button id="dropdown-toggle" class="flex items-center space-x-2 text-white focus:outline-none">
@@ -42,35 +46,119 @@ document.addEventListener("DOMContentLoaded", () => {
         </div>
       </div>
       <div class="sm:hidden flex items-center gap-2">
-        <div id="user-balance-mobile-header" class="flex items-center gap-1 bg-gray-800 text-white px-3 py-1 rounded-full text-sm">
-          <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" />
-          <span id="balance-amount-mobile">0</span>
-          <span>coins</span>
+        <div id="user-balance-mobile-header" class="hidden items-center gap-2">
+          <div class="flex items-center bg-gray-800 text-white px-3 py-1 rounded-full text-sm">
+            <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" />
+            <span id="balance-amount-mobile">0</span>
+            <span>coins</span>
+          </div>
+          <button id="topup-button-mobile-header" class="flex items-center justify-center w-8 h-8 rounded-full bg-green-600 text-white">
+            <i class="fas fa-wallet"></i>
+          </button>
         </div>
-        <button id="menu-toggle" class="text-white text-2xl">
-          <i class="fas fa-bars"></i>
+        <div id="auth-buttons-mobile-header" class="hidden items-center gap-2">
+          <a id="signin-mobile-header" href="auth.html" class="px-3 py-1 rounded bg-green-600 text-white text-sm">Sign In</a>
+          <a id="register-mobile-header" href="auth.html?register=true" class="px-3 py-1 rounded bg-blue-600 text-white text-sm">Register</a>
+        </div>
+      </div>
+      </nav>
+      <div id="drawer-overlay" class="fixed inset-0 bg-black/50 hidden z-40 sm:hidden"></div>
+      <aside id="mobile-drawer" class="fixed top-0 left-0 h-full w-64 bg-gray-900 border-r border-gray-800 transform -translate-x-full transition-transform duration-300 z-[100] sm:hidden">
+        <div class="p-4 h-full overflow-y-auto pb-24 space-y-4">
+          <div id="drawer-balance-section" class="flex items-center justify-between text-white">
+            <div class="flex items-center gap-2">
+              <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-5 h-5" />
+              <span id="drawer-balance-amount">0</span>
+              <span>coins</span>
+            </div>
+            <button id="topup-button-mobile-drawer" class="text-green-400 hover:text-green-300">
+              <i class="fas fa-wallet text-xl"></i>
+            </button>
+          </div>
+          <div id="drawer-auth-buttons" class="flex flex-col gap-2">
+            <a id="drawer-signin" href="auth.html" class="w-full text-center py-2 bg-green-600 rounded text-white">Sign In</a>
+            <a id="drawer-register" href="auth.html?register=true" class="w-full text-center py-2 bg-blue-600 rounded text-white">Register</a>
+          </div>
+          <nav class="flex flex-col gap-2">
+            <a href="index.html" class="block px-4 py-2 text-sm text-white rounded hover:bg-gray-800 flex items-center gap-2"><i class="fas fa-cube"></i> Open Packs</a>
+            <a id="drawer-inventory-link" href="inventory.html" class="block px-4 py-2 text-sm text-white rounded hover:bg-gray-800 flex items-center gap-2 hidden"><i class="fas fa-box-open"></i> Inventory</a>
+            <a id="drawer-profile-link" href="profile.html" class="block px-4 py-2 text-sm text-white rounded hover:bg-gray-800 flex items-center gap-2 hidden"><i class="fas fa-user"></i> Profile</a>
+            <a href="how-it-works.html" class="block px-4 py-2 text-sm text-white rounded hover:bg-gray-800 flex items-center gap-2"><i class="fas fa-question-circle"></i> How It Works</a>
+            <a href="rewards.html" class="block px-4 py-2 text-sm text-yellow-400 rounded hover:bg-gray-800 flex items-center gap-2"><i class="fas fa-gift"></i> Rewards</a>
+            <a href="marketplace.html" class="block px-4 py-2 text-sm text-pink-400 rounded hover:bg-gray-800 flex items-center gap-2"><i class="fas fa-store"></i> Marketplace</a>
+            <a href="leaderboard.html" class="block px-4 py-2 text-sm text-blue-400 rounded hover:bg-gray-800 flex items-center gap-2"><i class="fas fa-trophy"></i> Leaderboard</a>
+            <a id="drawer-logout" href="#" class="block px-4 py-2 text-sm text-red-400 rounded hover:bg-gray-800 flex items-center gap-2 hidden"><i class="fas fa-sign-out-alt"></i> Logout</a>
+          </nav>
+        </div>
+      </aside>
+      <nav id="mobile-bottom-nav" class="fixed bottom-0 left-0 right-0 bg-gray-900 border-t border-gray-800 flex justify-around py-2 sm:hidden z-50">
+        <button id="drawer-menu-button" type="button" class="flex flex-col items-center text-xs text-white">
+          <i class="fas fa-bars text-lg"></i>
+          <span>Menu</span>
         </button>
-      </div>
-    </nav>
-    <div id="mobile-dropdown" class="hidden mt-2 bg-gray-800 border border-gray-700 rounded-lg w-48 py-2 fixed right-4 top-[72px] z-[9999] shadow-lg sm:hidden">
-      <div id="user-balance-mobile" class="flex items-center justify-between px-4 py-2 text-sm text-white border-b border-gray-700">
-        <span><img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="inline w-4 h-4 mr-1"> <span id="balance-amount-mobile-dropdown">0</span> coins</span>
-        <button id="topup-button-mobile" class="text-green-400 text-lg font-bold hover:text-green-500">+</button>
-      </div>
-      <a href="index.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm"><i class="fas fa-cube mr-2"></i> Open Packs</a>
-      <a id="inventory-link" href="inventory.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm hidden"><i class="fas fa-box-open mr-2"></i> Inventory</a>
-      <a id="profile-link" href="profile.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm hidden"><i class="fas fa-user mr-2"></i> Profile</a>
-      <a href="how-it-works.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm"><i class="fas fa-question-circle mr-2"></i> How It Works</a>
-      <a href="rewards.html" class="block px-4 py-2 hover:bg-gray-700 text-yellow-400 text-sm"><i class="fas fa-gift mr-2"></i> Rewards</a>
-      <a href="marketplace.html" class="block px-4 py-2 hover:bg-gray-700 text-pink-400 text-sm"><i class="fas fa-store mr-2"></i> Marketplace</a>
-      <a href="leaderboard.html" class="block px-4 py-2 hover:bg-gray-700 text-blue-400 text-sm"><i class="fas fa-trophy mr-2"></i> Leaderboard</a>
-      <a id="mobile-auth-button" href="auth.html" class="block px-4 py-2 hover:bg-gray-700 text-red-400 text-sm"><i class="fas fa-sign-in-alt mr-2"></i> Sign In</a>
-    </div>
-  `; // <-- closing backtick and semicolon!
+        <a id="inventory-link" href="inventory.html" class="flex flex-col items-center text-xs text-white hidden">
+          <i class="fas fa-box-open text-lg"></i>
+          <span>Inventory</span>
+        </a>
+        <a href="how-it-works.html" class="flex flex-col items-center text-xs text-white">
+          <i class="fas fa-question-circle text-lg"></i>
+          <span>How It Works</span>
+        </a>
+        <a href="rewards.html" class="flex flex-col items-center text-xs text-yellow-400">
+          <i class="fas fa-gift text-lg"></i>
+          <span>Rewards</span>
+        </a>
+        <a href="marketplace.html" class="flex flex-col items-center text-xs text-pink-400">
+          <i class="fas fa-store text-lg"></i>
+          <span>Market</span>
+        </a>
+      </nav>
+    `; // <-- closing backtick and semicolon!
+  const drawerMenuButton = document.getElementById("drawer-menu-button");
+  const mobileDrawer = document.getElementById("mobile-drawer");
+  const drawerOverlay = document.getElementById("drawer-overlay");
+
+  if (drawerMenuButton && mobileDrawer && drawerOverlay) {
+    const toggleDrawer = () => {
+      mobileDrawer.classList.toggle("-translate-x-full");
+      drawerOverlay.classList.toggle("hidden");
+    };
+    drawerMenuButton.onclick = toggleDrawer;
+    drawerOverlay.onclick = toggleDrawer;
+  }
 
   // Firebase auth logic
   firebase.auth().onAuthStateChanged(async (user) => {
-    if (!user) return;
+    const drawerAuthButtons = document.getElementById("drawer-auth-buttons");
+    const drawerBalanceSection = document.getElementById("drawer-balance-section");
+    const authButtonsMobileHeader = document.getElementById("auth-buttons-mobile-header");
+    const userBalanceMobileHeader = document.getElementById("user-balance-mobile-header");
+    const drawerInventoryLink = document.getElementById("drawer-inventory-link");
+    const drawerProfileLink = document.getElementById("drawer-profile-link");
+    const drawerLogout = document.getElementById("drawer-logout");
+    const inventoryLink = document.getElementById("inventory-link");
+
+    if (!user) {
+      if (authButtonsMobileHeader) authButtonsMobileHeader.classList.remove("hidden");
+      if (userBalanceMobileHeader) userBalanceMobileHeader.classList.add("hidden");
+      if (drawerAuthButtons) drawerAuthButtons.classList.remove("hidden");
+      if (drawerBalanceSection) drawerBalanceSection.classList.add("hidden");
+      if (drawerInventoryLink) drawerInventoryLink.classList.add("hidden");
+      if (drawerProfileLink) drawerProfileLink.classList.add("hidden");
+      if (drawerLogout) drawerLogout.classList.add("hidden");
+      if (inventoryLink) inventoryLink.classList.add("hidden");
+      return;
+    }
+
+    if (authButtonsMobileHeader) authButtonsMobileHeader.classList.add("hidden");
+    if (userBalanceMobileHeader) userBalanceMobileHeader.classList.remove("hidden");
+    if (drawerAuthButtons) drawerAuthButtons.classList.add("hidden");
+    if (drawerBalanceSection) drawerBalanceSection.classList.remove("hidden");
+    if (drawerInventoryLink) drawerInventoryLink.classList.remove("hidden");
+    if (drawerProfileLink) drawerProfileLink.classList.remove("hidden");
+    if (drawerLogout) drawerLogout.classList.remove("hidden");
+    if (inventoryLink) inventoryLink.classList.remove("hidden");
+
     const db = firebase.database();
     const userRef = db.ref("users/" + user.uid);
     let prevBalance = null;
@@ -81,25 +169,21 @@ document.addEventListener("DOMContentLoaded", () => {
 
       const balanceDesktop = document.getElementById("balance-amount");
       const balanceMobile = document.getElementById("balance-amount-mobile");
-      const balanceDropdown = document.getElementById("balance-amount-mobile-dropdown");
+      const balanceDrawer = document.getElementById("drawer-balance-amount");
       const userBalanceDiv = document.getElementById("user-balance");
-      const userBalanceMobileHeader = document.getElementById("user-balance-mobile-header");
       const usernameDisplay = document.getElementById("username-display");
       const signinDesktop = document.getElementById("signin-desktop");
       const logoutDesktop = document.getElementById("logout-desktop");
-      const mobileAuth = document.getElementById("mobile-auth-button");
-      const inventoryLink = document.getElementById("inventory-link");
-      const profileLink = document.getElementById("profile-link");
 
       const formatted = parseInt(balance, 10).toLocaleString();
       if (balanceDesktop) balanceDesktop.innerText = formatted;
       if (balanceMobile) balanceMobile.innerText = formatted;
-      if (balanceDropdown) balanceDropdown.innerText = formatted;
+      if (balanceDrawer) balanceDrawer.innerText = formatted;
       if (userBalanceDiv) userBalanceDiv.classList.remove("hidden");
+      if (drawerBalanceSection) drawerBalanceSection.classList.remove("hidden");
 
       if (prevBalance !== balance) {
-        const userBalanceMobileDiv = document.getElementById("user-balance-mobile");
-        [userBalanceDiv, userBalanceMobileHeader, userBalanceMobileDiv].forEach((el) => {
+        [userBalanceDiv, userBalanceMobileHeader, drawerBalanceSection].forEach((el) => {
           if (el) {
             el.classList.add("pulse-balance");
             el.addEventListener(
@@ -114,8 +198,6 @@ document.addEventListener("DOMContentLoaded", () => {
       if (usernameDisplay) usernameDisplay.innerText = user.displayName || data.username || user.email || "User";
       if (signinDesktop) signinDesktop.classList.add("hidden");
       if (logoutDesktop) logoutDesktop.classList.remove("hidden");
-      if (inventoryLink) inventoryLink.classList.remove("hidden");
-      if (profileLink) profileLink.classList.remove("hidden");
 
       if (logoutDesktop) {
         logoutDesktop.onclick = (e) => {
@@ -123,11 +205,8 @@ document.addEventListener("DOMContentLoaded", () => {
           firebase.auth().signOut().then(() => location.reload());
         };
       }
-
-      if (mobileAuth) {
-        mobileAuth.innerHTML = '<i class="fas fa-sign-out-alt mr-2"></i> Logout';
-        mobileAuth.href = "#";
-        mobileAuth.onclick = (e) => {
+      if (drawerLogout) {
+        drawerLogout.onclick = (e) => {
           e.preventDefault();
           firebase.auth().signOut().then(() => location.reload());
         };

--- a/scripts/header.js
+++ b/scripts/header.js
@@ -19,13 +19,13 @@ document.addEventListener("DOMContentLoaded", () => {
         <a href="marketplace.html" class="flex items-center gap-1 text-pink-400 font-semibold hover:text-pink-300 transition">
           <i class="fas fa-store"></i> Marketplace
         </a>
-        <div id="user-balance" class="hidden items-center gap-2">
+        <div id="user-balance" class="hidden flex items-center gap-2">
           <div class="flex items-center gap-1 bg-gray-800 text-white px-3 py-1 rounded-full text-sm">
             <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" />
             <span id="balance-amount">0</span>
             <span>coins</span>
           </div>
-          <button id="topup-button" class="flex items-center justify-center w-8 h-8 rounded-full bg-green-600 text-white">
+          <button id="topup-button" class="flex items-center justify-center w-8 h-8 rounded-full bg-gray-800 text-yellow-400 hover:text-yellow-300">
             <i class="fas fa-wallet"></i>
           </button>
         </div>
@@ -46,13 +46,13 @@ document.addEventListener("DOMContentLoaded", () => {
         </div>
       </div>
       <div class="sm:hidden flex items-center gap-2">
-        <div id="user-balance-mobile-header" class="hidden items-center gap-2">
+        <div id="user-balance-mobile-header" class="hidden flex items-center gap-2">
           <div class="flex items-center bg-gray-800 text-white px-3 py-1 rounded-full text-sm">
             <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" />
             <span id="balance-amount-mobile">0</span>
             <span>coins</span>
           </div>
-          <button id="topup-button-mobile-header" class="flex items-center justify-center w-8 h-8 rounded-full bg-green-600 text-white">
+          <button id="topup-button-mobile-header" class="flex items-center justify-center w-8 h-8 rounded-full bg-gray-800 text-yellow-400 hover:text-yellow-300">
             <i class="fas fa-wallet"></i>
           </button>
         </div>
@@ -71,7 +71,7 @@ document.addEventListener("DOMContentLoaded", () => {
               <span id="drawer-balance-amount">0</span>
               <span>coins</span>
             </div>
-            <button id="topup-button-mobile-drawer" class="text-green-400 hover:text-green-300">
+            <button id="topup-button-mobile-drawer" class="text-yellow-400 hover:text-yellow-300">
               <i class="fas fa-wallet text-xl"></i>
             </button>
           </div>

--- a/scripts/header.js
+++ b/scripts/header.js
@@ -20,10 +20,9 @@ document.addEventListener("DOMContentLoaded", () => {
           <i class="fas fa-store"></i> Marketplace
         </a>
         <div id="user-balance" class="hidden flex items-center gap-2">
-          <div class="flex items-center gap-1 bg-gray-800 text-white px-3 py-1 rounded-full text-sm">
+          <div class="flex items-center gap-2 bg-gray-800 text-white px-3 py-1 rounded-full text-sm">
             <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" />
             <span id="balance-amount">0</span>
-            <span>coins</span>
           </div>
           <button id="topup-button" class="flex items-center justify-center w-8 h-8 rounded-full bg-gray-800 text-yellow-400 hover:text-yellow-300">
             <i class="fas fa-wallet"></i>
@@ -47,10 +46,9 @@ document.addEventListener("DOMContentLoaded", () => {
       </div>
       <div class="sm:hidden flex items-center gap-2">
         <div id="user-balance-mobile-header" class="hidden flex items-center gap-2">
-          <div class="flex items-center bg-gray-800 text-white px-3 py-1 rounded-full text-sm">
+          <div class="flex items-center gap-2 bg-gray-800 text-white px-3 py-1 rounded-full text-sm">
             <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" />
             <span id="balance-amount-mobile">0</span>
-            <span>coins</span>
           </div>
           <button id="topup-button-mobile-header" class="flex items-center justify-center w-8 h-8 rounded-full bg-gray-800 text-yellow-400 hover:text-yellow-300">
             <i class="fas fa-wallet"></i>
@@ -69,7 +67,6 @@ document.addEventListener("DOMContentLoaded", () => {
             <div class="flex items-center gap-2">
               <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-5 h-5" />
               <span id="drawer-balance-amount">0</span>
-              <span>coins</span>
             </div>
             <button id="topup-button-mobile-drawer" class="text-yellow-400 hover:text-yellow-300">
               <i class="fas fa-wallet text-xl"></i>

--- a/scripts/topup.js
+++ b/scripts/topup.js
@@ -19,7 +19,17 @@ async function loadTopupPopup() {
     closeBtn.onclick = () => popup.classList.add("hidden");
   }
 
-  const openPopup = () => popup?.classList.remove("hidden");
+  const openPopup = () => {
+    if (popup) popup.classList.remove("hidden");
+    const mobileDrawer = document.getElementById("mobile-drawer");
+    const drawerOverlay = document.getElementById("drawer-overlay");
+    if (mobileDrawer && !mobileDrawer.classList.contains("-translate-x-full")) {
+      mobileDrawer.classList.add("-translate-x-full");
+    }
+    if (drawerOverlay && !drawerOverlay.classList.contains("hidden")) {
+      drawerOverlay.classList.add("hidden");
+    }
+  };
   if (topupDesktop) topupDesktop.onclick = openPopup;
   if (topupMobileHeader) topupMobileHeader.onclick = openPopup;
   if (topupMobileDrawer) topupMobileDrawer.onclick = openPopup;

--- a/scripts/topup.js
+++ b/scripts/topup.js
@@ -12,7 +12,8 @@ async function loadTopupPopup() {
   const popup = document.getElementById("topup-popup");
   const closeBtn = document.getElementById("close-topup");
   const topupDesktop = document.getElementById("topup-button");
-  const topupMobile = document.getElementById("topup-button-mobile");
+  const topupMobileHeader = document.getElementById("topup-button-mobile-header");
+  const topupMobileDrawer = document.getElementById("topup-button-mobile-drawer");
 
   if (popup && closeBtn) {
     closeBtn.onclick = () => popup.classList.add("hidden");
@@ -20,7 +21,8 @@ async function loadTopupPopup() {
 
   const openPopup = () => popup?.classList.remove("hidden");
   if (topupDesktop) topupDesktop.onclick = openPopup;
-  if (topupMobile) topupMobile.onclick = openPopup;
+  if (topupMobileHeader) topupMobileHeader.onclick = openPopup;
+  if (topupMobileDrawer) topupMobileDrawer.onclick = openPopup;
 
   // Attach loading feedback to all buy buttons
   document.querySelectorAll("#topup-popup form").forEach(form => {


### PR DESCRIPTION
## Summary
- streamline mobile header to only show coin balance/top-up or sign-in/register
- add persistent bottom bar with menu button that toggles a full drawer of site links
- wire up new top-up buttons in header and drawer
- refine top header styling with cleaner balance pill, wallet icon buttons, and prominent auth buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68940d3d53f48320abeae42ebe895ebe