### PR TITLE
fix: prevent mobile drawer from flashing on load

### DIFF
--- a/scripts/header.js
+++ b/scripts/header.js
@@ -125,6 +125,14 @@ document.addEventListener("DOMContentLoaded", () => {
   const mobileDrawer = document.getElementById("mobile-drawer");
   const drawerOverlay = document.getElementById("drawer-overlay");
 
+  // Prevent drawer animation on initial load
+  if (mobileDrawer) {
+    mobileDrawer.style.transition = "none";
+    requestAnimationFrame(() => {
+      mobileDrawer.style.transition = "";
+    });
+  }
+
   if (drawerMenuButton && mobileDrawer && drawerOverlay) {
     const toggleDrawer = () => {
       mobileDrawer.classList.toggle("-translate-x-full");


### PR DESCRIPTION
## Summary
- avoid visible mobile drawer animation on initial page load by temporarily disabling the drawer transition

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68942529a2d08320b4d818e1bc226d59