### PR TITLE
feat: swap homepage hero carousel for rare-card spinner

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,40 +57,43 @@
 <header></header>
 
 <!-- Hero -->
-<section id="hero" class="relative overflow-hidden bg-gradient-to-b from-gray-900 via-purple-900 to-gray-900">
-  <div class="container mx-auto max-w-6xl px-6 pt-20 pb-16 flex flex-col gap-8">
+<section id="hero" class="hero-bg relative w-full aspect-[16/9] flex items-center justify-center">
+  <!-- HEADLINE -->
+  <div class="absolute top-16 w-full px-6 text-center">
+    <h1 class="mx-auto max-w-5xl text-4xl md:text-6xl font-extrabold tracking-tight leading-tight">
+      DISCOVER, OPEN & COLLECT
+      <span class="block text-transparent bg-clip-text bg-gradient-to-r from-[#6C5CE7] via-[#09F] to-[#FF4DD8]">
+        POKÉMON CARDS
+      </span>
+    </h1>
+    <p class="mt-4 opacity-75 text-lg">Packly.gg — premium case opening with provably fair spins.</p>
+  </div>
 
-    <!-- Updates Bar -->
-    <div class="w-full bg-gradient-to-r from-yellow-500 via-pink-500 to-purple-600 text-white py-2 overflow-hidden rounded-xl shadow-md">
-      <div class="animate-marquee whitespace-nowrap text-sm font-medium flex items-center gap-12 px-4">
-        <span>📦 All cards are near mint unless specified otherwise</span>
-        <span class="flex items-center gap-1">
-          🪙 Sell back unwanted cards for coins
-          <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" alt="Coin" class="w-4 h-4 inline-block" />
-        </span>
-      </div>
+  <!-- SPINNER -->
+  <div class="relative w-full max-w-4xl mt-12 px-4">
+    <div class="spin-viewport relative mx-auto overflow-hidden rounded-2xl border border-white/10 bg-black/20 backdrop-blur-sm p-4">
+      <div id="spinTrack" class="spin-track flex gap-4 will-change-transform"></div>
+      <div class="center-pin"></div>
     </div>
-
-    <div class="flex flex-col md:flex-row items-center gap-12">
-      <!-- Text -->
-      <div class="flex-1 text-center md:text-left">
-        <h1 class="text-4xl md:text-5xl font-extrabold mb-4 text-white tracking-tight leading-tight opacity-0 animate-fade-up">
-          Virtual packs,<br>real cards. <span class="emoji-sparkle">✨</span>
-        </h1>
-        <p class="text-md md:text-lg text-gray-300 mb-6 leading-relaxed opacity-0 animate-fade-up">
-          Open digital packs. Win real cards. Start ripping in seconds. Packly.gg.
-        </p>
-        <a href="#cases" class="inline-block px-6 py-3 bg-yellow-400 text-black rounded-full font-semibold border border-yellow-500 hover:bg-yellow-300 transition-all duration-200 shadow-md hover:scale-105 opacity-0 animate-fade-up">
-          Grab A Pack
-        </a>
-      </div>
-
-      <!-- Pack Animation -->
-      <div class="flex-1 relative w-full h-64 md:h-80">
-        <div id="hero-pack-carousel" class="absolute inset-0"></div>
-      </div>
+    <!-- CTA placeholders -->
+    <div class="mt-8 flex items-center justify-center gap-3">
+      <a href="/signup" class="btn-ghost rounded-xl px-6 py-3 text-lg font-semibold hover:bg-white/10 transition">
+        Sign up now
+      </a>
+      <a href="/auth/google" class="btn-ghost rounded-xl px-6 py-3 text-lg font-semibold hover:bg-white/10 transition">
+        Continue with Google
+      </a>
     </div>
+  </div>
 
+  <!-- SUBTLE STARDUST -->
+  <div class="pointer-events-none absolute inset-0">
+    <div class="absolute inset-0 animate-pulse opacity-30" style="
+      background: radial-gradient(2px 2px at 20% 30%, #fff 50%, transparent 55%),
+                  radial-gradient(1.5px 1.5px at 60% 40%, #fff 50%, transparent 55%),
+                  radial-gradient(1.7px 1.7px at 80% 70%, #fff 50%, transparent 55%),
+                  radial-gradient(1.2px 1.2px at 35% 80%, #fff 50%, transparent 55%);
+      "></div>
   </div>
 </section>
 

--- a/scripts/hero.js
+++ b/scripts/hero.js
@@ -1,51 +1,121 @@
-window.addEventListener('DOMContentLoaded', () => {
-  const title = document.querySelector('h1.animate-fade-up');
-  const paragraph = document.querySelector('p.animate-fade-up');
-  const cta = document.querySelector('#hero a.animate-fade-up');
+// Demo spinner that fetches pack prizes and always lands on a rare card
 
-  if (title) setTimeout(() => title.classList.remove('opacity-0'), 200);
-  if (paragraph) setTimeout(() => paragraph.classList.remove('opacity-0'), 400);
-  if (cta) setTimeout(() => cta.classList.remove('opacity-0'), 600);
+document.addEventListener('DOMContentLoaded', () => {
+  const CARD_W = 160;
+  const GAP = 16;
+  const TILE_W = CARD_W + GAP;
 
-  const carousel = document.getElementById('hero-pack-carousel');
-  const casesContainer = document.getElementById('cases-container');
+  const track = document.getElementById('spinTrack');
+  const cards = [];
+  let tiles = [];
 
-  function buildCarousel() {
-    const packImgs = casesContainer?.querySelectorAll('.case-card-img') || [];
-    if (!packImgs.length || !carousel) return;
+  let offset = 0;
+  let baseSpeed = 0.6;
+  let speed = baseSpeed;
+  let demoLock = false;
+  let lastTs = performance.now();
+  let tilesCount = 0;
+  let trackPx = 0;
 
-    Array.from(packImgs).slice(0, 5).forEach((img, i) => {
-      const clone = document.createElement('img');
-      clone.src = img.src;
-      clone.alt = img.alt || 'Pack';
-      clone.className = 'hero-pack-img';
-      if (i === 0) clone.classList.add('active');
-      carousel.appendChild(clone);
+  function buildTrack(prizes) {
+    const tripled = [...prizes, ...prizes, ...prizes];
+    tripled.forEach(p => {
+      const tile = document.createElement('div');
+      tile.className = 'card select-none';
+      tile.style.flex = '0 0 auto';
+      tile.style.width = CARD_W + 'px';
+      tile.innerHTML = `<img src="${p.img}" alt="" loading="lazy" draggable="false">`;
+      track.appendChild(tile);
+      cards.push(p);
     });
-
-    startCarousel();
+    tiles = Array.from(track.children);
+    tilesCount = tiles.length;
+    trackPx = tilesCount * TILE_W;
   }
 
-  function startCarousel() {
-    const slides = carousel?.querySelectorAll('img') || [];
-    if (slides.length <= 1) return;
-
-    let index = 0;
-    setInterval(() => {
-      slides[index].classList.remove('active');
-      index = (index + 1) % slides.length;
-      slides[index].classList.add('active');
-    }, 3000);
+  function loop(ts) {
+    const dt = ts - lastTs;
+    lastTs = ts;
+    offset -= speed * dt;
+    if (offset < -trackPx) offset += trackPx;
+    track.style.transform = `translateX(${offset}px)`;
+    requestAnimationFrame(loop);
   }
 
-  if (casesContainer) {
-    const observer = new MutationObserver((mutations, obs) => {
-      if (casesContainer.querySelector('.case-card-img')) {
-        obs.disconnect();
-        buildCarousel();
+  function centerTargetIndex(idx) {
+    const viewport = track.parentElement.getBoundingClientRect();
+    const heroCenterX = viewport.width / 2;
+    const tileCenterX = idx * TILE_W + CARD_W / 2;
+    return heroCenterX - tileCenterX;
+  }
+
+  async function demoOpen() {
+    if (demoLock) return;
+    demoLock = true;
+
+    const rares = cards
+      .map((c, i) => ({ i, rarity: c.rarity }))
+      .filter(o => o.rarity === 'rare');
+    if (!rares.length) {
+      demoLock = false;
+      return;
+    }
+    const idx = rares[Math.floor(Math.random() * rares.length)].i;
+
+    speed = baseSpeed * 8;
+    await new Promise(r => setTimeout(r, 600));
+
+    const targetOffset = centerTargetIndex(idx);
+    const startOffset = offset;
+    const delta = startOffset - targetOffset;
+    const duration = 1600;
+    const start = performance.now();
+    speed = 0;
+
+    function easeOutCubic(t) {
+      return 1 - Math.pow(1 - t, 3);
+    }
+
+    function animate(ts) {
+      const t = Math.min(1, (ts - start) / duration);
+      const eased = easeOutCubic(t);
+      offset = startOffset - delta * eased;
+      if (t < 1) {
+        requestAnimationFrame(animate);
+      } else {
+        tiles.forEach(tile => tile.classList.remove('glow'));
+        tiles[idx % tiles.length].classList.add('glow');
+        setTimeout(() => { speed = baseSpeed; }, 1200);
+        demoLock = false;
       }
-    });
-    observer.observe(casesContainer, { childList: true, subtree: true });
+    }
+    requestAnimationFrame(animate);
   }
+
+  function scheduleDemo() {
+    demoOpen();
+    setInterval(demoOpen, 5000);
+  }
+
+  function fetchPrizes() {
+    return firebase.database().ref('cases').once('value').then(snap => {
+      const data = snap.val() || {};
+      const prizes = [];
+      Object.values(data).forEach(caseInfo => {
+        (caseInfo.prizes || []).forEach(p => {
+          const rarity = (p.rarity || '').toLowerCase();
+          prizes.push({ img: p.image, rarity });
+        });
+      });
+      return prizes;
+    });
+  }
+
+  fetchPrizes().then(prizes => {
+    if (!prizes.length) return;
+    buildTrack(prizes.slice(0, 12));
+    requestAnimationFrame(loop);
+    scheduleDemo();
+  });
 });
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -958,3 +958,97 @@ html {
   z-index: -1;
 }
 
+/* --- Hero Spinner Demo --- */
+.hero-bg {
+  background: radial-gradient(1200px 600px at 50% 20%, rgba(108,92,231,0.25), transparent 60%),
+              radial-gradient(900px 500px at 20% 80%, rgba(0,153,255,0.18), transparent 60%),
+              radial-gradient(900px 500px at 80% 80%, rgba(255,77,216,0.18), transparent 60%),
+              linear-gradient(180deg, #0c0f1a 0%, #0a0d18 60%, #070a14 100%);
+  position: relative;
+  overflow: hidden;
+}
+.hero-bg:before, .hero-bg:after {
+  content: "";
+  position: absolute;
+  inset: -30%;
+  background:
+    repeating-linear-gradient(120deg, rgba(255,255,255,0.02) 0 2px, transparent 2px 8px);
+  filter: blur(2px);
+  opacity: .4;
+  pointer-events: none;
+  transform: rotate(5deg);
+}
+.hero-bg:after {
+  transform: rotate(-8deg) scale(1.2);
+  opacity: .25;
+}
+
+.spin-viewport {
+  mask-image: linear-gradient(90deg, transparent 0%, black 14%, black 86%, transparent 100%);
+  -webkit-mask-image: linear-gradient(90deg, transparent 0%, black 14%, black 86%, transparent 100%);
+}
+.spin-track {
+  will-change: transform;
+}
+
+.card {
+  width: 160px;
+  height: 232px;
+  border-radius: 12px;
+  background: linear-gradient(180deg,#1a1f2f,#121622);
+  box-shadow:
+    0 12px 30px rgba(0,0,0,.55),
+    inset 0 0 0 1px rgba(255,255,255,.05);
+  position: relative;
+  overflow: hidden;
+}
+.card::after {
+  content: "";
+  position: absolute; inset: 0;
+  background: conic-gradient(from 180deg at 50% 50%,
+    rgba(255,255,255,0) 0deg, rgba(255,255,255,0.15) 25deg,
+    rgba(255,255,255,0) 60deg, rgba(255,255,255,0.1) 120deg,
+    rgba(255,255,255,0) 200deg);
+  mix-blend-mode: screen;
+  opacity: .75;
+  pointer-events: none;
+}
+.card img {
+  width: 100%; height: 100%; object-fit: cover; display: block;
+  filter: saturate(1.08) contrast(1.05);
+}
+.glow {
+  box-shadow:
+    0 0 0 2px rgba(108,92,231,.6),
+    0 0 32px 8px rgba(108,92,231,.35),
+    0 0 80px 16px rgba(9,153,255,.18);
+  transform: scale(1.04) translateY(-2px);
+}
+
+.center-pin {
+  position: absolute; left: 50%; top: 50%;
+  width: 60px; height: 60px;
+  border-radius: 50%; transform: translate(-50%,-50%);
+  box-shadow: inset 0 0 0 2px rgba(255,255,255,.08),
+              0 0 0 2px rgba(255,77,216,.18);
+  pointer-events: none;
+}
+.center-pin:after {
+  content: "";
+  position: absolute; left: 50%; top: -30px;
+  width: 0; height: 0; transform: translateX(-50%);
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+  border-bottom: 12px solid rgba(255,255,255,0.9);
+  filter: drop-shadow(0 2px 6px rgba(255,255,255,.45));
+}
+
+.btn-ghost {
+  backdrop-filter: blur(6px);
+  border: 1px solid rgba(255,255,255,.12);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spin-track { transition: none !important; }
+}
+


### PR DESCRIPTION
## Summary
- replace homepage hero carousel markup with full-width spinner demo without touching other sections
- reuse `hero.js` for spinner logic, fetching pack prizes and easing to a chosen rare card
- drop `hero-spinner.js` now that spinner script lives in `hero.js`
- fix layout by enforcing 16:9 hero aspect and shrinking spinner dimensions for consistency

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689853885fa4832099c193c3884bf2dc