### PR TITLE
Refactor mobile menu into drawer with bottom navigation

### DIFF
--- a/components/topup.html
+++ b/components/topup.html
@@ -1,5 +1,5 @@
 <!-- components/topup.html -->
-<div id="topup-popup" class="fixed inset-0 z-50 flex items-center justify-center px-4 py-8 sm:py-12 hidden backdrop-blur-xl bg-black/70 overflow-auto">
+<div id="topup-popup" class="fixed inset-0 z-[200] flex items-center justify-center px-4 py-8 sm:py-12 hidden backdrop-blur-xl bg-black/70 overflow-auto">
  <div class="relative w-full max-w-sm sm:max-w-md bg-gradient-to-br from-gray-900/95 via-gray-800/90 to-gray-900/95 border border-purple-700 p-5 sm:p-6 rounded-2xl shadow-2xl">
     
     <!-- Close Button -->

--- a/scripts/header.js
+++ b/scripts/header.js
@@ -19,11 +19,14 @@ document.addEventListener("DOMContentLoaded", () => {
         <a href="marketplace.html" class="flex items-center gap-1 text-pink-400 font-semibold hover:text-pink-300 transition">
           <i class="fas fa-store"></i> Marketplace
         </a>
-        <div id="user-balance" class="flex items-center gap-1 bg-gray-800 text-white px-3 py-1 rounded-full text-sm hidden">
-          <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" />
-          <span id="balance-amount">0</span>
-          <span>coins</span>
-          <button id="topup-button" class="text-green-400 font-bold ml-1">+</button>
+        <div id="user-balance" class="hidden flex items-center bg-gray-800 rounded-full overflow-hidden text-sm">
+          <div class="flex items-center gap-1 px-3 py-1">
+            <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" />
+            <span id="balance-amount">0</span>
+          </div>
+          <button id="topup-button" class="px-3 py-1 bg-gray-700 text-yellow-400 hover:text-yellow-300 border-l border-gray-700 flex items-center">
+            <i class="fas fa-wallet"></i>
+          </button>
         </div>
         <div class="relative">
           <button id="dropdown-toggle" class="flex items-center space-x-2 text-white focus:outline-none">
@@ -42,64 +45,159 @@ document.addEventListener("DOMContentLoaded", () => {
         </div>
       </div>
       <div class="sm:hidden flex items-center gap-2">
-        <div id="user-balance-mobile-header" class="flex items-center gap-1 bg-gray-800 text-white px-3 py-1 rounded-full text-sm">
-          <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" />
-          <span id="balance-amount-mobile">0</span>
-          <span>coins</span>
+        <div id="user-balance-mobile-header" class="hidden flex items-center bg-gray-800 rounded-full overflow-hidden text-sm">
+          <div class="flex items-center gap-1 px-3 py-1">
+            <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" />
+            <span id="balance-amount-mobile">0</span>
+          </div>
+          <button id="topup-button-mobile-header" class="px-3 py-1 bg-gray-700 text-yellow-400 hover:text-yellow-300 border-l border-gray-700 flex items-center">
+            <i class="fas fa-wallet"></i>
+          </button>
         </div>
-        <button id="menu-toggle" class="text-white text-2xl">
-          <i class="fas fa-bars"></i>
+        <div id="auth-buttons-mobile-header" class="hidden items-center gap-2">
+          <a id="signin-mobile-header" href="auth.html" class="px-3 py-1 rounded bg-green-600 text-white text-sm">Sign In</a>
+          <a id="register-mobile-header" href="auth.html?register=true" class="px-3 py-1 rounded bg-blue-600 text-white text-sm">Register</a>
+        </div>
+      </div>
+      </nav>
+      <div id="drawer-overlay" class="fixed inset-0 bg-black/50 hidden z-40 sm:hidden"></div>
+      <aside id="mobile-drawer" class="fixed top-0 left-0 h-full w-64 bg-gray-900 border-r border-gray-800 transform -translate-x-full transition-transform duration-300 z-[100] sm:hidden">
+        <div class="p-4 h-full overflow-y-auto pb-24 space-y-4">
+          <div
+            id="drawer-user-info"
+            class="hidden flex flex-col items-center text-center text-white space-y-1 pb-4 border-b border-gray-800"
+          >
+            <span id="drawer-username" class="font-semibold"></span>
+            <div class="flex items-center gap-2 text-xs">
+              <div id="drawer-badge" class="px-2 py-0.5 rounded-full bg-purple-600"></div>
+              <span class="text-gray-400">Lvl <span id="drawer-level"></span></span>
+            </div>
+          </div>
+          <div id="drawer-balance-section" class="flex items-center justify-between text-white">
+            <div class="flex items-center gap-2">
+              <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-5 h-5" />
+              <span id="drawer-balance-amount">0</span>
+            </div>
+            <button id="topup-button-mobile-drawer" class="text-yellow-400 hover:text-yellow-300">
+              <i class="fas fa-wallet text-xl"></i>
+            </button>
+          </div>
+          <div id="drawer-auth-buttons" class="flex flex-col gap-2">
+            <a id="drawer-signin" href="auth.html" class="w-full text-center py-2 bg-green-600 rounded text-white">Sign In</a>
+            <a id="drawer-register" href="auth.html?register=true" class="w-full text-center py-2 bg-blue-600 rounded text-white">Register</a>
+          </div>
+          <nav class="flex flex-col gap-2">
+            <a href="index.html" class="block px-4 py-2 text-sm text-white rounded hover:bg-gray-800 flex items-center gap-2"><i class="fas fa-cube"></i> Open Packs</a>
+            <a id="drawer-inventory-link" href="inventory.html" class="block px-4 py-2 text-sm text-white rounded hover:bg-gray-800 flex items-center gap-2 hidden"><i class="fas fa-box-open"></i> Inventory</a>
+            <a id="drawer-profile-link" href="profile.html" class="block px-4 py-2 text-sm text-white rounded hover:bg-gray-800 flex items-center gap-2 hidden"><i class="fas fa-user"></i> Profile</a>
+            <a href="how-it-works.html" class="block px-4 py-2 text-sm text-white rounded hover:bg-gray-800 flex items-center gap-2"><i class="fas fa-question-circle"></i> How It Works</a>
+            <a href="rewards.html" class="block px-4 py-2 text-sm text-yellow-400 rounded hover:bg-gray-800 flex items-center gap-2"><i class="fas fa-gift"></i> Rewards</a>
+            <a href="marketplace.html" class="block px-4 py-2 text-sm text-pink-400 rounded hover:bg-gray-800 flex items-center gap-2"><i class="fas fa-store"></i> Marketplace</a>
+            <a href="leaderboard.html" class="block px-4 py-2 text-sm text-blue-400 rounded hover:bg-gray-800 flex items-center gap-2"><i class="fas fa-trophy"></i> Leaderboard</a>
+            <a id="drawer-logout" href="#" class="block px-4 py-2 text-sm text-red-400 rounded hover:bg-gray-800 flex items-center gap-2 hidden"><i class="fas fa-sign-out-alt"></i> Logout</a>
+          </nav>
+        </div>
+      </aside>
+      <nav id="mobile-bottom-nav" class="fixed bottom-0 left-0 right-0 bg-gray-900 border-t border-gray-800 flex justify-around py-2 sm:hidden z-50">
+        <button id="drawer-menu-button" type="button" class="flex flex-col items-center text-xs text-white">
+          <i class="fas fa-bars text-lg"></i>
+          <span>Menu</span>
         </button>
-      </div>
-    </nav>
-    <div id="mobile-dropdown" class="hidden mt-2 bg-gray-800 border border-gray-700 rounded-lg w-48 py-2 fixed right-4 top-[72px] z-[9999] shadow-lg sm:hidden">
-      <div id="user-balance-mobile" class="flex items-center justify-between px-4 py-2 text-sm text-white border-b border-gray-700">
-        <span><img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="inline w-4 h-4 mr-1"> <span id="balance-amount-mobile-dropdown">0</span> coins</span>
-        <button id="topup-button-mobile" class="text-green-400 text-lg font-bold hover:text-green-500">+</button>
-      </div>
-      <a href="index.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm"><i class="fas fa-cube mr-2"></i> Open Packs</a>
-      <a id="inventory-link" href="inventory.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm hidden"><i class="fas fa-box-open mr-2"></i> Inventory</a>
-      <a id="profile-link" href="profile.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm hidden"><i class="fas fa-user mr-2"></i> Profile</a>
-      <a href="how-it-works.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm"><i class="fas fa-question-circle mr-2"></i> How It Works</a>
-      <a href="rewards.html" class="block px-4 py-2 hover:bg-gray-700 text-yellow-400 text-sm"><i class="fas fa-gift mr-2"></i> Rewards</a>
-      <a href="marketplace.html" class="block px-4 py-2 hover:bg-gray-700 text-pink-400 text-sm"><i class="fas fa-store mr-2"></i> Marketplace</a>
-      <a href="leaderboard.html" class="block px-4 py-2 hover:bg-gray-700 text-blue-400 text-sm"><i class="fas fa-trophy mr-2"></i> Leaderboard</a>
-      <a id="mobile-auth-button" href="auth.html" class="block px-4 py-2 hover:bg-gray-700 text-red-400 text-sm"><i class="fas fa-sign-in-alt mr-2"></i> Sign In</a>
-    </div>
-  `; // <-- closing backtick and semicolon!
+        <a id="inventory-link" href="inventory.html" class="flex flex-col items-center text-xs text-white hidden">
+          <i class="fas fa-box-open text-lg"></i>
+          <span>Inventory</span>
+        </a>
+        <a href="how-it-works.html" class="flex flex-col items-center text-xs text-white">
+          <i class="fas fa-question-circle text-lg"></i>
+          <span>How It Works</span>
+        </a>
+        <a href="rewards.html" class="flex flex-col items-center text-xs text-yellow-400">
+          <i class="fas fa-gift text-lg"></i>
+          <span>Rewards</span>
+        </a>
+        <a href="marketplace.html" class="flex flex-col items-center text-xs text-pink-400">
+          <i class="fas fa-store text-lg"></i>
+          <span>Market</span>
+        </a>
+      </nav>
+    `; // <-- closing backtick and semicolon!
+  const drawerMenuButton = document.getElementById("drawer-menu-button");
+  const mobileDrawer = document.getElementById("mobile-drawer");
+  const drawerOverlay = document.getElementById("drawer-overlay");
+
+  if (drawerMenuButton && mobileDrawer && drawerOverlay) {
+    const toggleDrawer = () => {
+      mobileDrawer.classList.toggle("-translate-x-full");
+      drawerOverlay.classList.toggle("hidden");
+    };
+    drawerMenuButton.onclick = toggleDrawer;
+    drawerOverlay.onclick = toggleDrawer;
+  }
 
   // Firebase auth logic
   firebase.auth().onAuthStateChanged(async (user) => {
-    if (!user) return;
+    const drawerAuthButtons = document.getElementById("drawer-auth-buttons");
+    const drawerBalanceSection = document.getElementById("drawer-balance-section");
+    const authButtonsMobileHeader = document.getElementById("auth-buttons-mobile-header");
+    const userBalanceMobileHeader = document.getElementById("user-balance-mobile-header");
+    const drawerInventoryLink = document.getElementById("drawer-inventory-link");
+    const drawerProfileLink = document.getElementById("drawer-profile-link");
+    const drawerLogout = document.getElementById("drawer-logout");
+    const inventoryLink = document.getElementById("inventory-link");
+    const drawerUserInfo = document.getElementById("drawer-user-info");
+    const drawerBadge = document.getElementById("drawer-badge");
+    const drawerUsername = document.getElementById("drawer-username");
+    const drawerLevel = document.getElementById("drawer-level");
+
+    if (!user) {
+      if (authButtonsMobileHeader) authButtonsMobileHeader.classList.remove("hidden");
+      if (userBalanceMobileHeader) userBalanceMobileHeader.classList.add("hidden");
+      if (drawerAuthButtons) drawerAuthButtons.classList.remove("hidden");
+      if (drawerBalanceSection) drawerBalanceSection.classList.add("hidden");
+      if (drawerInventoryLink) drawerInventoryLink.classList.add("hidden");
+      if (drawerProfileLink) drawerProfileLink.classList.add("hidden");
+      if (drawerLogout) drawerLogout.classList.add("hidden");
+      if (inventoryLink) inventoryLink.classList.add("hidden");
+      if (drawerUserInfo) drawerUserInfo.classList.add("hidden");
+      return;
+    }
+
+    if (authButtonsMobileHeader) authButtonsMobileHeader.classList.add("hidden");
+    if (userBalanceMobileHeader) userBalanceMobileHeader.classList.remove("hidden");
+    if (drawerAuthButtons) drawerAuthButtons.classList.add("hidden");
+    if (drawerBalanceSection) drawerBalanceSection.classList.remove("hidden");
+    if (drawerInventoryLink) drawerInventoryLink.classList.remove("hidden");
+    if (drawerProfileLink) drawerProfileLink.classList.remove("hidden");
+    if (drawerLogout) drawerLogout.classList.remove("hidden");
+    if (inventoryLink) inventoryLink.classList.remove("hidden");
+    if (drawerUserInfo) drawerUserInfo.classList.remove("hidden");
+
     const db = firebase.database();
     const userRef = db.ref("users/" + user.uid);
-    let prevBalance = null;
 
+    // Load username and balance continuously
+    let prevBalance = null;
     userRef.on("value", (snapshot) => {
       const data = snapshot.val() || {};
       const balance = data.balance || 0;
 
       const balanceDesktop = document.getElementById("balance-amount");
       const balanceMobile = document.getElementById("balance-amount-mobile");
-      const balanceDropdown = document.getElementById("balance-amount-mobile-dropdown");
+      const balanceDrawer = document.getElementById("drawer-balance-amount");
       const userBalanceDiv = document.getElementById("user-balance");
-      const userBalanceMobileHeader = document.getElementById("user-balance-mobile-header");
       const usernameDisplay = document.getElementById("username-display");
       const signinDesktop = document.getElementById("signin-desktop");
       const logoutDesktop = document.getElementById("logout-desktop");
-      const mobileAuth = document.getElementById("mobile-auth-button");
-      const inventoryLink = document.getElementById("inventory-link");
-      const profileLink = document.getElementById("profile-link");
 
       const formatted = parseInt(balance, 10).toLocaleString();
       if (balanceDesktop) balanceDesktop.innerText = formatted;
       if (balanceMobile) balanceMobile.innerText = formatted;
-      if (balanceDropdown) balanceDropdown.innerText = formatted;
+      if (balanceDrawer) balanceDrawer.innerText = formatted;
       if (userBalanceDiv) userBalanceDiv.classList.remove("hidden");
+      if (drawerBalanceSection) drawerBalanceSection.classList.remove("hidden");
 
       if (prevBalance !== balance) {
-        const userBalanceMobileDiv = document.getElementById("user-balance-mobile");
-        [userBalanceDiv, userBalanceMobileHeader, userBalanceMobileDiv].forEach((el) => {
+        [userBalanceDiv, userBalanceMobileHeader, drawerBalanceSection].forEach((el) => {
           if (el) {
             el.classList.add("pulse-balance");
             el.addEventListener(
@@ -111,28 +209,84 @@ document.addEventListener("DOMContentLoaded", () => {
         });
         prevBalance = balance;
       }
-      if (usernameDisplay) usernameDisplay.innerText = user.displayName || data.username || user.email || "User";
+      const uname = user.displayName || data.username || user.email || "User";
+      if (usernameDisplay) usernameDisplay.innerText = uname;
+      if (drawerUsername) drawerUsername.innerText = uname;
       if (signinDesktop) signinDesktop.classList.add("hidden");
       if (logoutDesktop) logoutDesktop.classList.remove("hidden");
-      if (inventoryLink) inventoryLink.classList.remove("hidden");
-      if (profileLink) profileLink.classList.remove("hidden");
-
       if (logoutDesktop) {
         logoutDesktop.onclick = (e) => {
           e.preventDefault();
           firebase.auth().signOut().then(() => location.reload());
         };
       }
-
-      if (mobileAuth) {
-        mobileAuth.innerHTML = '<i class="fas fa-sign-out-alt mr-2"></i> Logout';
-        mobileAuth.href = "#";
-        mobileAuth.onclick = (e) => {
+      if (drawerLogout) {
+        drawerLogout.onclick = (e) => {
           e.preventDefault();
           firebase.auth().signOut().then(() => location.reload());
         };
       }
     });
+
+    // Load level and badge info
+    const [lbDoc, badgeSnap, levelSnap] = await Promise.all([
+      firebase.firestore().collection("leaderboard").doc(user.uid).get(),
+      db.ref("milestoneConfig/badges").once("value"),
+      db.ref("milestoneConfig/levels").once("value"),
+    ]);
+    const lbData = lbDoc.data() || {};
+    const packsOpened = lbData.packsOpened || 0;
+    const cardValue = lbData.cardValue || 0;
+    const badgeCfg = badgeSnap.val() || [];
+    let currentBadge = null;
+    if (Array.isArray(badgeCfg)) {
+      badgeCfg.forEach((b) => {
+        const threshold = b.threshold || 0;
+        const type = b.type || "packs";
+        if (
+          (type === "packs" && packsOpened >= threshold) ||
+          (type === "value" && cardValue >= threshold)
+        ) {
+          if (!currentBadge || threshold > (currentBadge.threshold || 0)) {
+            currentBadge = b;
+          }
+        }
+      });
+    }
+    const thresholds = levelSnap.val() || [];
+    const levelInfo = determineLevel(packsOpened, thresholds);
+    if (drawerLevel) drawerLevel.innerText = levelInfo.level;
+    if (drawerBadge) {
+      if (currentBadge) {
+        drawerBadge.innerText = currentBadge.name;
+        drawerBadge.style.backgroundColor = currentBadge.color || "#9333ea";
+        drawerBadge.classList.remove("hidden");
+      } else {
+        drawerBadge.classList.add("hidden");
+      }
+    }
   });
+
+  function determineLevel(packs, thresholds) {
+    if (!Array.isArray(thresholds) || thresholds.length === 0) {
+      const level = Math.floor(packs / 10) + 1;
+      const prev = (level - 1) * 10;
+      const next = level * 10;
+      return { level, prevThreshold: prev, nextThreshold: next };
+    }
+    let lvl = 1;
+    let prev = 0;
+    let next = null;
+    thresholds.forEach((t, idx) => {
+      if (packs >= t) {
+        lvl = idx + 1;
+        prev = t;
+      } else if (next === null) {
+        next = t;
+      }
+    });
+    if (next === null) next = prev;
+    return { level: lvl, prevThreshold: prev, nextThreshold: next };
+  }
 });
 

--- a/scripts/topup.js
+++ b/scripts/topup.js
@@ -12,15 +12,27 @@ async function loadTopupPopup() {
   const popup = document.getElementById("topup-popup");
   const closeBtn = document.getElementById("close-topup");
   const topupDesktop = document.getElementById("topup-button");
-  const topupMobile = document.getElementById("topup-button-mobile");
+  const topupMobileHeader = document.getElementById("topup-button-mobile-header");
+  const topupMobileDrawer = document.getElementById("topup-button-mobile-drawer");
 
   if (popup && closeBtn) {
     closeBtn.onclick = () => popup.classList.add("hidden");
   }
 
-  const openPopup = () => popup?.classList.remove("hidden");
+  const openPopup = () => {
+    if (popup) popup.classList.remove("hidden");
+    const mobileDrawer = document.getElementById("mobile-drawer");
+    const drawerOverlay = document.getElementById("drawer-overlay");
+    if (mobileDrawer && !mobileDrawer.classList.contains("-translate-x-full")) {
+      mobileDrawer.classList.add("-translate-x-full");
+    }
+    if (drawerOverlay && !drawerOverlay.classList.contains("hidden")) {
+      drawerOverlay.classList.add("hidden");
+    }
+  };
   if (topupDesktop) topupDesktop.onclick = openPopup;
-  if (topupMobile) topupMobile.onclick = openPopup;
+  if (topupMobileHeader) topupMobileHeader.onclick = openPopup;
+  if (topupMobileDrawer) topupMobileDrawer.onclick = openPopup;
 
   // Attach loading feedback to all buy buttons
   document.querySelectorAll("#topup-popup form").forEach(form => {


### PR DESCRIPTION
## Summary
- streamline mobile header to only show coin balance/top-up or sign-in/register
- add persistent bottom bar with menu button that toggles a full drawer of site links
- wire up new top-up buttons in header and drawer
- refine top header styling with cleaner balance pill, yellow wallet buttons, and prominent auth buttons
- remove extra "coins" label and add spacing between coin icon and balance across header and drawer
- display username, level, and current badge at the top of the mobile drawer for authenticated users
- tidy top header by merging balance and wallet into a single rounded pill on desktop and mobile
- polish drawer profile section by centering username above a badge/level row with subtle spacing and a divider

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68940d3d53f48320abeae42ebe895ebe