### PR TITLE
Refine topup popup design

### DIFF
--- a/components/topup.html
+++ b/components/topup.html
@@ -1,85 +1,50 @@
 <!-- components/topup.html -->
-<div id="topup-popup" class="fixed inset-0 z-[200] flex items-center justify-center px-4 py-8 sm:py-12 hidden backdrop-blur-xl bg-black/70 overflow-auto">
- <div class="relative w-full max-w-sm sm:max-w-md bg-gradient-to-br from-gray-900/95 via-gray-800/90 to-gray-900/95 border border-purple-700 p-5 sm:p-6 rounded-2xl shadow-2xl">
-    
-    <!-- Close Button -->
-    <button id="close-topup" class="absolute top-3 right-4 text-gray-400 hover:text-white text-2xl font-bold leading-none transition duration-200 ease-in-out">
-      &times;
-    </button>
-
-    <!-- Title -->
- <h2 class="text-center text-3xl sm:text-4xl font-extrabold mb-6 tracking-wide text-transparent bg-clip-text bg-gradient-to-r from-yellow-400 via-pink-500 to-purple-600 drop-shadow-lg">
-  Recharge Your Coins
-</h2>
-
-
-    <!-- Grid Container -->
-    <div class="grid grid-cols-2 sm:grid-cols-2 gap-4">
-      
-      <!-- Package -->
-      <form data-price-id="price_1RTtr3I76TkBIa1xiGafiRfX" class="bg-gray-800/80 rounded-xl px-4 py-5 text-center shadow-inner border border-purple-600 hover:shadow-purple-600/40 hover:scale-[1.02] transition-all duration-200">
-        <div class="text-yellow-400 text-lg font-bold flex justify-center items-center gap-1 mb-1">
-          2,000 
-          <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4" alt="coin" />
+<div id="topup-popup" class="fixed inset-0 z-[200] hidden items-center justify-center px-4 py-8 sm:py-12 backdrop-blur-sm bg-black/70 overflow-auto">
+  <div class="relative w-full max-w-md bg-gray-900 p-6 rounded-2xl border border-gray-700 shadow-xl">
+    <button id="close-topup" class="absolute top-4 right-4 text-gray-400 hover:text-white text-2xl font-bold">&times;</button>
+    <h2 class="text-center text-3xl font-bold text-white mb-2">Top Up Coins</h2>
+    <p class="text-center text-sm text-gray-400 mb-6">Choose a package to continue</p>
+    <div class="grid grid-cols-2 gap-4">
+      <form data-price-id="price_1RTtr3I76TkBIa1xiGafiRfX" class="rounded-xl border border-gray-700 p-4 text-center hover:border-purple-500 transition">
+        <div class="text-yellow-400 text-lg font-semibold flex justify-center items-center gap-1 mb-1">
+          2,000 <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4" alt="coin" />
         </div>
-        <div class="text-sm text-gray-300 mb-3">$20.00</div>
-        <button type="submit" class="w-full bg-purple-600 hover:bg-purple-700 text-white text-sm font-semibold py-1.5 rounded-full transition">
-          Buy
-        </button>
+        <div class="text-gray-400 text-sm mb-3">$20.00</div>
+        <button type="submit" class="w-full py-2 bg-purple-600 hover:bg-purple-700 text-white text-sm font-semibold rounded-full">Select</button>
       </form>
-
-      <!-- Package -->
-      <form data-price-id="price_1RTtwSI76TkBIa1xmcHFALFX" class="bg-gray-800/80 rounded-xl px-4 py-5 text-center shadow-inner border border-purple-600 hover:shadow-purple-600/40 hover:scale-[1.02] transition-all duration-200">
-        <div class="text-yellow-400 text-lg font-bold flex justify-center items-center gap-1 mb-1">
-          3,000 
-          <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4" alt="coin" />
+      <form data-price-id="price_1RTtwSI76TkBIa1xmcHFALFX" class="rounded-xl border border-gray-700 p-4 text-center hover:border-purple-500 transition">
+        <div class="text-yellow-400 text-lg font-semibold flex justify-center items-center gap-1 mb-1">
+          3,000 <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4" alt="coin" />
         </div>
-        <div class="text-sm text-gray-300 mb-3">$30.00</div>
-        <button type="submit" class="w-full bg-purple-600 hover:bg-purple-700 text-white text-sm font-semibold py-1.5 rounded-full transition">
-          Buy
-        </button>
+        <div class="text-gray-400 text-sm mb-3">$30.00</div>
+        <button type="submit" class="w-full py-2 bg-purple-600 hover:bg-purple-700 text-white text-sm font-semibold rounded-full">Select</button>
       </form>
-
-      <!-- Package -->
-      <form data-price-id="price_1RTu1cI76TkBIa1xGbcbubuY" class="bg-gray-800/80 rounded-xl px-4 py-5 text-center shadow-inner border border-purple-600 hover:shadow-purple-600/40 hover:scale-[1.02] transition-all duration-200">
-        <div class="text-yellow-400 text-lg font-bold flex justify-center items-center gap-1 mb-1">
-          5,000 
-          <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4" alt="coin" />
+      <form data-price-id="price_1RTu1cI76TkBIa1xGbcbubuY" class="rounded-xl border border-gray-700 p-4 text-center hover:border-purple-500 transition">
+        <div class="text-yellow-400 text-lg font-semibold flex justify-center items-center gap-1 mb-1">
+          5,000 <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4" alt="coin" />
         </div>
-        <div class="text-sm text-gray-300 mb-3">$50.00</div>
-        <button type="submit" class="w-full bg-purple-600 hover:bg-purple-700 text-white text-sm font-semibold py-1.5 rounded-full transition">
-          Buy
-        </button>
+        <div class="text-gray-400 text-sm mb-3">$50.00</div>
+        <button type="submit" class="w-full py-2 bg-purple-600 hover:bg-purple-700 text-white text-sm font-semibold rounded-full">Select</button>
       </form>
-
-      <!-- Package -->
-      <form data-price-id="price_1RTu5pI76TkBIa1xqsVfedwB" class="bg-gray-800/80 rounded-xl px-4 py-5 text-center shadow-inner border border-purple-600 hover:shadow-purple-600/40 hover:scale-[1.02] transition-all duration-200">
-        <div class="text-yellow-400 text-lg font-bold flex justify-center items-center gap-1 mb-1">
-          10,000 
-          <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4" alt="coin" />
+      <form data-price-id="price_1RTu5pI76TkBIa1xqsVfedwB" class="rounded-xl border border-gray-700 p-4 text-center hover:border-purple-500 transition">
+        <div class="text-yellow-400 text-lg font-semibold flex justify-center items-center gap-1 mb-1">
+          10,000 <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4" alt="coin" />
         </div>
-        <div class="text-sm text-gray-300 mb-3">$100.00</div>
-        <button type="submit" class="w-full bg-purple-600 hover:bg-purple-700 text-white text-sm font-semibold py-1.5 rounded-full transition">
-          Buy
-        </button>
+        <div class="text-gray-400 text-sm mb-3">$100.00</div>
+        <button type="submit" class="w-full py-2 bg-purple-600 hover:bg-purple-700 text-white text-sm font-semibold rounded-full">Select</button>
       </form>
-
-     <!-- Bonus Package -->
-<form data-price-id="price_1RTuAMI76TkBIa1x1mEVXL2M" class="bg-gray-800/80 rounded-xl px-4 py-5 text-center shadow-inner border border-pink-500 hover:shadow-pink-500/40 hover:scale-[1.02] transition-all duration-200 col-span-2">
-  <div class="text-yellow-400 text-lg font-bold flex justify-center items-center gap-1 mb-1">
-    15,000 
-    <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4" alt="coin" />
-    <span class="ml-1 text-xs text-pink-400 font-semibold">+ 1,500 Bonus</span>
+      <form data-price-id="price_1RTuAMI76TkBIa1x1mEVXL2M" class="col-span-2 rounded-xl border border-pink-500 p-4 text-center hover:border-pink-400 transition">
+        <div class="text-yellow-400 text-lg font-semibold flex justify-center items-center gap-1 mb-1">
+          15,000 <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4" alt="coin" />
+          <span class="ml-1 text-xs text-pink-400 font-semibold">+ 1,500 Bonus</span>
+        </div>
+        <div class="text-gray-400 text-sm mb-3">$150.00</div>
+        <button type="submit" class="w-full py-2 bg-gradient-to-r from-pink-500 via-purple-600 to-purple-700 hover:brightness-110 text-white text-sm font-semibold rounded-full">Select</button>
+      </form>
+    </div>
+    <div class="mt-6 text-center text-xs text-gray-500 flex flex-col items-center gap-1">
+      <span>Secure payments by</span>
+      <img src="https://stripe.com/img/v3/home/social.png" alt="Stripe Logo" class="h-4 w-auto" />
+    </div>
   </div>
-  <div class="text-sm text-gray-300 mb-3">$150.00</div>
-  <button type="submit" class="w-full bg-gradient-to-r from-pink-500 via-purple-600 to-purple-700 hover:brightness-110 text-white text-sm font-bold py-1.5 rounded-full transition">
-    Buy
-  </button>
-</form>
-
-<!-- Secure Payment Badge (Smaller) -->
-<div class="col-span-2 mt-4 text-center text-xs text-gray-400 flex flex-col items-center gap-1 opacity-80">
-  <span>Secure payments by</span>
-  <img src="https://stripe.com/img/v3/home/social.png" alt="Stripe Logo" class="h-4 w-auto">
 </div>
-

--- a/components/topup.html
+++ b/components/topup.html
@@ -1,75 +1,54 @@
 <!-- components/topup.html -->
-<div id="topup-popup" class="fixed inset-0 z-[200] hidden items-center justify-center p-4 bg-black/80 backdrop-blur-xl overflow-auto">
-  <div class="relative w-full max-w-5xl">
-    <div class="absolute inset-0 -z-10 animate-[spin_20s_linear_infinite]">
-      <div class="h-full w-full bg-gradient-to-br from-purple-700 via-pink-500 to-yellow-400 rounded-[2rem] opacity-30 blur-3xl"></div>
+<div id="topup-popup" class="fixed inset-0 z-[200] hidden items-center justify-center bg-black/70 backdrop-blur-sm p-4">
+  <div class="relative w-full max-w-xl rounded-xl bg-gray-900 p-6 text-white">
+    <button id="close-topup" class="absolute top-4 right-4 text-2xl text-white/60 hover:text-white">&times;</button>
+    <h2 class="mb-2 text-center text-3xl font-bold">Add Coins</h2>
+    <p class="mb-6 text-center text-sm text-gray-400">Choose a package</p>
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      <form data-price-id="price_1RTtr3I76TkBIa1xiGafiRfX" class="rounded-lg border border-gray-700 bg-gray-800 p-4 text-center transition hover:border-pink-500">
+        <div class="mb-1 flex items-center justify-center gap-1 text-xl font-semibold">
+          <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="h-5 w-5" alt="coin" />
+          2,000
+        </div>
+        <div class="text-sm text-gray-400">$20.00</div>
+        <button type="submit" class="mt-3 w-full rounded-md bg-pink-600 py-2 text-sm font-medium text-white hover:bg-pink-500">Select</button>
+      </form>
+      <form data-price-id="price_1RTtwSI76TkBIa1xmcHFALFX" class="rounded-lg border border-gray-700 bg-gray-800 p-4 text-center transition hover:border-pink-500">
+        <div class="mb-1 flex items-center justify-center gap-1 text-xl font-semibold">
+          <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="h-5 w-5" alt="coin" />
+          3,000
+        </div>
+        <div class="text-sm text-gray-400">$30.00</div>
+        <button type="submit" class="mt-3 w-full rounded-md bg-pink-600 py-2 text-sm font-medium text-white hover:bg-pink-500">Select</button>
+      </form>
+      <form data-price-id="price_1RTu1cI76TkBIa1xGbcbubuY" class="rounded-lg border border-gray-700 bg-gray-800 p-4 text-center transition hover:border-pink-500">
+        <div class="mb-1 flex items-center justify-center gap-1 text-xl font-semibold">
+          <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="h-5 w-5" alt="coin" />
+          5,000
+        </div>
+        <div class="text-sm text-gray-400">$50.00</div>
+        <button type="submit" class="mt-3 w-full rounded-md bg-pink-600 py-2 text-sm font-medium text-white hover:bg-pink-500">Select</button>
+      </form>
+      <form data-price-id="price_1RTu5pI76TkBIa1xqsVfedwB" class="rounded-lg border border-gray-700 bg-gray-800 p-4 text-center transition hover:border-pink-500">
+        <div class="mb-1 flex items-center justify-center gap-1 text-xl font-semibold">
+          <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="h-5 w-5" alt="coin" />
+          10,000
+        </div>
+        <div class="text-sm text-gray-400">$100.00</div>
+        <button type="submit" class="mt-3 w-full rounded-md bg-pink-600 py-2 text-sm font-medium text-white hover:bg-pink-500">Select</button>
+      </form>
+      <form data-price-id="price_1RTuAMI76TkBIa1x1mEVXL2M" class="rounded-lg border border-pink-500 bg-gray-800 p-4 text-center sm:col-span-2">
+        <div class="mb-1 flex items-center justify-center gap-1 text-xl font-semibold">
+          <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="h-5 w-5" alt="coin" />
+          15,000 <span class="ml-1 text-xs font-bold text-pink-300">+1,500 Bonus</span>
+        </div>
+        <div class="text-sm text-gray-400">$150.00</div>
+        <button type="submit" class="mt-3 w-full rounded-md bg-pink-600 py-2 text-sm font-medium text-white hover:bg-pink-500">Select</button>
+      </form>
     </div>
-    <div class="relative bg-gray-900/90 rounded-[2rem] p-10 border border-gray-700 shadow-[0_0_50px_rgba(0,0,0,0.5)]">
-      <button id="close-topup" class="absolute top-6 right-6 text-3xl text-white/60 hover:text-white font-bold">&times;</button>
-      <h2 class="text-center text-5xl font-extrabold bg-gradient-to-r from-yellow-300 via-pink-400 to-purple-600 bg-clip-text text-transparent mb-4">Recharge Vault</h2>
-      <p class="text-center text-gray-300 mb-10">Select a vault to flood your balance with coins</p>
-      <div class="grid gap-6 md:grid-cols-3">
-        <form data-price-id="price_1RTtr3I76TkBIa1xiGafiRfX" class="group relative p-8 rounded-2xl bg-gray-800/60 border border-transparent hover:border-pink-500 hover:bg-gray-800 transition overflow-hidden">
-          <div class="absolute inset-0 opacity-10 group-hover:opacity-20 bg-[radial-gradient(circle_at_top,_#ff7af5,_transparent)]"></div>
-          <div class="relative flex flex-col items-center">
-            <div class="text-4xl font-black text-yellow-400 flex items-center gap-2 mb-2">
-              <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-8 h-8" alt="coin" />
-              2,000
-            </div>
-            <div class="text-gray-400 text-lg">$20.00</div>
-            <button type="submit" class="mt-6 w-full py-3 rounded-full bg-gradient-to-r from-pink-500 to-purple-600 text-white font-semibold shadow-lg group-hover:from-yellow-400 group-hover:to-pink-500 transition-transform group-hover:scale-105">Make it Rain</button>
-          </div>
-        </form>
-        <form data-price-id="price_1RTtwSI76TkBIa1xmcHFALFX" class="group relative p-8 rounded-2xl bg-gray-800/60 border border-transparent hover:border-pink-500 hover:bg-gray-800 transition overflow-hidden">
-          <div class="absolute inset-0 opacity-10 group-hover:opacity-20 bg-[radial-gradient(circle_at_top,_#ff7af5,_transparent)]"></div>
-          <div class="relative flex flex-col items-center">
-            <div class="text-4xl font-black text-yellow-400 flex items-center gap-2 mb-2">
-              <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-8 h-8" alt="coin" />
-              3,000
-            </div>
-            <div class="text-gray-400 text-lg">$30.00</div>
-            <button type="submit" class="mt-6 w-full py-3 rounded-full bg-gradient-to-r from-pink-500 to-purple-600 text-white font-semibold shadow-lg group-hover:from-yellow-400 group-hover:to-pink-500 transition-transform group-hover:scale-105">Boost Balance</button>
-          </div>
-        </form>
-        <form data-price-id="price_1RTu1cI76TkBIa1xGbcbubuY" class="group relative p-8 rounded-2xl bg-gray-800/60 border border-transparent hover:border-pink-500 hover:bg-gray-800 transition overflow-hidden">
-          <div class="absolute inset-0 opacity-10 group-hover:opacity-20 bg-[radial-gradient(circle_at_top,_#ff7af5,_transparent)]"></div>
-          <div class="relative flex flex-col items-center">
-            <div class="text-4xl font-black text-yellow-400 flex items-center gap-2 mb-2">
-              <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-8 h-8" alt="coin" />
-              5,000
-            </div>
-            <div class="text-gray-400 text-lg">$50.00</div>
-            <button type="submit" class="mt-6 w-full py-3 rounded-full bg-gradient-to-r from-pink-500 to-purple-600 text-white font-semibold shadow-lg group-hover:from-yellow-400 group-hover:to-pink-500 transition-transform group-hover:scale-105">Supercharge</button>
-          </div>
-        </form>
-        <form data-price-id="price_1RTu5pI76TkBIa1xqsVfedwB" class="group relative p-8 rounded-2xl bg-gray-800/60 border border-transparent hover:border-pink-500 hover:bg-gray-800 transition overflow-hidden md:col-span-2">
-          <div class="absolute inset-0 opacity-10 group-hover:opacity-20 bg-[radial-gradient(circle_at_top,_#ff7af5,_transparent)]"></div>
-          <div class="relative flex flex-col items-center">
-            <div class="text-4xl font-black text-yellow-400 flex items-center gap-2 mb-2">
-              <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-8 h-8" alt="coin" />
-              10,000
-            </div>
-            <div class="text-gray-400 text-lg">$100.00</div>
-            <button type="submit" class="mt-6 w-full py-3 rounded-full bg-gradient-to-r from-pink-500 to-purple-600 text-white font-semibold shadow-lg group-hover:from-yellow-400 group-hover:to-pink-500 transition-transform group-hover:scale-105">Elite Boost</button>
-          </div>
-        </form>
-        <form data-price-id="price_1RTuAMI76TkBIa1x1mEVXL2M" class="group relative p-8 rounded-2xl bg-gray-800/60 border border-pink-500 hover:border-yellow-300 hover:bg-gray-800 transition overflow-hidden md:col-span-3">
-          <div class="absolute inset-0 opacity-20 bg-[conic-gradient(at_center,_#ff7af5,_#ffe57a,_#ff7af5)] animate-[spin_8s_linear_infinite]"></div>
-          <div class="relative flex flex-col items-center">
-            <div class="text-4xl font-black text-yellow-400 flex items-center gap-2 mb-2">
-              <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-8 h-8" alt="coin" />
-              15,000
-              <span class="ml-2 text-sm font-bold text-pink-300">+ 1,500 Bonus</span>
-            </div>
-            <div class="text-gray-400 text-lg">$150.00</div>
-            <button type="submit" class="mt-6 w-full py-3 rounded-full bg-gradient-to-r from-yellow-400 via-pink-500 to-purple-600 text-gray-900 font-bold shadow-lg group-hover:from-yellow-300 group-hover:via-yellow-400 group-hover:to-pink-500 transition-transform group-hover:scale-105">Go Platinum</button>
-          </div>
-        </form>
-      </div>
-      <div class="mt-10 flex flex-col items-center gap-2 text-gray-500 text-xs">
-        <span>Payments processed securely by</span>
-        <img src="https://stripe.com/img/v3/home/social.png" alt="Stripe Logo" class="h-5 w-auto" />
-      </div>
+    <div class="mt-6 flex flex-col items-center gap-1 text-xs text-gray-500">
+      <span>Payments processed securely by</span>
+      <img src="https://stripe.com/img/v3/home/social.png" alt="Stripe Logo" class="h-4 w-auto" />
     </div>
   </div>
 </div>

--- a/components/topup.html
+++ b/components/topup.html
@@ -1,5 +1,5 @@
 <!-- components/topup.html -->
-<div id="topup-popup" class="fixed inset-0 z-[200] hidden items-center justify-center bg-black/70 backdrop-blur-sm p-4">
+<div id="topup-popup" class="fixed inset-0 z-[200] hidden flex items-center justify-center bg-black/70 backdrop-blur-sm p-4">
   <div class="relative w-full max-w-xl rounded-xl bg-gray-900 p-6 text-white">
     <button id="close-topup" class="absolute top-4 right-4 text-2xl text-white/60 hover:text-white">&times;</button>
     <h2 class="mb-2 text-center text-3xl font-bold">Add Coins</h2>

--- a/components/topup.html
+++ b/components/topup.html
@@ -1,50 +1,75 @@
 <!-- components/topup.html -->
-<div id="topup-popup" class="fixed inset-0 z-[200] hidden items-center justify-center px-4 py-8 sm:py-12 backdrop-blur-sm bg-black/70 overflow-auto">
-  <div class="relative w-full max-w-md bg-gray-900 p-6 rounded-2xl border border-gray-700 shadow-xl">
-    <button id="close-topup" class="absolute top-4 right-4 text-gray-400 hover:text-white text-2xl font-bold">&times;</button>
-    <h2 class="text-center text-3xl font-bold text-white mb-2">Top Up Coins</h2>
-    <p class="text-center text-sm text-gray-400 mb-6">Choose a package to continue</p>
-    <div class="grid grid-cols-2 gap-4">
-      <form data-price-id="price_1RTtr3I76TkBIa1xiGafiRfX" class="rounded-xl border border-gray-700 p-4 text-center hover:border-purple-500 transition">
-        <div class="text-yellow-400 text-lg font-semibold flex justify-center items-center gap-1 mb-1">
-          2,000 <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4" alt="coin" />
-        </div>
-        <div class="text-gray-400 text-sm mb-3">$20.00</div>
-        <button type="submit" class="w-full py-2 bg-purple-600 hover:bg-purple-700 text-white text-sm font-semibold rounded-full">Select</button>
-      </form>
-      <form data-price-id="price_1RTtwSI76TkBIa1xmcHFALFX" class="rounded-xl border border-gray-700 p-4 text-center hover:border-purple-500 transition">
-        <div class="text-yellow-400 text-lg font-semibold flex justify-center items-center gap-1 mb-1">
-          3,000 <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4" alt="coin" />
-        </div>
-        <div class="text-gray-400 text-sm mb-3">$30.00</div>
-        <button type="submit" class="w-full py-2 bg-purple-600 hover:bg-purple-700 text-white text-sm font-semibold rounded-full">Select</button>
-      </form>
-      <form data-price-id="price_1RTu1cI76TkBIa1xGbcbubuY" class="rounded-xl border border-gray-700 p-4 text-center hover:border-purple-500 transition">
-        <div class="text-yellow-400 text-lg font-semibold flex justify-center items-center gap-1 mb-1">
-          5,000 <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4" alt="coin" />
-        </div>
-        <div class="text-gray-400 text-sm mb-3">$50.00</div>
-        <button type="submit" class="w-full py-2 bg-purple-600 hover:bg-purple-700 text-white text-sm font-semibold rounded-full">Select</button>
-      </form>
-      <form data-price-id="price_1RTu5pI76TkBIa1xqsVfedwB" class="rounded-xl border border-gray-700 p-4 text-center hover:border-purple-500 transition">
-        <div class="text-yellow-400 text-lg font-semibold flex justify-center items-center gap-1 mb-1">
-          10,000 <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4" alt="coin" />
-        </div>
-        <div class="text-gray-400 text-sm mb-3">$100.00</div>
-        <button type="submit" class="w-full py-2 bg-purple-600 hover:bg-purple-700 text-white text-sm font-semibold rounded-full">Select</button>
-      </form>
-      <form data-price-id="price_1RTuAMI76TkBIa1x1mEVXL2M" class="col-span-2 rounded-xl border border-pink-500 p-4 text-center hover:border-pink-400 transition">
-        <div class="text-yellow-400 text-lg font-semibold flex justify-center items-center gap-1 mb-1">
-          15,000 <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4" alt="coin" />
-          <span class="ml-1 text-xs text-pink-400 font-semibold">+ 1,500 Bonus</span>
-        </div>
-        <div class="text-gray-400 text-sm mb-3">$150.00</div>
-        <button type="submit" class="w-full py-2 bg-gradient-to-r from-pink-500 via-purple-600 to-purple-700 hover:brightness-110 text-white text-sm font-semibold rounded-full">Select</button>
-      </form>
+<div id="topup-popup" class="fixed inset-0 z-[200] hidden items-center justify-center p-4 bg-black/80 backdrop-blur-xl overflow-auto">
+  <div class="relative w-full max-w-5xl">
+    <div class="absolute inset-0 -z-10 animate-[spin_20s_linear_infinite]">
+      <div class="h-full w-full bg-gradient-to-br from-purple-700 via-pink-500 to-yellow-400 rounded-[2rem] opacity-30 blur-3xl"></div>
     </div>
-    <div class="mt-6 text-center text-xs text-gray-500 flex flex-col items-center gap-1">
-      <span>Secure payments by</span>
-      <img src="https://stripe.com/img/v3/home/social.png" alt="Stripe Logo" class="h-4 w-auto" />
+    <div class="relative bg-gray-900/90 rounded-[2rem] p-10 border border-gray-700 shadow-[0_0_50px_rgba(0,0,0,0.5)]">
+      <button id="close-topup" class="absolute top-6 right-6 text-3xl text-white/60 hover:text-white font-bold">&times;</button>
+      <h2 class="text-center text-5xl font-extrabold bg-gradient-to-r from-yellow-300 via-pink-400 to-purple-600 bg-clip-text text-transparent mb-4">Recharge Vault</h2>
+      <p class="text-center text-gray-300 mb-10">Select a vault to flood your balance with coins</p>
+      <div class="grid gap-6 md:grid-cols-3">
+        <form data-price-id="price_1RTtr3I76TkBIa1xiGafiRfX" class="group relative p-8 rounded-2xl bg-gray-800/60 border border-transparent hover:border-pink-500 hover:bg-gray-800 transition overflow-hidden">
+          <div class="absolute inset-0 opacity-10 group-hover:opacity-20 bg-[radial-gradient(circle_at_top,_#ff7af5,_transparent)]"></div>
+          <div class="relative flex flex-col items-center">
+            <div class="text-4xl font-black text-yellow-400 flex items-center gap-2 mb-2">
+              <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-8 h-8" alt="coin" />
+              2,000
+            </div>
+            <div class="text-gray-400 text-lg">$20.00</div>
+            <button type="submit" class="mt-6 w-full py-3 rounded-full bg-gradient-to-r from-pink-500 to-purple-600 text-white font-semibold shadow-lg group-hover:from-yellow-400 group-hover:to-pink-500 transition-transform group-hover:scale-105">Make it Rain</button>
+          </div>
+        </form>
+        <form data-price-id="price_1RTtwSI76TkBIa1xmcHFALFX" class="group relative p-8 rounded-2xl bg-gray-800/60 border border-transparent hover:border-pink-500 hover:bg-gray-800 transition overflow-hidden">
+          <div class="absolute inset-0 opacity-10 group-hover:opacity-20 bg-[radial-gradient(circle_at_top,_#ff7af5,_transparent)]"></div>
+          <div class="relative flex flex-col items-center">
+            <div class="text-4xl font-black text-yellow-400 flex items-center gap-2 mb-2">
+              <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-8 h-8" alt="coin" />
+              3,000
+            </div>
+            <div class="text-gray-400 text-lg">$30.00</div>
+            <button type="submit" class="mt-6 w-full py-3 rounded-full bg-gradient-to-r from-pink-500 to-purple-600 text-white font-semibold shadow-lg group-hover:from-yellow-400 group-hover:to-pink-500 transition-transform group-hover:scale-105">Boost Balance</button>
+          </div>
+        </form>
+        <form data-price-id="price_1RTu1cI76TkBIa1xGbcbubuY" class="group relative p-8 rounded-2xl bg-gray-800/60 border border-transparent hover:border-pink-500 hover:bg-gray-800 transition overflow-hidden">
+          <div class="absolute inset-0 opacity-10 group-hover:opacity-20 bg-[radial-gradient(circle_at_top,_#ff7af5,_transparent)]"></div>
+          <div class="relative flex flex-col items-center">
+            <div class="text-4xl font-black text-yellow-400 flex items-center gap-2 mb-2">
+              <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-8 h-8" alt="coin" />
+              5,000
+            </div>
+            <div class="text-gray-400 text-lg">$50.00</div>
+            <button type="submit" class="mt-6 w-full py-3 rounded-full bg-gradient-to-r from-pink-500 to-purple-600 text-white font-semibold shadow-lg group-hover:from-yellow-400 group-hover:to-pink-500 transition-transform group-hover:scale-105">Supercharge</button>
+          </div>
+        </form>
+        <form data-price-id="price_1RTu5pI76TkBIa1xqsVfedwB" class="group relative p-8 rounded-2xl bg-gray-800/60 border border-transparent hover:border-pink-500 hover:bg-gray-800 transition overflow-hidden md:col-span-2">
+          <div class="absolute inset-0 opacity-10 group-hover:opacity-20 bg-[radial-gradient(circle_at_top,_#ff7af5,_transparent)]"></div>
+          <div class="relative flex flex-col items-center">
+            <div class="text-4xl font-black text-yellow-400 flex items-center gap-2 mb-2">
+              <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-8 h-8" alt="coin" />
+              10,000
+            </div>
+            <div class="text-gray-400 text-lg">$100.00</div>
+            <button type="submit" class="mt-6 w-full py-3 rounded-full bg-gradient-to-r from-pink-500 to-purple-600 text-white font-semibold shadow-lg group-hover:from-yellow-400 group-hover:to-pink-500 transition-transform group-hover:scale-105">Elite Boost</button>
+          </div>
+        </form>
+        <form data-price-id="price_1RTuAMI76TkBIa1x1mEVXL2M" class="group relative p-8 rounded-2xl bg-gray-800/60 border border-pink-500 hover:border-yellow-300 hover:bg-gray-800 transition overflow-hidden md:col-span-3">
+          <div class="absolute inset-0 opacity-20 bg-[conic-gradient(at_center,_#ff7af5,_#ffe57a,_#ff7af5)] animate-[spin_8s_linear_infinite]"></div>
+          <div class="relative flex flex-col items-center">
+            <div class="text-4xl font-black text-yellow-400 flex items-center gap-2 mb-2">
+              <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-8 h-8" alt="coin" />
+              15,000
+              <span class="ml-2 text-sm font-bold text-pink-300">+ 1,500 Bonus</span>
+            </div>
+            <div class="text-gray-400 text-lg">$150.00</div>
+            <button type="submit" class="mt-6 w-full py-3 rounded-full bg-gradient-to-r from-yellow-400 via-pink-500 to-purple-600 text-gray-900 font-bold shadow-lg group-hover:from-yellow-300 group-hover:via-yellow-400 group-hover:to-pink-500 transition-transform group-hover:scale-105">Go Platinum</button>
+          </div>
+        </form>
+      </div>
+      <div class="mt-10 flex flex-col items-center gap-2 text-gray-500 text-xs">
+        <span>Payments processed securely by</span>
+        <img src="https://stripe.com/img/v3/home/social.png" alt="Stripe Logo" class="h-5 w-auto" />
+      </div>
     </div>
   </div>
 </div>

--- a/components/topup.html
+++ b/components/topup.html
@@ -1,6 +1,6 @@
 <!-- components/topup.html -->
 <div id="topup-popup" class="fixed inset-0 z-[200] hidden flex items-center justify-center bg-black/70 backdrop-blur-sm p-4">
-  <div class="relative w-full max-w-xl rounded-xl bg-gray-900 p-6 text-white">
+  <div class="relative w-full max-w-xl max-h-[90vh] overflow-y-auto rounded-xl bg-gray-900 p-4 text-white sm:p-6">
     <button id="close-topup" class="absolute top-4 right-4 text-2xl text-white/60 hover:text-white">&times;</button>
     <h2 class="mb-2 text-center text-3xl font-bold">Add Coins</h2>
     <p class="mb-6 text-center text-sm text-gray-400">Choose a package</p>


### PR DESCRIPTION
## Summary
- Rework top-up modal with cleaner layout, simplified colors, and concise package cards
- Add instructional text and maintain secure payment badge for clarity

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68984d4f9d548320a383b22257b1343b