### PR TITLE
Revamp inventory page with playful responsive design

### DIFF
--- a/inventory.html
+++ b/inventory.html
@@ -17,8 +17,17 @@
       margin: 0;
       padding: 0;
       font-family: 'Poppins', sans-serif;
-      background: linear-gradient(to bottom right, #0f0f12, #1a1625);
+      background: linear-gradient(135deg, #3b0764, #9333ea, #ec4899);
+      background-size: 300% 300%;
+      animation: gradientMove 15s ease infinite;
       color: #fff;
+      overflow-x: hidden;
+    }
+
+    @keyframes gradientMove {
+      0% { background-position: 0% 50%; }
+      50% { background-position: 100% 50%; }
+      100% { background-position: 0% 50%; }
     }
 
     header {
@@ -30,36 +39,56 @@
     }
 
     .panel {
-      background: rgba(255,255,255,0.05);
-      border: 1px solid rgba(255,255,255,0.1);
-      backdrop-filter: blur(6px);
-      border-radius: 1rem;
+      background: rgba(255, 255, 255, 0.15);
+      border: 2px solid rgba(255, 255, 255, 0.25);
+      backdrop-filter: blur(10px);
+      border-radius: 1.5rem;
     }
 
     .item-card {
-      background: rgba(255,255,255,0.05);
-      border: 1px solid rgba(255,255,255,0.1);
-      backdrop-filter: blur(6px);
+      background: rgba(255, 255, 255, 0.1);
+      border: 2px solid rgba(255, 255, 255, 0.25);
+      backdrop-filter: blur(10px);
       transition: transform 0.3s ease, box-shadow 0.3s ease;
     }
 
     .item-card:hover {
-      transform: translateY(-4px);
-      box-shadow: 0 10px 20px rgba(0,0,0,0.5);
+      transform: translateY(-6px) rotate(1deg);
+      box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5);
     }
 
     .btn {
       font-weight: 600;
-      transition: all 0.3s ease;
+      transition: transform 0.3s ease, box-shadow 0.3s ease;
     }
 
     .btn:hover {
       transform: scale(1.05);
+      box-shadow: 0 0 10px rgba(255, 255, 255, 0.5);
     }
 
     select {
       background-color: white;
       color: black;
+    }
+
+    /* Background blobs */
+    .animate-blob {
+      animation: blob 8s infinite;
+    }
+
+    .animation-delay-2000 {
+      animation-delay: 2s;
+    }
+
+    .animation-delay-4000 {
+      animation-delay: 4s;
+    }
+
+    @keyframes blob {
+      0%, 100% { transform: translate(0,0) scale(1); }
+      33% { transform: translate(30px,-50px) scale(1.1); }
+      66% { transform: translate(-20px,20px) scale(0.9); }
     }
 
     /* Item preview popup */
@@ -119,22 +148,33 @@
   <header></header>
 
   <!-- Hero -->
-  <section class="pt-24 pb-12 px-4 text-center">
-    <div class="max-w-4xl mx-auto">
-      <h1 class="text-4xl md:text-5xl font-extrabold mb-2 bg-gradient-to-r from-fuchsia-400 to-pink-600 bg-clip-text text-transparent flex items-center justify-center">
-        <i class="fas fa-box-open mr-2"></i>Inventory
+  <section class="pt-32 pb-32 px-4 text-center relative overflow-hidden">
+    <div class="absolute -top-10 -left-10 w-52 h-52 bg-pink-500 rounded-full mix-blend-screen filter blur-3xl opacity-70 animate-blob"></div>
+    <div class="absolute -bottom-16 -right-16 w-64 h-64 bg-purple-600 rounded-full mix-blend-screen filter blur-3xl opacity-70 animate-blob animation-delay-2000"></div>
+    <div class="absolute top-1/2 left-1/2 w-40 h-40 bg-yellow-400 rounded-full mix-blend-screen filter blur-3xl opacity-60 animate-blob animation-delay-4000"></div>
+    <div class="max-w-4xl mx-auto relative">
+      <h1 class="text-5xl md:text-6xl font-extrabold mb-6 flex items-center justify-center gap-3">
+        <i class="fas fa-box-open text-yellow-300 animate-bounce"></i>
+        <span class="bg-gradient-to-r from-yellow-300 via-pink-500 to-purple-500 bg-clip-text text-transparent drop-shadow-lg">Inventory</span>
       </h1>
-      <p class="mt-2 text-gray-300">Ship out your pulls or sell them back for coins — manage your inventory with ease.</p>
+      <p class="mt-2 text-pink-200 text-lg">Ship out your pulls or sell them back for coins — manage your inventory with flair.</p>
     </div>
+    <svg class="absolute bottom-0 left-0 w-full" viewBox="0 0 1440 320" xmlns="http://www.w3.org/2000/svg"><path fill="rgba(255,255,255,0.1)" d="M0,224L80,229.3C160,235,320,245,480,234.7C640,224,800,192,960,186.7C1120,181,1280,203,1360,213.3L1440,224V320H0Z"></path></svg>
   </section>
 
-  <!-- Inventory -->
-  <main class="max-w-6xl mx-auto px-4 pb-16">
-    <div class="panel flex flex-col md:flex-row justify-between items-center gap-4 p-4 mb-8">
+  <!-- Tabs & Content -->
+  <main class="max-w-6xl mx-auto px-4 pb-24">
+    <div class="flex justify-center gap-4 mb-12 pt-6">
+      <button id="inventory-tab" class="px-6 py-2 rounded-full font-semibold text-white bg-gradient-to-r from-fuchsia-500 via-pink-500 to-amber-400">Inventory</button>
+      <button id="orders-tab" class="px-6 py-2 rounded-full font-semibold text-white bg-white/20 hover:bg-white/30 transition">Recent Orders</button>
+    </div>
+
+    <section id="inventory-section">
+      <div class="panel flex flex-col md:flex-row justify-between items-center gap-4 p-6 mb-12">
       <div class="flex flex-wrap items-center gap-4 text-sm">
         <label class="flex items-center gap-2"><input type="checkbox" id="select-all-checkbox" class="accent-pink-500">Select All</label>
         <div class="flex items-center gap-2">
-          <label for="sort-select">Sort by:</label>
+          <label for="sort-select" class="whitespace-nowrap">Sort by:</label>
           <select id="sort-select" class="text-black rounded px-3 py-1">
             <option value="rarity">Rarity</option>
             <option value="value">Value</option>
@@ -143,18 +183,18 @@
         </div>
       </div>
       <div class="flex flex-col sm:flex-row items-center gap-3">
-        <span id="selected-total" class="text-sm text-gray-300">Total: 0 coins</span>
-        <button onclick="sellSelected()" class="px-5 py-2 rounded-full font-semibold bg-gradient-to-r from-pink-500 to-fuchsia-600 hover:from-pink-600 hover:to-fuchsia-700 transition btn">Sell Selected</button>
-        <button onclick="shipSelected()" class="px-5 py-2 rounded-full font-semibold bg-gradient-to-r from-pink-500 to-fuchsia-600 hover:from-pink-600 hover:to-fuchsia-700 transition btn">Ship Selected</button>
+        <span id="selected-total" class="text-sm text-gray-200">Total: 0 coins</span>
+        <button onclick="sellSelected()" class="px-6 py-2 rounded-full font-semibold text-white bg-gradient-to-r from-fuchsia-500 via-pink-500 to-amber-400 hover:from-amber-400 hover:via-pink-500 hover:to-fuchsia-500 transition btn">Sell Selected</button>
+        <button onclick="shipSelected()" class="px-6 py-2 rounded-full font-semibold text-white bg-gradient-to-r from-fuchsia-500 via-pink-500 to-amber-400 hover:from-amber-400 hover:via-pink-500 hover:to-fuchsia-500 transition btn">Ship Selected</button>
       </div>
     </div>
+      <div id="inventory-container" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6"></div>
+    </section>
 
-    <div id="inventory-container" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6"></div>
-
-    <section class="mt-16">
+    <section id="orders-section" class="hidden">
       <div class="text-center mb-8">
-        <h2 class="text-3xl font-bold mb-2 bg-gradient-to-r from-fuchsia-400 to-pink-600 bg-clip-text text-transparent flex items-center justify-center"><i class="fas fa-truck mr-2"></i>Your Recent Orders</h2>
-        <p class="text-sm text-gray-400">Below are your previous shipment requests and their current status.</p>
+        <h2 class="text-3xl font-bold mb-2 bg-gradient-to-r from-yellow-300 via-pink-500 to-purple-500 bg-clip-text text-transparent flex items-center justify-center"><i class="fas fa-truck mr-2"></i>Your Recent Orders</h2>
+        <p class="text-sm text-pink-200">Below are your previous shipment requests and their current status.</p>
       </div>
       <div id="orders-container" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6"></div>
     </section>
@@ -165,11 +205,12 @@
     <div class="panel w-full max-w-md p-6">
       <h2 class="text-xl font-bold mb-4">Enter Shipping Info</h2>
       <input id="ship-username" type="text" placeholder="Username" class="w-full mb-2 px-4 py-2 rounded bg-gray-700 text-gray-400 cursor-not-allowed" disabled />
-      <input id="ship-name" type="text" placeholder="Full Name" class="w-full mb-2 px-4 py-2 rounded bg-gray-700" />
-      <input id="ship-address" type="text" placeholder="Address" class="w-full mb-2 px-4 py-2 rounded bg-gray-700" />
-      <input id="ship-city" type="text" placeholder="City" class="w-full mb-2 px-4 py-2 rounded bg-gray-700" />
-      <input id="ship-zip" type="text" placeholder="Zip Code" class="w-full mb-2 px-4 py-2 rounded bg-gray-700" />
-      <input id="ship-phone" type="text" placeholder="Phone Number" class="w-full mb-4 px-4 py-2 rounded bg-gray-700" />
+      <input id="ship-name" type="text" placeholder="Full Name" autocomplete="shipping name" class="w-full mb-2 px-4 py-2 rounded bg-gray-700" />
+      <input id="ship-address" type="text" placeholder="Address" autocomplete="shipping address-line1" class="w-full mb-2 px-4 py-2 rounded bg-gray-700" />
+      <input id="ship-address2" type="text" placeholder="Address 2 (Apt, Suite, etc)" autocomplete="shipping address-line2" class="w-full mb-2 px-4 py-2 rounded bg-gray-700" />
+      <input id="ship-city" type="text" placeholder="City" autocomplete="shipping address-level2" class="w-full mb-2 px-4 py-2 rounded bg-gray-700" />
+      <input id="ship-zip" type="text" placeholder="Zip Code" autocomplete="shipping postal-code" class="w-full mb-2 px-4 py-2 rounded bg-gray-700" />
+      <input id="ship-phone" type="text" placeholder="Phone Number" autocomplete="shipping tel" class="w-full mb-4 px-4 py-2 rounded bg-gray-700" />
       <p id="shipment-cost" class="text-sm text-pink-300 mb-4"></p>
       <div class="flex justify-end gap-3">
         <button onclick="closeShipmentPopup()" class="px-4 py-2 bg-gray-600 hover:bg-gray-700 rounded-full btn">Cancel</button>
@@ -209,6 +250,7 @@
   <script src="scripts/footer.js"></script>
   <script src="https://js.stripe.com/v3/"></script>
   <script src="scripts/topup.js"></script>
+  <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCyRm6dWH-fAmfWy83zLTrPFVi9Ny8gyxE&libraries=places"></script>
   <script src="scripts/inventory.js"></script>
   <div id="topup-popup-container"></div>
   <script>

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -3,11 +3,73 @@
 let shipmentSelection = [];
 const selectedItems = new Set();
 let currentItems = [];
+let addressAutocomplete;
+
+function initAddressAutocomplete() {
+  const addressInput = document.getElementById('ship-address');
+  if (!addressInput || !window.google || !google.maps?.places) return;
+
+  // Tear down any previous autocomplete to avoid multiple listeners
+  if (addressAutocomplete) {
+    google.maps.event.clearInstanceListeners(addressAutocomplete);
+    addressAutocomplete = null;
+  }
+
+  addressAutocomplete = new google.maps.places.Autocomplete(addressInput, {
+    types: ['address'],
+    fields: ['address_components']
+  });
+  addressAutocomplete.addListener('place_changed', () => {
+    const place = addressAutocomplete.getPlace();
+    let street = '', city = '', zip = '';
+    place.address_components?.forEach(component => {
+      const types = component.types;
+      if (types.includes('street_number')) street = component.long_name + ' ' + street;
+      if (types.includes('route')) street += component.long_name;
+      if (types.includes('locality')) city = component.long_name;
+      if (types.includes('postal_town') && !city) city = component.long_name;
+      if (types.includes('postal_code')) zip = component.long_name;
+    });
+    if (street) addressInput.value = street;
+    const cityInput = document.getElementById('ship-city');
+    if (cityInput && city) cityInput.value = city;
+    const zipInput = document.getElementById('ship-zip');
+    if (zipInput && zip) zipInput.value = zip;
+    setTimeout(() => {
+      addressInput.focus();
+      const len = addressInput.value.length;
+      addressInput.setSelectionRange(len, len);
+    }, 0);
+  });
+}
 
 document.addEventListener('DOMContentLoaded', () => {
   const itemPopup = document.getElementById('item-popup');
   document.getElementById('close-item-popup')?.addEventListener('click', closeItemPopup);
   itemPopup?.addEventListener('click', e => { if (e.target === itemPopup) closeItemPopup(); });
+
+  const inventoryTab = document.getElementById('inventory-tab');
+  const ordersTab = document.getElementById('orders-tab');
+  const inventorySection = document.getElementById('inventory-section');
+  const ordersSection = document.getElementById('orders-section');
+
+  inventoryTab?.addEventListener('click', () => {
+    inventoryTab.classList.add('bg-gradient-to-r','from-fuchsia-500','via-pink-500','to-amber-400');
+    inventoryTab.classList.remove('bg-white/20');
+    ordersTab.classList.remove('bg-gradient-to-r','from-fuchsia-500','via-pink-500','to-amber-400');
+    ordersTab.classList.add('bg-white/20');
+    ordersSection.classList.add('hidden');
+    inventorySection.classList.remove('hidden');
+  });
+
+  ordersTab?.addEventListener('click', () => {
+    ordersTab.classList.add('bg-gradient-to-r','from-fuchsia-500','via-pink-500','to-amber-400');
+    ordersTab.classList.remove('bg-white/20');
+    inventoryTab.classList.remove('bg-gradient-to-r','from-fuchsia-500','via-pink-500','to-amber-400');
+    inventoryTab.classList.add('bg-white/20');
+    inventorySection.classList.add('hidden');
+    ordersSection.classList.remove('hidden');
+  });
 
   firebase.auth().onAuthStateChanged(user => {
     if (!user) return (window.location.href = "auth.html");
@@ -65,11 +127,11 @@ document.addEventListener('DOMContentLoaded', () => {
       snap.forEach(order => {
         const data = order.val();
         container.innerHTML += `
-          <div class="item-card rounded-lg p-4 text-center">
-            <img src="${data.image}" class="mx-auto mb-3 h-24 object-contain rounded shadow" />
-            <h2 class="font-bold text-lg text-pink-300">${data.name}</h2>
-            <p class="text-sm text-gray-400 mb-2">Status: ${data.status}</p>
-            <p class="text-sm text-gray-400">Shipping Info: ${data.shippingInfo?.name}</p>
+          <div class="item-card rounded-2xl p-6 text-center">
+            <img src="${data.image}" class="mx-auto mb-4 h-24 object-contain rounded shadow-lg" />
+            <h2 class="font-bold text-xl text-yellow-300">${data.name}</h2>
+            <p class="text-sm text-pink-200 mb-1">Status: ${data.status}</p>
+            <p class="text-sm text-pink-200">Shipping Info: ${data.shippingInfo?.name}</p>
           </div>`;
       });
     });
@@ -128,18 +190,18 @@ function renderItems(items) {
     const refund = Math.floor((item.value || 0) * 0.8);
     const checked = selectedItems.has(item.key) ? 'checked' : '';
     container.innerHTML += `
-      <div class="item-card rounded-lg p-4 text-center">
-        <input type="checkbox" onchange="toggleItem('${item.key}')" ${checked} class="mb-2" ${item.shipped || item.requested ? 'disabled' : ''} />
-        <img src="${item.image}" onclick="showItemPopup('${encodeURIComponent(item.image)}')" class="mx-auto mb-3 h-24 object-contain rounded shadow cursor-pointer" />
-        <h2 class="font-bold text-lg text-pink-300">${item.name}</h2>
-        <p class="text-sm text-gray-400 mb-2">Rarity: ${item.rarity}</p>
-        <p class="text-sm text-gray-400">Value: ${item.value || 0} coins</p>
-        <div class="flex justify-center gap-2">
-          <button onclick="sellBack('${item.key}', ${item.value || 0})" ${item.shipped || item.requested ? 'disabled class="px-4 py-2 bg-gray-600 cursor-not-allowed rounded-full flex items-center space-x-1"' : 'class="px-4 py-2 bg-red-600 hover:bg-red-700 rounded-full flex items-center space-x-1"'}>
+      <div class="item-card rounded-2xl p-6 text-center">
+        <input type="checkbox" onchange="toggleItem('${item.key}')" ${checked} class="mb-3 accent-pink-500" ${item.shipped || item.requested ? 'disabled' : ''} />
+        <img src="${item.image}" onclick="showItemPopup('${encodeURIComponent(item.image)}')" class="mx-auto mb-4 h-28 object-contain rounded shadow-lg cursor-pointer transition-transform duration-300 hover:rotate-2 hover:scale-110" />
+        <h2 class="font-bold text-xl text-yellow-300">${item.name}</h2>
+        <p class="text-sm text-pink-200 mb-1">Rarity: ${item.rarity}</p>
+        <p class="text-sm text-pink-200 mb-3">Value: ${item.value || 0} coins</p>
+        <div class="flex justify-center gap-3">
+          <button onclick="sellBack('${item.key}', ${item.value || 0})" ${item.shipped || item.requested ? 'disabled class="px-4 py-2 bg-gray-600 cursor-not-allowed rounded-full flex items-center space-x-1"' : 'class="px-4 py-2 bg-gradient-to-r from-red-500 to-pink-600 hover:from-pink-600 hover:to-red-500 rounded-full flex items-center space-x-1"'}>
             <span>Sell for ${refund}</span>
             <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" width="16" height="16" />
           </button>
-          <button onclick="shipItem('${item.key}')" ${item.shipped || item.requested ? 'disabled class="px-4 py-2 bg-gray-600 cursor-not-allowed rounded-full"' : 'class="px-4 py-2 bg-green-600 hover:bg-green-700 rounded-full"'}>Ship</button>
+          <button onclick="shipItem('${item.key}')" ${item.shipped || item.requested ? 'disabled class="px-4 py-2 bg-gray-600 cursor-not-allowed rounded-full"' : 'class="px-4 py-2 bg-gradient-to-r from-green-500 to-emerald-600 hover:from-emerald-600 hover:to-green-500 rounded-full"'}>Ship</button>
         </div>
       </div>`;
   });
@@ -276,7 +338,12 @@ function shipSelected() {
 
   const cost = shipmentSelection.length <= 5 ? shipmentSelection.length * 500 : 2500;
   document.getElementById('shipment-cost').innerText = `Shipping ${shipmentSelection.length} item(s) will cost ${cost} coins.`;
-  document.getElementById('shipment-popup').classList.remove('hidden');
+  const popup = document.getElementById('shipment-popup');
+  popup.classList.remove('hidden');
+  setTimeout(() => {
+    initAddressAutocomplete();
+    document.getElementById('ship-address')?.focus();
+  }, 100);
 }
 
 function shipItem(key) {
@@ -285,7 +352,12 @@ function shipItem(key) {
   shipmentSelection = [item];
   const cost = 500;
   document.getElementById('shipment-cost').innerText = `Shipping 1 item will cost ${cost} coins.`;
-  document.getElementById('shipment-popup').classList.remove('hidden');
+  const popup = document.getElementById('shipment-popup');
+  popup.classList.remove('hidden');
+  setTimeout(() => {
+    initAddressAutocomplete();
+    document.getElementById('ship-address')?.focus();
+  }, 100);
 }
 
 function closeShipmentPopup() {
@@ -298,6 +370,7 @@ function submitShipmentRequest() {
 
   const name = document.getElementById('ship-name').value.trim();
   const address = document.getElementById('ship-address').value.trim();
+  const address2 = document.getElementById('ship-address2').value.trim();
   const city = document.getElementById('ship-city').value.trim();
   const zip = document.getElementById('ship-zip').value.trim();
   const phone = document.getElementById('ship-phone').value.trim();
@@ -320,7 +393,7 @@ function submitShipmentRequest() {
         itemId: item.id,
         name: item.name,
         image: item.image,
-        shippingInfo: { name, address, city, zip, phone },
+        shippingInfo: { name, address, address2, city, zip, phone },
         status: 'Requested',
         timestamp: Date.now()
       });


### PR DESCRIPTION
## Summary
- upgrade inventory header into a lively hero with animated blobs and a wavy footer
- split recent orders into a separate tab alongside inventory controls
- standardize typography across the page to match site-wide Poppins font
- add top padding to tab navigation for improved spacing
- enable shipping address autocomplete using Google Places to prefill city and ZIP
- keep the keyboard open after selecting an address and add an optional second address line for apartments or suites
- fix shipping address autocomplete glitch by reinitializing after the popup opens
- clear out stale autocomplete listeners and keep the cursor positioned so the keyboard stays active while typing

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_6897b8c231688320951a4fdd0fa44504