### PR TITLE
Limit main page pack grid to two columns

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@
 </div>
 
     <!-- Cases Grid -->
-    <div id="cases-container" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6"></div>
+    <div id="cases-container" class="grid grid-cols-1 sm:grid-cols-2 gap-6"></div>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- Display packs two-per-row on the main page for a cleaner layout.

## Testing
- `npm test` *(fails: could not find a package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68941eaef8b0832080569b3706173e12