### PR TITLE
Organize pack listings with category tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,6 +173,14 @@
   <button id="clear-filters" class="text-sm text-gray-400 hover:text-white ml-auto">Clear Filters</button>
 </div>
 
+ <!-- Category Tabs -->
+ <div id="category-tabs" class="flex flex-wrap justify-center gap-2 mb-6">
+   <button data-category="all" class="category-tab active">All</button>
+   <button data-category="free" class="category-tab">Free</button>
+   <button data-category="budget" class="category-tab">Budget (≤50)</button>
+   <button data-category="premium" class="category-tab">Premium (>50)</button>
+ </div>
+
     <!-- Cases Grid -->
     <div id="cases-container" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 sm:gap-6"></div>
   </div>

--- a/scripts/filters.js
+++ b/scripts/filters.js
@@ -1,6 +1,7 @@
 // scripts/filters.js
 
 export function setupFilters(cases, renderFn, getUserBalanceFn) {
+  let currentCases = cases;
   const searchInput = document.getElementById("search-box");
   const minInput = document.getElementById("min-price");
   const maxInput = document.getElementById("max-price");
@@ -63,7 +64,7 @@ export function setupFilters(cases, renderFn, getUserBalanceFn) {
   }
 
   function applyFilters() {
-    let filtered = [...cases];
+    let filtered = [...currentCases];
 
     const search = searchInput?.value.toLowerCase() || "";
     const min = parseFloat(minInput?.value) || 0;
@@ -101,5 +102,12 @@ export function setupFilters(cases, renderFn, getUserBalanceFn) {
   });
 
   applyFilters();
+
+  return {
+    updateCases(newCases) {
+      currentCases = newCases;
+      applyFilters();
+    }
+  };
 }
 

--- a/scripts/packs.js
+++ b/scripts/packs.js
@@ -69,6 +69,27 @@ function renderCases(caseList) {
   });
 }
 
+function setupCategoryTabs(filterControls) {
+  const tabs = document.querySelectorAll('.category-tab');
+  const budgetLimit = 50;
+  tabs.forEach(tab => {
+    tab.addEventListener('click', () => {
+      tabs.forEach(t => t.classList.remove('active'));
+      tab.classList.add('active');
+      const category = tab.dataset.category;
+      let filtered = [...allCases];
+      if (category === 'free') {
+        filtered = allCases.filter(c => c.isFree);
+      } else if (category === 'budget') {
+        filtered = allCases.filter(c => !c.isFree && parseFloat(c.price) <= budgetLimit);
+      } else if (category === 'premium') {
+        filtered = allCases.filter(c => parseFloat(c.price) > budgetLimit);
+      }
+      filterControls.updateCases(filtered);
+    });
+  });
+}
+
 function loadCases() {
   firebase.auth().onAuthStateChanged(user => {
     const dbRef = firebase.database().ref("cases");
@@ -95,7 +116,8 @@ function loadCases() {
         return parseFloat(document.getElementById("balance-amount")?.innerText.replace(/,/g, "")) || 0;
       };
 
-      setupFilters(allCases, renderCases, getUserBalance);
+      const filterControls = setupFilters(allCases, renderCases, getUserBalance);
+      setupCategoryTabs(filterControls);
     });
   });
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -991,3 +991,24 @@ html {
   z-index: -1;
 }
 
+/* Category tabs */
+.category-tab {
+  background-color: #1f2937;
+  color: #ffffff;
+  border: 1px solid #374151;
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.category-tab:hover {
+  background-color: #374151;
+}
+
+.category-tab.active {
+  background-color: #facc15;
+  border-color: #facc15;
+  color: #000;
+}
+


### PR DESCRIPTION
## Summary
- add category tabs above pack grid for easier navigation
- style category tabs and update filtering logic
- enable packs.js and filters.js to filter by selected category

## Testing
- `npm test` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6898d92c4db083208dd089c7c6126b64