### PR TITLE
feat: add futuristic spinner hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,41 +56,36 @@
 
 <header></header>
 
-<!-- Hero -->
-<section id="hero" class="relative overflow-hidden bg-gradient-to-b from-gray-900 via-purple-900 to-gray-900">
-  <div class="container mx-auto max-w-6xl px-6 pt-20 pb-16 flex flex-col gap-8">
+<!-- Futuristic Spinner Hero -->
+<section id="packly-hero" class="relative w-full overflow-hidden aspect-video">
+  <!-- Gradient background with faint Packly X shapes -->
+  <div class="absolute inset-0 bg-gradient-to-br from-[#020618] via-[#090d2d] to-[#1b0f3c]">
+    <div class="absolute inset-0 opacity-20 bg-[url('data:image/svg+xml;utf8,<svg xmlns=\'http://www.w3.org/2000/svg\' width=\'80\' height=\'80\' viewBox=\'0 0 100 100\' fill=\'none\' stroke=\'%236c5ce7\' stroke-width=\'5\' stroke-opacity=\'0.1\'><path d=\'M0 0L100 100M100 0L0 100\'/></svg>')] bg-[length:80px_80px] animate-bg-pan"></div>
+    <div class="absolute inset-0 pointer-events-none" id="hero-particles"></div>
+  </div>
 
-    <!-- Updates Bar -->
-    <div class="w-full bg-gradient-to-r from-yellow-500 via-pink-500 to-purple-600 text-white py-2 overflow-hidden rounded-xl shadow-md">
-      <div class="animate-marquee whitespace-nowrap text-sm font-medium flex items-center gap-12 px-4">
-        <span>📦 All cards are near mint unless specified otherwise</span>
-        <span class="flex items-center gap-1">
-          🪙 Sell back unwanted cards for coins
-          <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" alt="Coin" class="w-4 h-4 inline-block" />
-        </span>
-      </div>
-    </div>
+  <!-- Spotlight overlay -->
+  <div class="absolute inset-0 bg-[radial-gradient(ellipse_at_center,rgba(255,255,255,0.15)_0%,rgba(0,0,0,0.6)_70%)] pointer-events-none"></div>
 
-    <div class="flex flex-col md:flex-row items-center gap-12">
-      <!-- Text -->
-      <div class="flex-1 text-center md:text-left">
-        <h1 class="text-4xl md:text-5xl font-extrabold mb-4 text-white tracking-tight leading-tight opacity-0 animate-fade-up">
-          Virtual packs,<br>real cards. <span class="emoji-sparkle">✨</span>
-        </h1>
-        <p class="text-md md:text-lg text-gray-300 mb-6 leading-relaxed opacity-0 animate-fade-up">
-          Open digital packs. Win real cards. Start ripping in seconds. Packly.gg.
-        </p>
-        <a href="#cases" class="inline-block px-6 py-3 bg-yellow-400 text-black rounded-full font-semibold border border-yellow-500 hover:bg-yellow-300 transition-all duration-200 shadow-md hover:scale-105 opacity-0 animate-fade-up">
-          Grab A Pack
-        </a>
-      </div>
+  <!-- Optional mascot -->
+  <div class="absolute left-0 top-1/2 -translate-y-1/2 z-20">
+    <img src="https://placehold.co/120x180?text=Mascot" alt="Mascot" class="opacity-80" />
+  </div>
 
-      <!-- Pack Animation -->
-      <div class="flex-1 relative w-full h-64 md:h-80">
-        <div id="hero-pack-carousel" class="absolute inset-0"></div>
-      </div>
-    </div>
+  <!-- Headline placeholder -->
+  <div class="absolute top-6 w-full text-center z-20 pointer-events-none">
+    <h1 class="text-4xl md:text-5xl font-extrabold tracking-tight text-transparent">Discover, Open & Collect</h1>
+  </div>
 
+  <!-- Spinner -->
+  <div id="card-spinner" class="relative z-10 flex items-center justify-center h-full px-8">
+    <div id="spinner-track" class="flex gap-4 will-change-transform"></div>
+  </div>
+
+  <!-- CTA placeholder buttons -->
+  <div class="absolute bottom-6 w-full flex justify-center gap-4 z-20 pointer-events-none">
+    <div class="w-32 h-10 rounded-full border border-white/20 bg-white/10 backdrop-blur-sm"></div>
+    <div class="w-32 h-10 rounded-full border border-white/20 bg-white/10 backdrop-blur-sm"></div>
   </div>
 </section>
 
@@ -234,7 +229,7 @@ if (filterToggle && filterPanel) {
 <!-- Core Functional Scripts -->
 <script type="module" src="scripts/auth.js"></script>
 <script src="scripts/navbar.js"></script>
-<script src="scripts/hero.js"></script>
+<script src="scripts/hero-spinner.js"></script>
 <script src="scripts/features.js"></script>
 <script type="module" src="scripts/packs.js"></script>
   <script type="module">

--- a/scripts/hero-spinner.js
+++ b/scripts/hero-spinner.js
@@ -1,0 +1,64 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const track = document.getElementById('spinner-track');
+  const spinner = document.getElementById('card-spinner');
+  if (!track || !spinner) return;
+
+  const gradients = [
+    'linear-gradient(135deg,#6C5CE7,#09F)',
+    'linear-gradient(135deg,#09F,#FF4DD8)',
+    'linear-gradient(135deg,#FF4DD8,#6C5CE7)',
+    'linear-gradient(135deg,#6C5CE7,#FF4DD8)',
+    'linear-gradient(135deg,#09F,#6C5CE7)',
+    'linear-gradient(135deg,#FF4DD8,#09F)',
+    'linear-gradient(135deg,#1a1a4f,#6C5CE7)',
+    'linear-gradient(135deg,#0a0f2c,#09F)',
+    'linear-gradient(135deg,#1b0f3c,#FF4DD8)',
+    'linear-gradient(135deg,#6C5CE7,#1b0f3c)'
+  ];
+
+  gradients.forEach(g => {
+    const card = document.createElement('div');
+    card.className = 'card';
+    card.style.setProperty('--bg', g);
+    track.appendChild(card);
+  });
+
+  const cards = Array.from(track.children);
+  let index = -1;
+
+  function spin() {
+    index = (index + 1) % cards.length;
+    const cardWidth = cards[0].offsetWidth + 16;
+    const offset = cardWidth * index;
+    const containerWidth = spinner.offsetWidth;
+    const centerShift = containerWidth / 2 - cardWidth / 2;
+    track.style.transform = `translateX(${centerShift - offset}px)`;
+
+    cards.forEach(c => c.classList.remove('prev','next','center'));
+    const center = index;
+    const prev = (center - 1 + cards.length) % cards.length;
+    const next = (center + 1) % cards.length;
+    cards[center].classList.add('center');
+    cards[prev].classList.add('prev');
+    cards[next].classList.add('next');
+  }
+
+  spin();
+  setInterval(spin, 5000);
+
+  const particleContainer = document.getElementById('hero-particles');
+  if (particleContainer) {
+    const colors = ['#6C5CE7','#09F','#FF4DD8'];
+    for (let i=0; i<30; i++) {
+      const p = document.createElement('span');
+      p.className = 'particle';
+      p.style.top = Math.random()*100 + '%';
+      p.style.left = Math.random()*100 + '%';
+      p.style.animationDelay = (Math.random()*8) + 's';
+      const c = colors[Math.floor(Math.random()*colors.length)];
+      p.style.backgroundColor = c;
+      p.style.boxShadow = `0 0 6px ${c}`;
+      particleContainer.appendChild(p);
+    }
+  }
+});

--- a/styles/main.css
+++ b/styles/main.css
@@ -958,3 +958,89 @@ html {
   z-index: -1;
 }
 
+/* --- Futuristic 16:9 Hero --- */
+#packly-hero {
+  position: relative;
+  overflow: hidden;
+}
+
+#packly-hero .animate-bg-pan {
+  animation: bg-pan 30s linear infinite;
+}
+
+@keyframes bg-pan {
+  from { background-position: 0 0; }
+  to { background-position: -200px -200px; }
+}
+
+#card-spinner {
+  perspective: 1000px;
+}
+
+#spinner-track {
+  transition: transform 1.8s cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+
+#spinner-track .card {
+  width: 160px;
+  height: 220px;
+  border-radius: 12px;
+  background: var(--bg, linear-gradient(135deg,#6C5CE7,#09F));
+  box-shadow: 0 0 8px rgba(0,0,0,0.6);
+  position: relative;
+  flex-shrink: 0;
+  overflow: hidden;
+  transform-style: preserve-3d;
+  transition: transform 0.6s, filter 0.6s, box-shadow 0.6s;
+}
+
+#spinner-track .card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 30% 30%, rgba(255,255,255,0.2), transparent 60%);
+  mix-blend-mode: overlay;
+}
+
+#spinner-track .card.center {
+  filter: none;
+  transform: scale(1.15) translateZ(20px);
+  box-shadow: 0 0 25px #FF4DD8;
+}
+
+#spinner-track .card.center::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, transparent, rgba(255,255,255,0.7), transparent);
+  transform: translateX(-100%);
+  animation: shimmer 2s infinite;
+}
+
+@keyframes shimmer {
+  100% { transform: translateX(100%); }
+}
+
+#spinner-track .card.prev {
+  transform: rotateY(20deg) scale(0.9);
+  filter: blur(2px);
+}
+
+#spinner-track .card.next {
+  transform: rotateY(-20deg) scale(0.9);
+  filter: blur(2px);
+}
+
+.particle {
+  position: absolute;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  animation: particle-float 8s linear infinite;
+}
+
+@keyframes particle-float {
+  from { transform: translateY(0); opacity: 1; }
+  to { transform: translateY(-40px); opacity: 0; }
+}
+


### PR DESCRIPTION
## Summary
- replace homepage hero with full-width 16:9 spinner carousel demo
- style hero with gradient background, glowing particles, and neon card effects
- add spinner logic and floating particle generator

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689853885fa4832099c193c3884bf2dc