### PR TITLE
Revamp homepage hero and highlights

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,40 +57,45 @@
 <header></header>
 
 <!-- Hero -->
-<section id="hero" class="relative overflow-hidden bg-gradient-to-b from-gray-900 via-purple-900 to-gray-900">
-  <div class="container mx-auto max-w-6xl px-6 pt-20 pb-16 flex flex-col gap-8">
+<section id="hero" class="relative h-[90vh] flex items-center justify-center text-center text-white overflow-hidden">
+  <img src="https://images.unsplash.com/photo-1535223289827-42f1e9919769?auto=format&fit=crop&w=1600&q=80" alt="" class="absolute inset-0 w-full h-full object-cover opacity-40">
+  <div class="absolute inset-0 bg-gradient-to-b from-black via-purple-900/60 to-black"></div>
+  <div class="relative z-10 max-w-3xl mx-auto px-6">
+    <h1 class="hero-fade opacity-0 translate-y-4 transition-all duration-700 text-4xl md:text-6xl font-extrabold mb-6">Virtual Packs.<br class="hidden md:block"/>Real Cards.</h1>
+    <p class="hero-fade opacity-0 translate-y-4 transition-all duration-700 text-lg md:text-2xl text-gray-200 mb-8">Join the most electrifying way to collect. Rip digital packs and claim authentic gear shipped worldwide.</p>
+    <div class="hero-fade opacity-0 translate-y-4 transition-all duration-700 flex flex-col sm:flex-row items-center justify-center gap-4">
+      <a href="#cases" class="px-8 py-4 bg-gradient-to-r from-yellow-400 via-pink-500 to-purple-600 text-black font-bold rounded-full shadow-lg transform hover:scale-105 transition">Open Packs</a>
+      <a href="how-it-works.html" class="px-8 py-4 border border-white/30 text-white rounded-full hover:bg-white/10 transition">How it works</a>
+    </div>
+  </div>
+</section>
 
-    <!-- Updates Bar -->
-    <div class="w-full bg-gradient-to-r from-yellow-500 via-pink-500 to-purple-600 text-white py-2 overflow-hidden rounded-xl shadow-md">
-      <div class="animate-marquee whitespace-nowrap text-sm font-medium flex items-center gap-12 px-4">
-        <span>📦 All cards are near mint unless specified otherwise</span>
-        <span class="flex items-center gap-1">
-          🪙 Sell back unwanted cards for coins
-          <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" alt="Coin" class="w-4 h-4 inline-block" />
-        </span>
+<!-- Highlights -->
+<section id="highlights" class="bg-[#0f0f12] py-20">
+  <div class="container mx-auto max-w-6xl px-6">
+    <div class="grid gap-10 md:grid-cols-3">
+      <div class="group bg-white/5 rounded-2xl p-8 border border-white/10 hover:border-pink-500 hover:bg-white/10 transition">
+        <div class="w-14 h-14 mb-5 rounded-full flex items-center justify-center bg-gradient-to-br from-pink-500 to-purple-600 text-white shadow-lg group-hover:scale-110 transition">
+          <i class="fa-solid fa-shield-halved text-2xl"></i>
+        </div>
+        <h3 class="text-xl font-semibold mb-2">Verified Pulls</h3>
+        <p class="text-gray-400 text-sm">Every card and collectible is authenticated from trusted partners and guaranteed real.</p>
+      </div>
+      <div class="group bg-white/5 rounded-2xl p-8 border border-white/10 hover:border-pink-500 hover:bg-white/10 transition">
+        <div class="w-14 h-14 mb-5 rounded-full flex items-center justify-center bg-gradient-to-br from-pink-500 to-purple-600 text-white shadow-lg group-hover:scale-110 transition">
+          <i class="fa-solid fa-rotate text-2xl"></i>
+        </div>
+        <h3 class="text-xl font-semibold mb-2">Instant Resell</h3>
+        <p class="text-gray-400 text-sm">Don’t like the hit? Flip it back for coins or trade with the community in seconds.</p>
+      </div>
+      <div class="group bg-white/5 rounded-2xl p-8 border border-white/10 hover:border-pink-500 hover:bg-white/10 transition">
+        <div class="w-14 h-14 mb-5 rounded-full flex items-center justify-center bg-gradient-to-br from-pink-500 to-purple-600 text-white shadow-lg group-hover:scale-110 transition">
+          <i class="fa-solid fa-truck-fast text-2xl"></i>
+        </div>
+        <h3 class="text-xl font-semibold mb-2">Fast Global Shipping</h3>
+        <p class="text-gray-400 text-sm">We deliver worldwide with tracking so your new grails reach you safely and fast.</p>
       </div>
     </div>
-
-    <div class="flex flex-col md:flex-row items-center gap-12">
-      <!-- Text -->
-      <div class="flex-1 text-center md:text-left">
-        <h1 class="text-4xl md:text-5xl font-extrabold mb-4 text-white tracking-tight leading-tight opacity-0 animate-fade-up">
-          Virtual packs,<br>real cards. <span class="emoji-sparkle">✨</span>
-        </h1>
-        <p class="text-md md:text-lg text-gray-300 mb-6 leading-relaxed opacity-0 animate-fade-up">
-          Open digital packs. Win real cards. Start ripping in seconds. Packly.gg.
-        </p>
-        <a href="#cases" class="inline-block px-6 py-3 bg-yellow-400 text-black rounded-full font-semibold border border-yellow-500 hover:bg-yellow-300 transition-all duration-200 shadow-md hover:scale-105 opacity-0 animate-fade-up">
-          Grab A Pack
-        </a>
-      </div>
-
-      <!-- Pack Animation -->
-      <div class="flex-1 relative w-full h-64 md:h-80">
-        <div id="hero-pack-carousel" class="absolute inset-0"></div>
-      </div>
-    </div>
-
   </div>
 </section>
 
@@ -235,7 +240,6 @@ if (filterToggle && filterPanel) {
 <script type="module" src="scripts/auth.js"></script>
 <script src="scripts/navbar.js"></script>
 <script src="scripts/hero.js"></script>
-<script src="scripts/features.js"></script>
 <script type="module" src="scripts/packs.js"></script>
   <script type="module">
   import { renderDailyQuests } from './scripts/quests.js';

--- a/scripts/hero.js
+++ b/scripts/hero.js
@@ -1,51 +1,7 @@
 window.addEventListener('DOMContentLoaded', () => {
-  const title = document.querySelector('h1.animate-fade-up');
-  const paragraph = document.querySelector('p.animate-fade-up');
-  const cta = document.querySelector('#hero a.animate-fade-up');
-
-  if (title) setTimeout(() => title.classList.remove('opacity-0'), 200);
-  if (paragraph) setTimeout(() => paragraph.classList.remove('opacity-0'), 400);
-  if (cta) setTimeout(() => cta.classList.remove('opacity-0'), 600);
-
-  const carousel = document.getElementById('hero-pack-carousel');
-  const casesContainer = document.getElementById('cases-container');
-
-  function buildCarousel() {
-    const packImgs = casesContainer?.querySelectorAll('.case-card-img') || [];
-    if (!packImgs.length || !carousel) return;
-
-    Array.from(packImgs).slice(0, 5).forEach((img, i) => {
-      const clone = document.createElement('img');
-      clone.src = img.src;
-      clone.alt = img.alt || 'Pack';
-      clone.className = 'hero-pack-img';
-      if (i === 0) clone.classList.add('active');
-      carousel.appendChild(clone);
-    });
-
-    startCarousel();
-  }
-
-  function startCarousel() {
-    const slides = carousel?.querySelectorAll('img') || [];
-    if (slides.length <= 1) return;
-
-    let index = 0;
-    setInterval(() => {
-      slides[index].classList.remove('active');
-      index = (index + 1) % slides.length;
-      slides[index].classList.add('active');
-    }, 3000);
-  }
-
-  if (casesContainer) {
-    const observer = new MutationObserver((mutations, obs) => {
-      if (casesContainer.querySelector('.case-card-img')) {
-        obs.disconnect();
-        buildCarousel();
-      }
-    });
-    observer.observe(casesContainer, { childList: true, subtree: true });
-  }
+  document.querySelectorAll('.hero-fade').forEach((el, i) => {
+    setTimeout(() => {
+      el.classList.remove('opacity-0', 'translate-y-4');
+    }, i * 200);
+  });
 });
-


### PR DESCRIPTION
## Summary
- Replace existing hero with full-screen gradient image background and animated CTAs
- Add premium highlights section showcasing verification, instant resell, and fast shipping
- Implement lightweight JS fade-in for hero elements

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68982e5aedf08320a65d6424309664a5