### PR TITLE
Add Wonder Pick card selection game mode

### DIFF
--- a/scripts/packs.js
+++ b/scripts/packs.js
@@ -36,13 +36,15 @@ function renderCases(caseList) {
 
     const imgId = `img-${c.id}`;
 
+    const openLink = c.wonderPick ? `wonder-pick.html?id=${c.id}` : `case.html?id=${c.id}`;
+
     casesContainer.innerHTML += `
       <div class="relative p-3 sm:p-4 bg-gray-800 rounded-lg shadow-md hover:shadow-lg transition">
         ${tagHTML}
         ${pepperHTML}
         <img src="${packImg}" id="${imgId}" class="case-card-img mb-2 transition-all duration-300">
         <h3 class="mt-2 font-semibold text-white text-sm sm:text-base">${c.name}</h3>
-        <a href="case.html?id=${c.id}" class="open-button glow-button text-xs sm:text-sm whitespace-nowrap">
+        <a href="${openLink}" class="open-button glow-button text-xs sm:text-sm whitespace-nowrap">
     Open for ${priceLabel}
     ${priceIcon}
   </a>

--- a/scripts/wonderpick.js
+++ b/scripts/wonderpick.js
@@ -1,0 +1,126 @@
+let currentPack = null;
+let currentPrize = null;
+
+function renderPack(data) {
+  document.getElementById('pack-name').textContent = data.name;
+  document.getElementById('pack-image').src = data.image;
+  const prizeList = document.getElementById('prize-list');
+  prizeList.innerHTML = '';
+  Object.values(data.prizes || {}).slice(0,5).forEach(p => {
+    const img = document.createElement('img');
+    img.src = p.image;
+    img.alt = p.name;
+    img.className = 'w-20 h-20 object-contain rounded';
+    prizeList.appendChild(img);
+  });
+}
+
+async function loadPack() {
+  const params = new URLSearchParams(window.location.search);
+  const id = params.get('id');
+  if (!id) return;
+  const snap = await firebase.database().ref('cases/' + id).once('value');
+  currentPack = snap.val();
+  if (currentPack) renderPack(currentPack);
+}
+
+async function openPack() {
+  if (!currentPack) return;
+  const user = firebase.auth().currentUser;
+  if (!user) return alert('You must be logged in.');
+
+  const fairSnap = await firebase.database().ref('users/' + user.uid + '/provablyFair').once('value');
+  const fairData = fairSnap.val();
+  if (!fairData) return alert('Provably fair data missing.');
+  const { serverSeed, clientSeed, nonce } = fairData;
+
+  const prizes = Object.values(currentPack.prizes || {}).sort((a,b) => a.odds - b.odds);
+  const totalOdds = prizes.reduce((sum,p) => sum + (p.odds || 0), 0);
+
+  const hashBuffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(`${serverSeed}:${clientSeed}:${nonce || 0}`));
+  const hashHex = Array.from(new Uint8Array(hashBuffer)).map(b => b.toString(16).padStart(2,'0')).join('');
+  const rand = parseInt(hashHex.substring(0,8),16) / 0xffffffff;
+
+  let cumulative = 0;
+  let winningPrize = prizes[prizes.length - 1];
+  for (const p of prizes) {
+    cumulative += p.odds || 0;
+    if (rand * totalOdds < cumulative) { winningPrize = p; break; }
+  }
+
+  const unboxData = {
+    name: winningPrize.name,
+    image: winningPrize.image,
+    rarity: winningPrize.rarity,
+    value: winningPrize.value,
+    timestamp: Date.now(),
+    sold: false
+  };
+  const invRef = firebase.database().ref('users/' + user.uid + '/inventory').push();
+  await invRef.set(unboxData);
+  await firebase.database().ref('users/' + user.uid + '/unboxHistory/' + invRef.key).set(unboxData);
+  currentPrize = { ...winningPrize, key: invRef.key };
+
+  document.getElementById('pack-section').classList.add('hidden');
+  document.getElementById('selection-section').classList.remove('hidden');
+  setupCards();
+}
+
+function setupCards() {
+  const container = document.getElementById('card-container');
+  container.innerHTML = '';
+  const backImg = currentPack.cardBack || 'https://via.placeholder.com/160x160?text=Back';
+  for (let i=0; i<5; i++) {
+    const card = document.createElement('div');
+    card.className = 'flip-card';
+    card.style.transform = `rotate(${(i-2)*10}deg)`;
+    card.innerHTML = `
+      <div class="flip-card-inner">
+        <img class="flip-card-front w-40 h-40 object-contain rounded" src="" alt="Front" />
+        <img class="flip-card-back w-40 h-40 object-contain rounded" src="${backImg}" alt="Back" />
+      </div>`;
+    card.addEventListener('click', () => revealCard(card));
+    container.appendChild(card);
+  }
+}
+
+function revealCard(card) {
+  const front = card.querySelector('.flip-card-front');
+  front.src = currentPrize.image;
+  card.classList.add('flipped');
+  showWinPopup();
+}
+
+function showWinPopup() {
+  document.getElementById('popup-image').src = currentPrize.image;
+  document.getElementById('popup-name').textContent = currentPrize.name;
+  document.getElementById('popup-value').textContent = currentPrize.value.toLocaleString();
+  document.getElementById('sell-value').textContent = Math.floor(currentPrize.value * 0.8).toLocaleString();
+  document.getElementById('win-popup').classList.remove('hidden');
+}
+
+async function sellPrize() {
+  const user = firebase.auth().currentUser;
+  if (!user || !currentPrize) return;
+  const sellAmount = Math.floor(currentPrize.value * 0.8);
+  const balanceRef = firebase.database().ref('users/' + user.uid + '/balance');
+  const balanceSnap = await balanceRef.once('value');
+  const currentBalance = balanceSnap.val() || 0;
+  await balanceRef.set(currentBalance + sellAmount);
+  await firebase.database().ref('users/' + user.uid + '/inventory/' + currentPrize.key).remove();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadPack();
+  document.getElementById('open-pack').addEventListener('click', openPack);
+  document.getElementById('close-popup').addEventListener('click', () => {
+    document.getElementById('win-popup').classList.add('hidden');
+  });
+  document.getElementById('keep-btn').addEventListener('click', () => {
+    document.getElementById('win-popup').classList.add('hidden');
+  });
+  document.getElementById('sell-btn').addEventListener('click', async () => {
+    await sellPrize();
+    document.getElementById('win-popup').classList.add('hidden');
+  });
+});

--- a/wonder-pick.html
+++ b/wonder-pick.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Packly.gg | Wonder Pick</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles/main.css" />
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-database-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
+  <script src="scripts/firebase-config.js"></script>
+  <script src="scripts/auth.js" type="module"></script>
+</head>
+<body class="bg-gradient-to-br from-gray-900 via-purple-900 to-black text-white min-h-screen">
+  <header></header>
+
+  <section id="pack-section" class="pt-32 pb-16 px-4 max-w-4xl mx-auto">
+    <div class="text-center mb-8">
+      <h1 id="pack-name" class="text-3xl font-bold mb-4"></h1>
+      <img id="pack-image" src="" alt="Pack" class="w-48 h-48 object-contain mx-auto mb-4 rounded-lg shadow" />
+      <div id="prize-list" class="flex flex-wrap justify-center gap-4"></div>
+      <button id="open-pack" class="mt-8 px-6 py-2 bg-pink-600 hover:bg-pink-700 rounded text-white font-semibold">Open Pack</button>
+    </div>
+  </section>
+
+  <section id="selection-section" class="hidden pt-32 pb-16 px-4 max-w-4xl mx-auto text-center">
+    <h2 class="text-2xl font-semibold mb-6">Choose a Card</h2>
+    <div id="card-container" class="flex justify-center gap-4"></div>
+  </section>
+
+  <!-- Win Popup -->
+  <div id="win-popup" class="fixed inset-0 bg-black/80 hidden items-center justify-center z-50">
+    <div class="bg-gray-900 p-6 rounded-xl text-center relative w-80">
+      <button id="close-popup" class="absolute top-2 right-3 text-gray-400 hover:text-white text-xl">&times;</button>
+      <img id="popup-image" src="" alt="Prize" class="w-40 h-40 object-contain mx-auto mb-4 rounded" />
+      <h3 id="popup-name" class="text-lg font-semibold mb-2"></h3>
+      <div class="text-yellow-300 font-bold mb-4"><span id="popup-value"></span> coins</div>
+      <div class="flex justify-center gap-4">
+        <button id="keep-btn" class="px-4 py-2 bg-green-600 hover:bg-green-700 rounded text-white text-sm font-bold">Keep</button>
+        <button id="sell-btn" class="px-4 py-2 bg-red-600 hover:bg-red-700 rounded text-white text-sm font-bold">Sell for <span id="sell-value"></span></button>
+      </div>
+    </div>
+  </div>
+
+  <script src="scripts/header.js"></script>
+  <script src="scripts/navbar.js"></script>
+  <script src="scripts/topup.js"></script>
+  <script src="scripts/wonderpick.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- introduce Wonder Pick page for opening packs by choosing from 5 face-down cards
- allow packs flagged with `wonderPick` to link to the new mode
- implement card flip reveal with keep or sell options using existing odds logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898f41317288320a333ca19a58ab05a