### PR TITLE
Revamp how-it-works page with animated cards

### DIFF
--- a/how-it-works.html
+++ b/how-it-works.html
@@ -25,14 +25,37 @@
       border: 1px solid rgba(255, 255, 255, 0.1);
       box-shadow: 0 4px 30px rgba(0, 0, 0, 0.5);
     }
-    .step-icon {
-      font-size: 2.5rem;
-      color: #ec4899;
-      animation: pop 0.6s ease;
+    .how-card {
+      position: relative;
+      overflow: hidden;
     }
-    @keyframes pop {
-      0% { transform: scale(0); opacity: 0; }
-      100% { transform: scale(1); opacity: 1; }
+    .how-card::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(135deg, rgba(236,72,153,0.2), rgba(234,179,8,0.2));
+      opacity: 0;
+      transition: opacity 0.3s ease;
+    }
+    .how-card:hover::before {
+      opacity: 1;
+    }
+    .step-icon {
+      width: 4rem;
+      height: 4rem;
+      font-size: 1.75rem;
+      background: linear-gradient(135deg, #f43f5e, #f59e0b);
+      border-radius: 9999px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #fff;
+      box-shadow: 0 0 15px rgba(236,72,153,0.5);
+      animation: float 3s ease-in-out infinite;
+    }
+    @keyframes float {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-6px); }
     }
   </style>
 </head>
@@ -49,36 +72,39 @@
     </p>
 
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-10">
-      <div class="glass rounded-3xl p-8 text-left transition hover:scale-[1.02]">
+      <div class="glass how-card rounded-3xl p-8 text-left transition-transform duration-300 hover:-translate-y-2">
         <div class="step-icon mb-4">🔑</div>
         <h2 class="text-xl font-bold mb-2">1. Sign Up or Log In</h2>
         <p class="text-gray-300">Create an account or sign in to start your pack-opening journey. Your pulls and balance will be securely tracked.</p>
       </div>
-      <div class="glass rounded-3xl p-8 text-left transition hover:scale-[1.02]">
+      <div class="glass how-card rounded-3xl p-8 text-left transition-transform duration-300 hover:-translate-y-2">
         <div class="step-icon mb-4">💼</div>
         <h2 class="text-xl font-bold mb-2">2. Top Up Coins</h2>
         <p class="text-gray-300">Easily top up your coin balance using the built-in system. Coins are used to open packs and try your luck!</p>
       </div>
-      <div class="glass rounded-3xl p-8 text-left transition hover:scale-[1.02]">
+      <div class="glass how-card rounded-3xl p-8 text-left transition-transform duration-300 hover:-translate-y-2">
         <div class="step-icon mb-4">🎁</div>
         <h2 class="text-xl font-bold mb-2">3. Open Packs</h2>
         <p class="text-gray-300">Choose a case, view its possible rewards, and open it for a chance to win amazing items of varying rarities.</p>
       </div>
-      <div class="glass rounded-3xl p-8 text-left transition hover:scale-[1.02]">
+      <div class="glass how-card rounded-3xl p-8 text-left transition-transform duration-300 hover:-translate-y-2">
         <div class="step-icon mb-4">🏆</div>
         <h2 class="text-xl font-bold mb-2">4. View Your Inventory</h2>
         <p class="text-gray-300">Everything you win is stored in your personal inventory. Access it anytime to manage your prizes.</p>
       </div>
-      <div class="glass rounded-3xl p-8 text-left transition hover:scale-[1.02]">
+      <div class="glass how-card rounded-3xl p-8 text-left transition-transform duration-300 hover:-translate-y-2">
         <div class="step-icon mb-4">🚚</div>
         <h2 class="text-xl font-bold mb-2">5. Ship or Sell Back</h2>
         <p class="text-gray-300">You can choose to ship your item straight to your home, or sell it back for coins (with a 20% restock fee).</p>
       </div>
-      <div class="glass rounded-3xl p-8 text-left transition hover:scale-[1.02]">
+      <div class="glass how-card rounded-3xl p-8 text-left transition-transform duration-300 hover:-translate-y-2">
         <div class="step-icon mb-4">✨</div>
         <h2 class="text-xl font-bold mb-2">6. Keep Pulling!</h2>
         <p class="text-gray-300">Top up, pull again, and chase those legendary rewards. Packly.gg is all about the thrill of the win.</p>
       </div>
+    </div>
+    <div class="mt-16">
+      <a href="marketplace.html" class="inline-block px-8 py-4 bg-yellow-400 text-black rounded-full font-semibold shadow-lg hover:shadow-yellow-400/40 hover:-translate-y-1 transition-transform duration-300">Start Pulling Packs</a>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- add colorful hover overlays and floating icons to how-it-works steps
- introduce animated step cards and a call-to-action link to packs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68941b2d79148320b3b09bd5a5213967