### PR TITLE
fix: ensure wallet top-up popup loads after header

### DIFF
--- a/scripts/topup.js
+++ b/scripts/topup.js
@@ -47,7 +47,10 @@ async function loadTopupPopup() {
   });
 }
 
-loadTopupPopup();
+// Ensure the top-up popup is initialized after the full page, including the
+// header component, has loaded. This avoids race conditions where the popup
+// tries to bind to wallet buttons before they exist in the DOM.
+window.addEventListener("load", loadTopupPopup);
 
 // Stripe redirect with loading indicator
 function redirectToCheckout(event, priceId, button) {


### PR DESCRIPTION
## Summary
- delay top-up popup initialization until the page fully loads so wallet buttons are present

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68941f566fb08320b58778cd0b848c4c