### PR TITLE
feat: integrate mute button into pack name bar

### DIFF
--- a/case.html
+++ b/case.html
@@ -54,7 +54,12 @@
         <i class="fas fa-arrow-left"></i>
       </a>
       <h2 id="case-name" class="flex-1 text-center text-xl sm:text-2xl font-bold mx-4 bg-gradient-to-r from-yellow-400 via-pink-500 to-purple-500 bg-clip-text text-transparent leading-none">Loading...</h2>
-      <img id="case-image" class="w-12 h-12 sm:w-16 sm:h-16 object-contain rounded-full bg-black/40 p-2 border border-white/20 shadow-md transition-transform hover:rotate-6 hover:scale-105" alt="" />
+      <div class="flex items-center gap-2">
+        <img id="case-image" class="w-12 h-12 sm:w-16 sm:h-16 object-contain rounded-full bg-black/40 p-2 border border-white/20 shadow-md transition-transform hover:rotate-6 hover:scale-105" alt="" />
+        <button id="mute-toggle" aria-label="Toggle sound" class="flex items-center justify-center w-10 h-10 rounded-full bg-gradient-to-br from-purple-500 to-pink-500 text-white shadow-lg hover:scale-110 transition-transform">
+          <i id="mute-icon" class="fas fa-volume-up"></i>
+        </button>
+      </div>
     </div>
     <div id="case-spice" class="text-center text-xs mt-2"></div>
   </div>
@@ -100,9 +105,6 @@
  <div id="prizes-grid" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-5 gap-4 sm:gap-6 text-sm"></div>
 </div>
   </section>
-  <button id="mute-toggle" aria-label="Toggle sound" class="fixed bottom-4 left-4 z-50 p-3 rounded-full bg-gradient-to-r from-purple-500 to-pink-500 text-white shadow-lg hover:scale-110 transition-transform">
-    <i id="mute-icon" class="fas fa-volume-up"></i>
-  </button>
   <!-- Main logic -->
 <script type="module">
 import { renderSpinner, spinToPrize } from './scripts/spinner.js';


### PR DESCRIPTION
## Summary
- Move mute toggle button into the pack name bar alongside the case image
- Remove standalone mute button from bottom corner

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894245a69bc8320ada96dce7540873d