### PR TITLE
Constrain hero spinner width on desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
       </div>
 
       <!-- Demo Spinner -->
-      <div class="flex-1 relative w-full h-64 md:h-80 flex flex-col items-center justify-center gap-4">
+      <div class="flex-1 md:flex-none relative w-full h-64 md:w-80 md:h-80 flex flex-col items-center justify-center gap-4">
         <div id="hero-pack-badge" class="absolute -top-6 -left-6 flex flex-col items-center text-center pointer-events-none z-20">
           <img id="hero-pack-image" src="" alt="Heat Check pack" class="w-16 md:w-20 rounded-lg shadow-lg" />
         </div>


### PR DESCRIPTION
## Summary
- prevent hero section spinner from overgrowing on desktop by limiting width and disabling flex growth

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898f4eb70bc8320bb9344fa0f5bf8f0