### PR TITLE
Replace pepper labels with color-coded icons

### DIFF
--- a/scripts/packs.js
+++ b/scripts/packs.js
@@ -3,16 +3,17 @@ import { setupFilters } from './filters.js';
 let allCases = [];
 function getPepperHTML(spiceLevel) {
   const map = {
-    easy: { class: "spice-label spice-easy", label: "Easy 🌶️" },
-    medium: { class: "spice-label spice-medium", label: "Medium 🌶️🌶️" },
-    hard: { class: "spice-label spice-hard", label: "Hard 🌶️🌶️🌶️" }
+    easy: { class: "spice-label spice-easy" },
+    medium: { class: "spice-label spice-medium" },
+    hard: { class: "spice-label spice-hard" }
   };
 
   if (!map[spiceLevel]) return "";
 
-  const { class: cls, label } = map[spiceLevel];
+  const { class: cls } = map[spiceLevel];
+  const iconUrl = "https://cdn.jsdelivr.net/npm/openmoji@14.0.0/color/svg/1F336.svg";
 
-  return `<div class="${cls}">${label}</div>`;
+  return `<div class="${cls}"><img src="${iconUrl}" alt="${spiceLevel} pepper" class="pepper-icon"></div>`;
 }
 function renderCases(caseList) {
   const casesContainer = document.getElementById("cases-container");

--- a/styles/main.css
+++ b/styles/main.css
@@ -809,16 +809,17 @@ html {
   position: absolute;
   top: 0.5rem;
   right: 0.5rem;
-  background-color: rgba(0, 0, 0, 0.5);
-  font-size: 0.75rem;
-  font-weight: 700;
-  padding: 0.25rem 0.5rem;
-  border-radius: 9999px;
   z-index: 10;
 }
-.spice-easy { color: #4ade80; }
-.spice-medium { color: #fb923c; }
-.spice-hard { color: #ef4444; }
+
+.pepper-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+.spice-easy .pepper-icon { filter: hue-rotate(120deg); }
+.spice-medium .pepper-icon { filter: hue-rotate(45deg); }
+.spice-hard .pepper-icon { filter: none; }
 
 .open-button {
   margin-top: 0.5rem;
@@ -837,10 +838,13 @@ html {
 }
 
 @media (max-width: 640px) {
-  .pack-tag,
-  .spice-label {
+  .pack-tag {
     font-size: 0.65rem;
     padding: 0.125rem 0.375rem;
+  }
+  .pepper-icon {
+    width: 0.75rem;
+    height: 0.75rem;
   }
   .open-button {
     padding: 0.375rem 0;


### PR DESCRIPTION
## Summary
- replace pepper text labels with standalone pepper icon on pack cards
- add CSS to color pepper icons for easy, medium, and hard levels

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898dffd235c8320b35a26432dfc1b6e