### PR TITLE
Organize pack listings with icon category tabs

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -91,6 +91,14 @@
   <input type="text" id="case-tag" class="w-full p-2 rounded" placeholder="Optional badge">
 </div>
             <div>
+  <label class="block mb-1">Categories:</label>
+  <div class="flex flex-wrap gap-4">
+    <label class="inline-flex items-center"><input type="checkbox" id="case-new" class="mr-2"> <i class="fa-solid fa-bolt mr-1 text-yellow-400"></i> New</label>
+    <label class="inline-flex items-center"><input type="checkbox" id="case-featured" class="mr-2"> <i class="fa-solid fa-star mr-1 text-yellow-400"></i> Featured</label>
+    <label class="inline-flex items-center"><input type="checkbox" id="case-starter" class="mr-2"> <i class="fa-solid fa-seedling mr-1 text-green-400"></i> Starter</label>
+  </div>
+</div>
+            <div>
   <label>Spice Level:</label>
   <select id="case-spice" class="w-full p-2 rounded">
     <option value="">None</option>
@@ -408,6 +416,9 @@ function adminReply(event, caseId) {
         document.getElementById('case-price').value = data.price;
         document.getElementById('case-free').checked = !!data.isFree;
         document.getElementById('case-tag').value = data.tag || '';
+        document.getElementById('case-new').checked = !!(data.categories && data.categories.new);
+        document.getElementById('case-featured').checked = !!(data.categories && data.categories.featured);
+        document.getElementById('case-starter').checked = !!(data.categories && data.categories.starter);
         document.getElementById('case-spice').value = data.spiceLevel || '';
         prizesSection.innerHTML = '<h3 class="text-xl">Prizes:</h3><button type="button" onclick="addPrize()" class="mb-2 px-4 py-2 bg-green-600 hover:bg-green-700 rounded">+ Add Prize</button>';
         if (data.prizes) Object.values(data.prizes).forEach(p => addPrize(p));
@@ -445,6 +456,11 @@ function adminReply(event, caseId) {
       const price = isFree ? 0 : parseFloat(document.getElementById('case-price').value) || 0;
       const tag = document.getElementById('case-tag').value.trim();
       const spiceLevel = document.getElementById('case-spice').value.trim();
+      const categories = {
+        new: document.getElementById('case-new').checked,
+        featured: document.getElementById('case-featured').checked,
+        starter: document.getElementById('case-starter').checked
+      };
       const prizesElements = prizesSection.querySelectorAll('div.prize-block');
       const prizes = {};
       prizesElements.forEach((div, idx) => {
@@ -456,11 +472,14 @@ function adminReply(event, caseId) {
           odds: parseFloat(div.querySelector('.prize-odds').value) || 0
         };
       });
-     db.ref('cases/' + id).set({ name, image, price, tag, spiceLevel, isFree, prizes }).then(() => {
+     db.ref('cases/' + id).set({ name, image, price, tag, spiceLevel, isFree, prizes, categories }).then(() => {
         caseForm.reset();
         previewImage('');
        document.getElementById('case-tag').value = '';
        document.getElementById('case-free').checked = false;
+       document.getElementById('case-new').checked = false;
+       document.getElementById('case-featured').checked = false;
+       document.getElementById('case-starter').checked = false;
         prizesSection.innerHTML = '<h3 class="text-xl">Prizes:</h3><button type="button" onclick="addPrize()" class="mb-2 px-4 py-2 bg-green-600 hover:bg-green-700 rounded">+ Add Prize</button>';
         document.getElementById('form-title').innerText = 'Add / Edit Case';
         cancelEditBtn.classList.add('hidden');
@@ -473,6 +492,9 @@ function cancelEdit() {
   previewImage('');
   document.getElementById('case-tag').value = '';
   document.getElementById('case-free').checked = false;
+  document.getElementById('case-new').checked = false;
+  document.getElementById('case-featured').checked = false;
+  document.getElementById('case-starter').checked = false;
   prizesSection.innerHTML = '<h3 class="text-xl">Prizes:</h3><button type="button" onclick="addPrize()" class="mb-2 px-4 py-2 bg-green-600 hover:bg-green-700 rounded">+ Add Prize</button>';
   document.getElementById('form-title').innerText = 'Add / Edit Case';
   cancelEditBtn.classList.add('hidden');

--- a/index.html
+++ b/index.html
@@ -173,6 +173,30 @@
   <button id="clear-filters" class="text-sm text-gray-400 hover:text-white ml-auto">Clear Filters</button>
 </div>
 
+ <!-- Category Tabs -->
+ <div id="category-tabs" class="flex flex-wrap justify-center gap-2 mb-6">
+   <button data-category="all" class="category-tab active" title="All">
+     <i class="fa-solid fa-layer-group"></i>
+     <span class="sr-only">All</span>
+   </button>
+   <button data-category="new" class="category-tab" title="New">
+     <i class="fa-solid fa-bolt"></i>
+     <span class="sr-only">New</span>
+   </button>
+   <button data-category="featured" class="category-tab" title="Featured">
+     <i class="fa-solid fa-star"></i>
+     <span class="sr-only">Featured</span>
+   </button>
+   <button data-category="starter" class="category-tab" title="Starter">
+     <i class="fa-solid fa-seedling"></i>
+     <span class="sr-only">Starter</span>
+   </button>
+   <button data-category="other" class="category-tab" title="Other Boxes">
+     <i class="fa-solid fa-box"></i>
+     <span class="sr-only">Other Boxes</span>
+   </button>
+ </div>
+
     <!-- Cases Grid -->
     <div id="cases-container" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 sm:gap-6"></div>
   </div>

--- a/scripts/filters.js
+++ b/scripts/filters.js
@@ -1,6 +1,7 @@
 // scripts/filters.js
 
 export function setupFilters(cases, renderFn, getUserBalanceFn) {
+  let currentCases = cases;
   const searchInput = document.getElementById("search-box");
   const minInput = document.getElementById("min-price");
   const maxInput = document.getElementById("max-price");
@@ -63,7 +64,7 @@ export function setupFilters(cases, renderFn, getUserBalanceFn) {
   }
 
   function applyFilters() {
-    let filtered = [...cases];
+    let filtered = [...currentCases];
 
     const search = searchInput?.value.toLowerCase() || "";
     const min = parseFloat(minInput?.value) || 0;
@@ -101,5 +102,12 @@ export function setupFilters(cases, renderFn, getUserBalanceFn) {
   });
 
   applyFilters();
+
+  return {
+    updateCases(newCases) {
+      currentCases = newCases;
+      applyFilters();
+    }
+  };
 }
 

--- a/scripts/packs.js
+++ b/scripts/packs.js
@@ -69,6 +69,28 @@ function renderCases(caseList) {
   });
 }
 
+function setupCategoryTabs(filterControls) {
+  const tabs = document.querySelectorAll('.category-tab');
+  tabs.forEach(tab => {
+    tab.addEventListener('click', () => {
+      tabs.forEach(t => t.classList.remove('active'));
+      tab.classList.add('active');
+      const category = tab.dataset.category;
+      let filtered = [...allCases];
+      if (category === 'new') {
+        filtered = allCases.filter(c => c.categories?.new);
+      } else if (category === 'featured') {
+        filtered = allCases.filter(c => c.categories?.featured);
+      } else if (category === 'starter') {
+        filtered = allCases.filter(c => c.categories?.starter);
+      } else if (category === 'other') {
+        filtered = allCases.filter(c => !(c.categories?.new || c.categories?.featured || c.categories?.starter));
+      }
+      filterControls.updateCases(filtered);
+    });
+  });
+}
+
 function loadCases() {
   firebase.auth().onAuthStateChanged(user => {
     const dbRef = firebase.database().ref("cases");
@@ -95,7 +117,8 @@ function loadCases() {
         return parseFloat(document.getElementById("balance-amount")?.innerText.replace(/,/g, "")) || 0;
       };
 
-      setupFilters(allCases, renderCases, getUserBalance);
+      const filterControls = setupFilters(allCases, renderCases, getUserBalance);
+      setupCategoryTabs(filterControls);
     });
   });
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -991,3 +991,34 @@ html {
   z-index: -1;
 }
 
+/* Category tabs */
+.category-tab {
+  background-color: #1f2937;
+  color: #ffffff;
+  border: 1px solid #374151;
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.category-tab:hover {
+  background-color: #374151;
+}
+
+.category-tab.active {
+  background-color: #facc15;
+  border-color: #facc15;
+  color: #000;
+}
+
+.category-tab i {
+  pointer-events: none;
+}
+


### PR DESCRIPTION
## Summary
- replace text tabs with icon buttons for new, featured, starter, and other pack categories
- style icon tabs and update filtering logic for category-based display
- enable admin panel to manage category tags for each case

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898d92c4db083208dd089c7c6126b64