### PR TITLE
fix: ensure Best Drops images display across devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,24 @@
         'top-2',
         'text-green-400',
         'text-orange-400',
-        'text-red-500'
+        'text-red-500',
+        'min-w-[120px]',
+        'md:min-w-[160px]',
+        'w-[90px]',
+        'h-[90px]',
+        'md:w-[120px]',
+        'md:h-[120px]',
+        'bg-[#12121b]',
+        'shadow-[0_0_20px_4px_rgba(255,215,0,0.5)]',
+        'border-yellow-400',
+        'shadow-[0_0_16px_3px_rgba(186,85,211,0.5)]',
+        'border-purple-500',
+        'shadow-[0_0_12px_2px_rgba(30,144,255,0.5)]',
+        'border-blue-500',
+        'shadow-[0_0_8px_1px_rgba(50,205,50,0.4)]',
+        'border-green-500',
+        'shadow-[0_0_6px_1px_rgba(255,255,255,0.1)]',
+        'border-gray-700'
       ]
     }
   </script>


### PR DESCRIPTION
## Summary
- safelist Best Drops carousel classes so Tailwind generates required width, height, background, and glow styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68942792ae1083208787359ebe86a243