### PR TITLE
Revamp leaderboard page design

### DIFF
--- a/leaderboard.html
+++ b/leaderboard.html
@@ -13,35 +13,53 @@
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <style>
     body { font-family: 'Poppins', sans-serif; }
+    @keyframes blob {
+      0%,100% { transform: translate(0,0); }
+      33% { transform: translate(30px,-20px); }
+      66% { transform: translate(-20px,30px); }
+    }
+    .animate-blob { animation: blob 8s infinite; }
+    .animation-delay-2000 { animation-delay: 2s; }
+    .animation-delay-4000 { animation-delay: 4s; }
   </style>
 </head>
 <body class="bg-gray-900 text-white min-h-screen">
   <header></header>
-  <section class="pt-32 pb-16 text-center bg-gradient-to-br from-gray-900 via-purple-900 to-gray-900">
-    <div class="max-w-3xl mx-auto">
-      <h1 class="text-4xl md:text-5xl font-extrabold mb-4 text-yellow-300">Weekly Leaderboard</h1>
-      <p class="text-lg text-gray-300 mb-2">Top 3 players each week earn <span class="text-yellow-400 font-semibold">500 coins</span>.</p>
-      <p class="text-gray-400 mb-4">Leaderboard resets every 7 days.</p>
-      <p id="reset-timer" class="text-sm text-gray-400">&nbsp;</p>
+
+  <section class="relative pt-32 pb-24 text-center overflow-hidden">
+    <div class="absolute inset-0 bg-gradient-to-br from-indigo-900 via-purple-800 to-pink-700"></div>
+    <div class="absolute -top-20 -left-20 w-72 h-72 bg-pink-500 rounded-full mix-blend-multiply filter blur-3xl opacity-70 animate-blob"></div>
+    <div class="absolute top-1/3 -right-10 w-72 h-72 bg-yellow-400 rounded-full mix-blend-multiply filter blur-3xl opacity-70 animate-blob animation-delay-2000"></div>
+    <div class="absolute -bottom-8 left-1/2 w-72 h-72 bg-purple-500 rounded-full mix-blend-multiply filter blur-3xl opacity-70 animate-blob animation-delay-4000"></div>
+    <div class="relative z-10 max-w-4xl mx-auto px-4">
+      <h1 class="text-5xl md:text-6xl font-extrabold mb-6 drop-shadow-lg">Weekly Leaderboard</h1>
+      <p class="text-xl md:text-2xl mb-2">Top 3 players earn <span class="text-yellow-300 font-bold">500 coins</span></p>
+      <p class="text-gray-200 mb-4">Leaderboard resets every 7 days.</p>
+      <p id="reset-timer" class="text-lg text-gray-200"></p>
     </div>
   </section>
+
   <section class="px-4 py-12">
-    <div class="max-w-3xl mx-auto bg-gray-800 rounded-2xl p-6 shadow-lg">
-      <h2 class="text-3xl font-bold text-center mb-2 text-yellow-300">Current Standings</h2>
-      <table class="w-full text-left">
-        <thead>
-          <tr class="border-b border-gray-700">
-            <th class="py-2 px-2">Rank</th>
-            <th class="py-2 px-2">Player</th>
-            <th class="py-2 px-2">Packs Opened</th>
-            <th class="py-2 px-2">Card Value</th>
-            <th class="py-2 px-2">Wins</th>
-          </tr>
-        </thead>
-        <tbody id="leaderboard-body"></tbody>
-      </table>
+    <div class="max-w-5xl mx-auto">
+      <div id="top-three" class="grid grid-cols-1 sm:grid-cols-3 gap-6 mb-12"></div>
+
+      <div class="overflow-x-auto bg-gray-800/70 rounded-xl shadow-xl backdrop-blur">
+        <table class="w-full text-left min-w-[500px]">
+          <thead class="bg-gray-700/80">
+            <tr>
+              <th class="py-3 px-4">Rank</th>
+              <th class="py-3 px-4">Player</th>
+              <th class="py-3 px-4 text-center">Packs</th>
+              <th class="py-3 px-4 text-center">Card Value</th>
+              <th class="py-3 px-4 text-center">Wins</th>
+            </tr>
+          </thead>
+          <tbody id="leaderboard-body"></tbody>
+        </table>
+      </div>
     </div>
   </section>
+
   <footer></footer>
   <script src="scripts/firebase-config.js"></script>
   <script src="scripts/header.js"></script>

--- a/scripts/leaderboard.js
+++ b/scripts/leaderboard.js
@@ -3,6 +3,7 @@
 
 document.addEventListener('DOMContentLoaded', async () => {
   const tbody = document.getElementById('leaderboard-body');
+  const topContainer = document.getElementById('top-three');
   const timerEl = document.getElementById('reset-timer');
   if (!tbody) return;
 
@@ -80,7 +81,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     setInterval(update, 60 * 1000); // update every minute
   }
 
-  // Render leaderboard rows
+  // Render leaderboard
   async function loadLeaderboard() {
     const snap = await fs
       .collection('leaderboard')
@@ -92,19 +93,32 @@ document.addEventListener('DOMContentLoaded', async () => {
     snap.forEach((doc) => {
       const data = doc.data();
       const wins = data.wins || 0;
-      let rowStyle = 'border-b border-gray-700';
-      if (rank === 1) rowStyle += ' bg-yellow-900 bg-opacity-40';
-      else if (rank === 2) rowStyle += ' bg-gray-800';
-      else if (rank === 3) rowStyle += ' bg-orange-900 bg-opacity-40';
 
-      tbody.innerHTML += `
-        <tr class="${rowStyle}">
-          <td class="py-2 px-2 text-center">${rank++}</td>
-          <td class="py-2 px-2">${data.username || 'Anonymous'}</td>
-          <td class="py-2 px-2 text-center">${data.packsOpened || 0}</td>
-          <td class="py-2 px-2 text-center">${(data.cardValue || 0).toLocaleString()}</td>
-          <td class="py-2 px-2 text-center">${wins} Win${wins === 1 ? '' : 's'}</td>
-        </tr>`;
+      if (rank <= 3 && topContainer) {
+        const medal = ['🥇', '🥈', '🥉'][rank - 1];
+        const colors = [
+          'from-yellow-300 to-yellow-500',
+          'from-gray-300 to-gray-500',
+          'from-orange-300 to-orange-500',
+        ];
+        topContainer.innerHTML += `
+          <div class="flex flex-col items-center p-6 rounded-xl bg-gradient-to-br ${colors[rank - 1]} text-gray-900 font-semibold shadow-lg transform hover:scale-105 transition">
+            <div class="text-4xl">${medal}</div>
+            <div class="text-xl mt-2">${data.username || 'Anonymous'}</div>
+            <div class="text-sm mt-1">Value: ${(data.cardValue || 0).toLocaleString()}</div>
+            <div class="text-sm">Packs: ${data.packsOpened || 0}</div>
+          </div>`;
+      } else {
+        tbody.innerHTML += `
+          <tr class="border-b border-gray-700 hover:bg-gray-700/40 transition">
+            <td class="py-2 px-4 text-center">${rank}</td>
+            <td class="py-2 px-4">${data.username || 'Anonymous'}</td>
+            <td class="py-2 px-4 text-center">${data.packsOpened || 0}</td>
+            <td class="py-2 px-4 text-center">${(data.cardValue || 0).toLocaleString()}</td>
+            <td class="py-2 px-4 text-center">${wins} Win${wins === 1 ? '' : 's'}</td>
+          </tr>`;
+      }
+      rank++;
     });
   }
 
@@ -112,4 +126,3 @@ document.addEventListener('DOMContentLoaded', async () => {
   startTimer(nextReset);
   loadLeaderboard();
 });
-


### PR DESCRIPTION
## Summary
- Redesign leaderboard page with animated hero, colorful blobs and responsive layout
- Highlight top three players with medal cards and modernize standings table

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897675e043483209c3b58fea00d3943