### PR TITLE
feat: award coins for level ups

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -779,11 +779,14 @@ function addBadge(badge = {}) {
   document.getElementById('badge-list').appendChild(div);
 }
 
-function addLevel(value = '') {
+function addLevel(level = {}) {
   const div = document.createElement('div');
   div.className = 'flex gap-2 items-center';
+  const threshold = typeof level === 'object' ? (level.threshold || '') : level;
+  const reward = typeof level === 'object' ? (level.reward || 0) : 0;
   div.innerHTML = `
-    <input type="number" placeholder="Pack Threshold" class="level-value w-full p-2 rounded" value="${value}">
+    <input type="number" placeholder="Pack Threshold" class="level-threshold w-full p-2 rounded" value="${threshold}">
+    <input type="number" placeholder="Coin Reward" class="level-reward w-full p-2 rounded" value="${reward}">
     <button type="button" class="text-red-400 hover:text-red-600" onclick="this.parentElement.remove()">Remove</button>
   `;
   document.getElementById('level-list').appendChild(div);
@@ -801,7 +804,10 @@ function loadMilestoneConfig() {
       addBadge();
     }
     if (levels.length) {
-      levels.forEach(l => addLevel(l));
+      levels.forEach(l => {
+        if (typeof l === 'object') addLevel(l);
+        else addLevel({ threshold: l, reward: 0 });
+      });
     } else {
       addLevel();
     }
@@ -818,9 +824,10 @@ document.getElementById('milestone-config-form').addEventListener('submit', e =>
     if (name) badges.push({ name, threshold, color });
   });
   const levels = [];
-  document.querySelectorAll('#level-list .level-value').forEach(input => {
-    const val = parseInt(input.value);
-    if (!isNaN(val)) levels.push(val);
+  document.querySelectorAll('#level-list > div').forEach(div => {
+    const threshold = parseInt(div.querySelector('.level-threshold').value);
+    const reward = parseInt(div.querySelector('.level-reward').value) || 0;
+    if (!isNaN(threshold)) levels.push({ threshold, reward });
   });
   firebase.database().ref('milestoneConfig').set({ badges, levels }).then(() => showToast('✅ Milestone config saved'));
 });

--- a/case.html
+++ b/case.html
@@ -376,6 +376,16 @@ setTimeout(() => {
           balanceAfter = balance - price;
           await firebase.database().ref('users/' + user.uid + '/balance').set(balanceAfter);
         }
+        const milestoneRes = await updateMilestones(user.uid, winningPrize.value);
+        if (milestoneRes.leveledUp && milestoneRes.reward) {
+          balanceAfter += milestoneRes.reward;
+          await firebase.database().ref('users/' + user.uid + '/balance').set(balanceAfter);
+          const toast = document.createElement('div');
+          toast.className = 'fixed bottom-6 left-1/2 transform -translate-x-1/2 bg-green-500 text-white font-semibold py-2 px-4 rounded-lg shadow-xl z-[9999] flex items-center gap-2';
+          toast.innerHTML = `You've reached level ${milestoneRes.level}! <span class="flex items-center">+${milestoneRes.reward}<img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 ml-1"/></span>`;
+          document.body.appendChild(toast);
+          setTimeout(() => toast.remove(), 3000);
+        }
         const unboxData = {
           name: winningPrize.name,
           image: winningPrize.image,
@@ -389,7 +399,6 @@ setTimeout(() => {
         const invRef = firebase.database().ref('users/' + user.uid + '/inventory').push();
         await invRef.set(unboxData);
         await firebase.database().ref('users/' + user.uid + '/unboxHistory/' + invRef.key).set(unboxData);
-        await updateMilestones(user.uid, winningPrize.value);
         if (isFreeCase) {
           await firebase.database().ref('users/' + user.uid + '/freeCaseOpened').set(true);
         }

--- a/scripts/header.js
+++ b/scripts/header.js
@@ -275,8 +275,8 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
-  function determineLevel(packs, thresholds) {
-    if (!Array.isArray(thresholds) || thresholds.length === 0) {
+  function determineLevel(packs, levels) {
+    if (!Array.isArray(levels) || levels.length === 0) {
       const level = Math.floor(packs / 10) + 1;
       const prev = (level - 1) * 10;
       const next = level * 10;
@@ -285,7 +285,8 @@ document.addEventListener("DOMContentLoaded", () => {
     let lvl = 1;
     let prev = 0;
     let next = null;
-    thresholds.forEach((t, idx) => {
+    levels.forEach((entry, idx) => {
+      const t = typeof entry === 'object' ? entry.threshold : entry;
       if (packs >= t) {
         lvl = idx + 1;
         prev = t;

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -188,8 +188,8 @@ function updateProfile() {
     .catch(err => alert('❌ Error: ' + err.message));
 }
 
-function determineLevel(packs, thresholds) {
-  if (!Array.isArray(thresholds) || thresholds.length === 0) {
+function determineLevel(packs, levels) {
+  if (!Array.isArray(levels) || levels.length === 0) {
     const level = Math.floor(packs / 10) + 1;
     const prev = (level - 1) * 10;
     const next = level * 10;
@@ -198,7 +198,8 @@ function determineLevel(packs, thresholds) {
   let lvl = 1;
   let prev = 0;
   let next = null;
-  thresholds.forEach((t, idx) => {
+  levels.forEach((entry, idx) => {
+    const t = typeof entry === 'object' ? entry.threshold : entry;
     if (packs >= t) {
       lvl = idx + 1;
       prev = t;


### PR DESCRIPTION
## Summary
- allow admins to set a coin reward for each level
- credit and toast coins when players reach a new level
- support new level config structure throughout site

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6894296d86a083209209109adeacc7c0