### PR TITLE
Rebrand Wonder Picks to Vaults with countdown nav

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -65,11 +65,14 @@
         <div>
           <h2 class="text-2xl mb-4">Existing Cases</h2>
           <div id="case-list" class="space-y-4"></div>
+          <h2 class="text-2xl mb-4 mt-8">Vaults</h2>
+          <div id="vault-list" class="space-y-4"></div>
         </div>
         <div>
           <h2 class="text-2xl mb-4" id="form-title">Add / Edit Case</h2>
           <form id="case-form" class="space-y-4">
             <input type="hidden" id="case-id">
+            <input type="hidden" id="case-path">
             <div>
               <label>Case Name:</label>
               <input type="text" id="case-name" class="w-full p-2 rounded">
@@ -107,6 +110,14 @@
     <option value="hard">🌶️🌶️🌶️ Hard</option>
   </select>
 </div>
+
+            <div>
+              <label class="inline-flex items-center"><input type="checkbox" id="case-vault" class="mr-2"> Vault Mode</label>
+            </div>
+            <div id="card-back-wrapper" class="hidden">
+              <label>Card Back Image URL:</label>
+              <input type="text" id="case-card-back" class="w-full p-2 rounded">
+            </div>
 
             <div id="prizes-section" class="space-y-4">
               <h3 class="text-xl">Prizes:</h3>
@@ -225,12 +236,16 @@
   <script>
     const db = firebase.database();
     const caseList = document.getElementById('case-list');
+    const vaultList = document.getElementById('vault-list');
     const shipmentList = document.getElementById('shipment-list');
     const caseForm = document.getElementById('case-form');
     const cancelEditBtn = document.getElementById('cancel-edit');
     const prizesSection = document.getElementById('prizes-section');
     const toast = document.getElementById('toast');
     const imagePreview = document.getElementById('image-preview');
+    const vaultCheck = document.getElementById('case-vault');
+    const cardBackInput = document.getElementById('case-card-back');
+    const cardBackWrapper = document.getElementById('card-back-wrapper');
 
     function showToast(message) {
       toast.textContent = message;
@@ -254,6 +269,10 @@
         imagePreview.classList.add('hidden');
       }
     }
+
+    vaultCheck.addEventListener('change', () => {
+      cardBackWrapper.classList.toggle('hidden', !vaultCheck.checked);
+    });
 
     function addPrize(prize = {}) {
       const div = document.createElement('div');
@@ -296,12 +315,34 @@
                 <p class="text-sm text-gray-400">${data.isFree ? 'Free' : '$' + data.price}</p>
               </div>
               <div class="flex gap-2">
-                <button onclick="editCase('${child.key}')" class="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded">Edit</button>
-                <button onclick="deleteCase('${child.key}')" class="px-4 py-2 bg-red-600 hover:bg-red-700 rounded">Delete</button>
+                <button onclick="editCase('${child.key}', false)" class="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded">Edit</button>
+                <button onclick="deleteCase('${child.key}', false)" class="px-4 py-2 bg-red-600 hover:bg-red-700 rounded">Delete</button>
               </div>
             </div>
           `;
           caseList.appendChild(div);
+        });
+      });
+
+      db.ref('vaults').on('value', snapshot => {
+        vaultList.innerHTML = '';
+        snapshot.forEach(child => {
+          const data = child.val();
+          const div = document.createElement('div');
+          div.className = 'p-4 bg-gray-800 rounded';
+          div.innerHTML = `
+            <div class="flex justify-between items-center">
+              <div>
+                <p class="font-bold text-lg">${data.name}</p>
+                <p class="text-sm text-gray-400">$${data.price}</p>
+              </div>
+              <div class="flex gap-2">
+                <button onclick="editCase('${child.key}', true)" class="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded">Edit</button>
+                <button onclick="deleteCase('${child.key}', true)" class="px-4 py-2 bg-red-600 hover:bg-red-700 rounded">Delete</button>
+              </div>
+            </div>
+          `;
+          vaultList.appendChild(div);
         });
       });
     }
@@ -405,11 +446,13 @@ function adminReply(event, caseId) {
 }
 
 
-    function editCase(id) {
-      db.ref('cases/' + id).once('value').then(snapshot => {
+    function editCase(id, isVault = false) {
+      const path = (isVault ? 'vaults/' : 'cases/') + id;
+      db.ref(path).once('value').then(snapshot => {
         const data = snapshot.val();
         document.getElementById('form-title').innerText = 'Edit Case';
         document.getElementById('case-id').value = id;
+        document.getElementById('case-path').value = isVault ? 'vaults' : 'cases';
         document.getElementById('case-name').value = data.name;
         document.getElementById('case-image').value = data.image;
         previewImage(data.image);
@@ -420,15 +463,19 @@ function adminReply(event, caseId) {
         document.getElementById('case-featured').checked = !!(data.categories && data.categories.featured);
         document.getElementById('case-starter').checked = !!(data.categories && data.categories.starter);
         document.getElementById('case-spice').value = data.spiceLevel || '';
+        document.getElementById('case-vault').checked = !!data.vault;
+        document.getElementById('case-card-back').value = data.cardBack || '';
+        document.getElementById('card-back-wrapper').classList.toggle('hidden', !data.vault);
         prizesSection.innerHTML = '<h3 class="text-xl">Prizes:</h3><button type="button" onclick="addPrize()" class="mb-2 px-4 py-2 bg-green-600 hover:bg-green-700 rounded">+ Add Prize</button>';
         if (data.prizes) Object.values(data.prizes).forEach(p => addPrize(p));
         cancelEditBtn.classList.remove('hidden');
       });
     }
 
-    function deleteCase(id) {
+    function deleteCase(id, isVault = false) {
       if (confirm('Are you sure you want to delete this case?')) {
-        db.ref('cases/' + id).remove().then(() => showToast('❌ Case deleted'));
+        const path = isVault ? 'vaults/' : 'cases/';
+        db.ref(path + id).remove().then(() => showToast('❌ Case deleted'));
       }
     }
 
@@ -449,13 +496,18 @@ function adminReply(event, caseId) {
 
     function saveCase(e) {
       e.preventDefault();
-      const id = document.getElementById('case-id').value || db.ref('cases').push().key;
+      const idField = document.getElementById('case-id');
+      const pathField = document.getElementById('case-path');
+      const vault = vaultCheck.checked;
+      const path = vault ? 'vaults' : 'cases';
+      const id = idField.value || db.ref(path).push().key;
       const name = document.getElementById('case-name').value;
       const image = document.getElementById('case-image').value;
       const isFree = document.getElementById('case-free').checked;
       const price = isFree ? 0 : parseFloat(document.getElementById('case-price').value) || 0;
       const tag = document.getElementById('case-tag').value.trim();
       const spiceLevel = document.getElementById('case-spice').value.trim();
+      const cardBack = cardBackInput.value.trim();
       const categories = {
         new: document.getElementById('case-new').checked,
         featured: document.getElementById('case-featured').checked,
@@ -472,17 +524,31 @@ function adminReply(event, caseId) {
           odds: parseFloat(div.querySelector('.prize-odds').value) || 0
         };
       });
-     db.ref('cases/' + id).set({ name, image, price, tag, spiceLevel, isFree, prizes, categories }).then(() => {
+
+      const data = { name, image, price, tag, spiceLevel, isFree, vault, cardBack, prizes, categories };
+      const updates = {};
+      updates[`${path}/${id}`] = data;
+      const originalPath = pathField.value;
+      if (originalPath && originalPath !== path) {
+        updates[`${originalPath}/${id}`] = null;
+      }
+
+      db.ref().update(updates).then(() => {
         caseForm.reset();
         previewImage('');
-       document.getElementById('case-tag').value = '';
-       document.getElementById('case-free').checked = false;
-       document.getElementById('case-new').checked = false;
-       document.getElementById('case-featured').checked = false;
-       document.getElementById('case-starter').checked = false;
+        document.getElementById('case-tag').value = '';
+        document.getElementById('case-free').checked = false;
+        document.getElementById('case-new').checked = false;
+        document.getElementById('case-featured').checked = false;
+        document.getElementById('case-starter').checked = false;
+        vaultCheck.checked = false;
+        cardBackInput.value = '';
+        cardBackWrapper.classList.add('hidden');
         prizesSection.innerHTML = '<h3 class="text-xl">Prizes:</h3><button type="button" onclick="addPrize()" class="mb-2 px-4 py-2 bg-green-600 hover:bg-green-700 rounded">+ Add Prize</button>';
         document.getElementById('form-title').innerText = 'Add / Edit Case';
         cancelEditBtn.classList.add('hidden');
+        idField.value = '';
+        pathField.value = '';
         showToast('✅ Case saved successfully!');
       });
     }
@@ -495,9 +561,14 @@ function cancelEdit() {
   document.getElementById('case-new').checked = false;
   document.getElementById('case-featured').checked = false;
   document.getElementById('case-starter').checked = false;
+  vaultCheck.checked = false;
+  cardBackInput.value = '';
+  cardBackWrapper.classList.add('hidden');
   prizesSection.innerHTML = '<h3 class="text-xl">Prizes:</h3><button type="button" onclick="addPrize()" class="mb-2 px-4 py-2 bg-green-600 hover:bg-green-700 rounded">+ Add Prize</button>';
   document.getElementById('form-title').innerText = 'Add / Edit Case';
   cancelEditBtn.classList.add('hidden');
+  document.getElementById('case-id').value = '';
+  document.getElementById('case-path').value = '';
 }
 
     caseForm.addEventListener('submit', saveCase);

--- a/components/header.html
+++ b/components/header.html
@@ -9,8 +9,8 @@
   
   <!-- Right: Desktop Menu -->
   <div class="hidden sm:flex items-center gap-4 relative">
-    <a href="rewards.html" class="flex items-center gap-1 text-yellow-400 font-semibold hover:text-yellow-300 transition">
-      <i class="fas fa-gift"></i> Rewards
+    <a href="vaults.html" class="flex items-center gap-1 text-yellow-400 font-semibold hover:text-yellow-300 transition">
+      <i class="fas fa-lock"></i> Vaults
     </a>
     <a href="marketplace.html" class="flex items-center gap-1 text-pink-400 font-semibold hover:text-pink-300 transition">
       <i class="fas fa-store"></i> Marketplace
@@ -68,8 +68,8 @@
   </div>
   <a id="inventory-link" href="inventory.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm">Inventory</a>
   <a href="how-it-works.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm">How It Works</a>
-  <a href="rewards.html" class="block px-4 py-2 hover:bg-gray-700 text-yellow-400 text-sm">
-    <i class="fas fa-gift mr-2"></i> Rewards
+  <a href="vaults.html" class="block px-4 py-2 hover:bg-gray-700 text-yellow-400 text-sm">
+    <i class="fas fa-lock mr-2"></i> Vaults
   </a>
   <a href="marketplace.html" class="block px-4 py-2 hover:bg-gray-700 text-pink-400 text-sm">
     <i class="fas fa-store mr-2"></i> Marketplace

--- a/components/nav.html
+++ b/components/nav.html
@@ -5,8 +5,8 @@
     </a>
   </div>
   <div class="hidden sm:flex items-center gap-4 relative">
-    <a href="rewards.html" class="flex items-center gap-1 text-yellow-400 font-semibold hover:text-yellow-300 transition">
-      <i class="fas fa-gift"></i> Rewards
+    <a href="vaults.html" class="flex items-center gap-1 text-yellow-400 font-semibold hover:text-yellow-300 transition">
+      <i class="fas fa-lock"></i> Vaults
     </a>
     <div id="user-balance" class="flex items-center gap-1 bg-gray-800 text-white px-3 py-1 rounded-full text-sm hidden">
       <div id="level-display" class="flex items-center gap-2 bg-black/40 px-3 py-1 rounded-full border border-white/10 shadow-md text-xs">
@@ -52,8 +52,8 @@
   </div>
   <a id="inventory-link" href="inventory.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm hidden">Inventory</a>
   <a href="how-it-works.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm">How It Works</a>
-  <a href="rewards.html" class="block px-4 py-2 hover:bg-gray-700 text-yellow-400 text-sm">
-    <i class="fas fa-gift mr-2"></i> Rewards
+  <a href="vaults.html" class="block px-4 py-2 hover:bg-gray-700 text-yellow-400 text-sm">
+    <i class="fas fa-lock mr-2"></i> Vaults
   </a>
   <a id="mobile-auth-button" href="auth.html" class="block px-4 py-2 hover:bg-gray-700 text-red-400 text-sm">Sign In</a>
 </div>

--- a/scripts/header.js
+++ b/scripts/header.js
@@ -18,7 +18,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </a>
       </div>
       <div class="hidden sm:flex items-center gap-6 relative">
-        <a href="rewards.html" class="nav-link text-yellow-400"><i class="fas fa-gift"></i><span>Rewards</span></a>
+        <a href="vaults.html" class="nav-link text-yellow-400"><i class="fas fa-lock"></i><span>Vaults</span></a>
         <a href="leaderboard.html" class="nav-link text-blue-400"><i class="fas fa-trophy"></i><span>Leaderboard</span></a>
         <a href="marketplace.html" class="nav-link text-pink-400"><i class="fas fa-store"></i><span>Marketplace</span></a>
         <div id="user-balance" class="hidden flex items-center neon-balance rounded-full overflow-hidden text-sm">
@@ -96,7 +96,7 @@ document.addEventListener("DOMContentLoaded", () => {
             <a id="drawer-inventory-link" href="inventory.html" class="block px-4 py-2 text-sm text-white rounded hover:bg-gray-800 flex items-center gap-2 hidden"><i class="fas fa-box-open"></i> Inventory</a>
             <a id="drawer-profile-link" href="profile.html" class="block px-4 py-2 text-sm text-white rounded hover:bg-gray-800 flex items-center gap-2 hidden"><i class="fas fa-user"></i> Profile</a>
             <a href="how-it-works.html" class="block px-4 py-2 text-sm text-white rounded hover:bg-gray-800 flex items-center gap-2"><i class="fas fa-question-circle"></i> How It Works</a>
-            <a href="rewards.html" class="block px-4 py-2 text-sm text-yellow-400 rounded hover:bg-gray-800 flex items-center gap-2"><i class="fas fa-gift"></i> Rewards</a>
+            <a href="vaults.html" class="block px-4 py-2 text-sm text-yellow-400 rounded hover:bg-gray-800 flex items-center gap-2"><i class="fas fa-lock"></i> Vaults</a>
             <a href="marketplace.html" class="block px-4 py-2 text-sm text-pink-400 rounded hover:bg-gray-800 flex items-center gap-2"><i class="fas fa-store"></i> Marketplace</a>
             <a href="leaderboard.html" class="block px-4 py-2 text-sm text-blue-400 rounded hover:bg-gray-800 flex items-center gap-2"><i class="fas fa-trophy"></i> Leaderboard</a>
             <a id="drawer-logout" href="#" class="block px-4 py-2 text-sm text-red-400 rounded hover:bg-gray-800 flex items-center gap-2 hidden"><i class="fas fa-sign-out-alt"></i> Logout</a>
@@ -116,9 +116,9 @@ document.addEventListener("DOMContentLoaded", () => {
           <i class="fas fa-cube text-lg"></i>
           <span>Open Packs</span>
         </a>
-        <a href="rewards.html" class="flex flex-col items-center text-xs text-yellow-400">
-          <i class="fas fa-gift text-lg"></i>
-          <span>Rewards</span>
+        <a href="vaults.html" class="flex flex-col items-center text-xs text-yellow-400">
+          <i class="fas fa-lock text-lg"></i>
+          <span id="vault-nav-timer">--:--</span>
         </a>
         <a href="marketplace.html" class="flex flex-col items-center text-xs text-pink-400">
           <i class="fas fa-store text-lg"></i>
@@ -332,5 +332,29 @@ document.addEventListener("DOMContentLoaded", () => {
     if (next === null) next = prev;
     return { level: lvl, prevThreshold: prev, nextThreshold: next };
   }
+
+  function updateVaultNavTimer() {
+    const timerEl = document.getElementById('vault-nav-timer');
+    if (!timerEl) return;
+    function render() {
+      const stored = JSON.parse(localStorage.getItem('vaultActive') || '{}');
+      if (!stored.expires) {
+        timerEl.textContent = '--:--';
+        return;
+      }
+      const diff = stored.expires - Date.now();
+      if (diff <= 0) {
+        timerEl.textContent = '00:00';
+        return;
+      }
+      const mins = Math.floor(diff / 60000);
+      const secs = Math.floor((diff % 60000) / 1000);
+      timerEl.textContent = `${String(mins).padStart(2,'0')}:${String(secs).padStart(2,'0')}`;
+    }
+    render();
+    setInterval(render, 1000);
+  }
+
+  updateVaultNavTimer();
 });
 

--- a/scripts/header.js
+++ b/scripts/header.js
@@ -18,7 +18,7 @@ document.addEventListener("DOMContentLoaded", () => {
         </a>
       </div>
       <div class="hidden sm:flex items-center gap-6 relative">
-        <a href="vaults.html" class="nav-link text-yellow-400"><i class="fas fa-lock"></i><span>Vaults</span></a>
+        <a href="vaults.html" class="nav-link text-yellow-400"><i class="fas fa-lock"></i><span>Vaults</span><span id="vault-nav-timer-desktop" class="ml-1 text-xs">--:--</span></a>
         <a href="leaderboard.html" class="nav-link text-blue-400"><i class="fas fa-trophy"></i><span>Leaderboard</span></a>
         <a href="marketplace.html" class="nav-link text-pink-400"><i class="fas fa-store"></i><span>Marketplace</span></a>
         <div id="user-balance" class="hidden flex items-center neon-balance rounded-full overflow-hidden text-sm">
@@ -118,7 +118,8 @@ document.addEventListener("DOMContentLoaded", () => {
         </a>
         <a href="vaults.html" class="flex flex-col items-center text-xs text-yellow-400">
           <i class="fas fa-lock text-lg"></i>
-          <span id="vault-nav-timer">--:--</span>
+          <span>Vaults</span>
+          <span id="vault-nav-timer" class="text-[10px]">--:--</span>
         </a>
         <a href="marketplace.html" class="flex flex-col items-center text-xs text-pink-400">
           <i class="fas fa-store text-lg"></i>
@@ -334,22 +335,25 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function updateVaultNavTimer() {
-    const timerEl = document.getElementById('vault-nav-timer');
-    if (!timerEl) return;
+    const timerEls = [
+      document.getElementById('vault-nav-timer'),
+      document.getElementById('vault-nav-timer-desktop')
+    ].filter(Boolean);
+    if (!timerEls.length) return;
     function render() {
       const stored = JSON.parse(localStorage.getItem('vaultActive') || '{}');
-      if (!stored.expires) {
-        timerEl.textContent = '--:--';
-        return;
+      let text = '--:--';
+      if (stored.expires) {
+        const diff = stored.expires - Date.now();
+        if (diff <= 0) {
+          text = '00:00';
+        } else {
+          const mins = Math.floor(diff / 60000);
+          const secs = Math.floor((diff % 60000) / 1000);
+          text = `${String(mins).padStart(2,'0')}:${String(secs).padStart(2,'0')}`;
+        }
       }
-      const diff = stored.expires - Date.now();
-      if (diff <= 0) {
-        timerEl.textContent = '00:00';
-        return;
-      }
-      const mins = Math.floor(diff / 60000);
-      const secs = Math.floor((diff % 60000) / 1000);
-      timerEl.textContent = `${String(mins).padStart(2,'0')}:${String(secs).padStart(2,'0')}`;
+      timerEls.forEach(el => el.textContent = text);
     }
     render();
     setInterval(render, 1000);

--- a/scripts/packs.js
+++ b/scripts/packs.js
@@ -36,13 +36,15 @@ function renderCases(caseList) {
 
     const imgId = `img-${c.id}`;
 
+    const openLink = `case.html?id=${c.id}`;
+
     casesContainer.innerHTML += `
       <div class="relative p-3 sm:p-4 bg-gray-800 rounded-lg shadow-md hover:shadow-lg transition">
         ${tagHTML}
         ${pepperHTML}
         <img src="${packImg}" id="${imgId}" class="case-card-img mb-2 transition-all duration-300">
         <h3 class="mt-2 font-semibold text-white text-sm sm:text-base">${c.name}</h3>
-        <a href="case.html?id=${c.id}" class="open-button glow-button text-xs sm:text-sm whitespace-nowrap">
+        <a href="${openLink}" class="open-button glow-button text-xs sm:text-sm whitespace-nowrap">
     Open for ${priceLabel}
     ${priceIcon}
   </a>

--- a/scripts/vault.js
+++ b/scripts/vault.js
@@ -102,20 +102,20 @@ async function openPack() {
 
   // prepare unique filler prizes for the face-down cards
   const allPrizes = Object.values(currentPack.prizes || {});
+  // start with unique fillers excluding the winning prize
   let fillers = allPrizes
     .filter(p => p !== winningPrize)
     .filter((p, i, self) => i === self.findIndex(q => q.name === p.name && q.image === p.image));
 
-  // ensure at least 5 unique fillers by randomly adding more if needed
-  while (fillers.length < 5) {
-    const candidate = allPrizes[Math.floor(Math.random() * allPrizes.length)];
-    if (candidate && candidate !== winningPrize && !fillers.find(p => p.name === candidate.name && p.image === candidate.image)) {
-      fillers.push(candidate);
+  // if we don't have enough unique fillers, allow duplicates until we have five
+  if (fillers.length < 5) {
+    const pool = allPrizes.filter(p => p !== winningPrize);
+    while (fillers.length < 5 && pool.length) {
+      fillers.push(pool[Math.floor(Math.random() * pool.length)]);
     }
-    if (fillers.length === allPrizes.length - 1) break;
   }
 
-  // shuffle and take first five
+  // shuffle and take the first five entries
   fillers.sort(() => Math.random() - 0.5);
   cardPrizes = fillers.slice(0, 5);
 

--- a/scripts/vault.js
+++ b/scripts/vault.js
@@ -141,8 +141,8 @@ function setupCards() {
     card.style.transition = 'transform 0.6s ease, opacity 0.6s ease';
     card.innerHTML = `
       <div class="flip-card-inner">
-        <img class="flip-card-front w-40 h-40 object-contain rounded-xl" src="${prize.image}" alt="Front" />
-        <img class="flip-card-back w-40 h-40 object-contain rounded-xl" src="${backImg}" alt="Back" />
+        <img class="flip-card-front w-full h-full object-contain rounded-xl" src="${prize.image}" alt="Front" />
+        <img class="flip-card-back w-full h-full object-contain rounded-xl" src="${backImg}" alt="Back" />
       </div>`;
     card.addEventListener('click', () => selectCard(card, i));
     container.appendChild(card);

--- a/scripts/vault.js
+++ b/scripts/vault.js
@@ -3,6 +3,14 @@ let currentPrize = null;
 let cardPrizes = [];
 let selectedIndex = null;
 
+const rarityColors = {
+  common: '#a1a1aa',
+  uncommon: '#4ade80',
+  rare: '#60a5fa',
+  ultrarare: '#c084fc',
+  legendary: '#facc15'
+};
+
 function renderPack(data) {
   document.getElementById('pack-name').textContent = data.name;
   document.title = `Packly.gg | ${data.name}`;
@@ -11,13 +19,6 @@ function renderPack(data) {
   document.getElementById('pack-price').textContent = (data.price || 0).toLocaleString();
 
   const prizes = Object.values(data.prizes || {});
-  const rarityColors = {
-    common: '#a1a1aa',
-    uncommon: '#4ade80',
-    rare: '#60a5fa',
-    ultrarare: '#c084fc',
-    legendary: '#facc15'
-  };
   document.getElementById('prizes-grid').innerHTML = prizes.map(prize => {
     const rarity = (prize.rarity || 'common').toLowerCase().replace(/\s+/g,'');
     const color = rarityColors[rarity] || '#a1a1aa';
@@ -191,10 +192,28 @@ function selectCard(card, index) {
 }
 
 function showWinPopup() {
-  document.getElementById('popup-image').src = currentPrize.image;
-  document.getElementById('popup-name').textContent = currentPrize.name;
-  document.getElementById('popup-value').textContent = currentPrize.value.toLocaleString();
+  const imgEl = document.getElementById('popup-image');
+  const nameEl = document.getElementById('popup-name');
+  const valueEl = document.getElementById('popup-value');
+  const rarityEl = document.getElementById('popup-rarity');
+  const oddsEl = document.getElementById('popup-odds');
+  const cardEl = document.getElementById('popup-card');
+
+  imgEl.src = currentPrize.image;
+  nameEl.textContent = currentPrize.name;
+  valueEl.textContent = currentPrize.value.toLocaleString();
   document.getElementById('sell-value').textContent = Math.floor(currentPrize.value * 0.8).toLocaleString();
+
+  const rarityKey = (currentPrize.rarity || 'common').toLowerCase().replace(/\s+/g,'');
+  const color = rarityColors[rarityKey] || '#a1a1aa';
+  rarityEl.textContent = currentPrize.rarity || '';
+  rarityEl.style.color = color;
+  oddsEl.textContent = `${(currentPrize.odds || 0).toFixed(1)}%`;
+  cardEl.style.borderColor = color;
+
+  imgEl.classList.remove('glow-flash-common','glow-flash-uncommon','glow-flash-rare','glow-flash-ultrarare','glow-flash-legendary');
+  imgEl.classList.add(`glow-flash-${rarityKey}`);
+
   document.getElementById('win-popup').classList.remove('hidden');
 }
 

--- a/scripts/vault.js
+++ b/scripts/vault.js
@@ -1,0 +1,223 @@
+let currentPack = null;
+let currentPrize = null;
+let cardPrizes = [];
+let selectedIndex = null;
+
+function renderPack(data) {
+  document.getElementById('pack-name').textContent = data.name;
+  document.getElementById('main-pack-image').src = data.image;
+  document.querySelectorAll('.case-pack-image').forEach(img => img.src = data.image);
+  document.getElementById('pack-price').textContent = (data.price || 0).toLocaleString();
+
+  const prizes = Object.values(data.prizes || {});
+  const rarityColors = {
+    common: '#a1a1aa',
+    uncommon: '#4ade80',
+    rare: '#60a5fa',
+    ultrarare: '#c084fc',
+    legendary: '#facc15'
+  };
+  document.getElementById('prizes-grid').innerHTML = prizes.map(prize => {
+    const rarity = (prize.rarity || 'common').toLowerCase().replace(/\s+/g,'');
+    const color = rarityColors[rarity] || '#a1a1aa';
+    return `
+      <div class="prize-card relative rounded-xl p-4 bg-gray-800 border-2 text-white text-center shadow-sm transition-transform duration-200 hover:scale-105" style="border-color:${color}">
+        <img src="${prize.image}" class="w-full h-[120px] object-contain mx-auto mb-3 bg-black/20 rounded-lg" />
+        <div class="font-semibold text-sm clamp-2 mb-8">${prize.name}</div>
+        <div class="absolute bottom-2 left-2 flex items-center gap-1 text-yellow-300 font-medium text-xs">
+          <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4" />
+          ${(prize.value || 0).toLocaleString()}
+        </div>
+        <div class="absolute bottom-2 right-2 text-white/70 bg-black/40 px-2 py-[2px] text-xs rounded-full">
+          ${(prize.odds || 0).toFixed(1)}%
+        </div>
+      </div>
+    `;
+  }).join('');
+}
+
+async function loadPack() {
+  const params = new URLSearchParams(window.location.search);
+  const id = params.get('id');
+  if (!id) return;
+  const snap = await firebase.database().ref('vaults/' + id).once('value');
+  currentPack = snap.val();
+  if (currentPack) renderPack(currentPack);
+}
+
+async function openPack() {
+  if (!currentPack) return;
+  const user = firebase.auth().currentUser;
+  if (!user) return alert('You must be logged in.');
+
+  const openBtn = document.getElementById('open-pack');
+  openBtn.disabled = true;
+
+  const userSnap = await firebase.database().ref('users/' + user.uid).once('value');
+  const userData = userSnap.val() || {};
+  const balance = parseFloat(userData.balance || 0);
+  const price = parseFloat(currentPack.price || 0);
+  if (balance < price) {
+    openBtn.disabled = false;
+    return alert('Not enough coins.');
+  }
+
+  const fairSnap = await firebase.database().ref('users/' + user.uid + '/provablyFair').once('value');
+  const fairData = fairSnap.val();
+  if (!fairData) {
+    openBtn.disabled = false;
+    return alert('Provably fair data missing.');
+  }
+  const { serverSeed, clientSeed, nonce } = fairData;
+
+  await firebase.database().ref('users/' + user.uid + '/balance').set(balance - price);
+
+  const prizes = Object.values(currentPack.prizes || {}).sort((a,b) => a.odds - b.odds);
+  const totalOdds = prizes.reduce((sum,p) => sum + (p.odds || 0), 0);
+
+  const hashBuffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(`${serverSeed}:${clientSeed}:${nonce || 0}`));
+  const hashHex = Array.from(new Uint8Array(hashBuffer)).map(b => b.toString(16).padStart(2,'0')).join('');
+  const rand = parseInt(hashHex.substring(0,8),16) / 0xffffffff;
+
+  let cumulative = 0;
+  let winningPrize = prizes[prizes.length - 1];
+  for (const p of prizes) {
+    cumulative += p.odds || 0;
+    if (rand * totalOdds < cumulative) { winningPrize = p; break; }
+  }
+
+  const unboxData = {
+    name: winningPrize.name,
+    image: winningPrize.image,
+    rarity: winningPrize.rarity,
+    value: winningPrize.value,
+    timestamp: Date.now(),
+    sold: false
+  };
+  const invRef = firebase.database().ref('users/' + user.uid + '/inventory').push();
+  await invRef.set(unboxData);
+  await firebase.database().ref('users/' + user.uid + '/unboxHistory/' + invRef.key).set(unboxData);
+  currentPrize = { ...winningPrize, key: invRef.key };
+
+  // prepare filler prizes for the face-down cards
+  const allPrizes = Object.values(currentPack.prizes || {});
+  const fillers = allPrizes.filter(p => p !== winningPrize);
+  while (fillers.length < 5) {
+    fillers.push(fillers[Math.floor(Math.random() * fillers.length)] || winningPrize);
+  }
+  // randomize filler order for card placement
+  cardPrizes = fillers.slice(0,5).sort(() => Math.random() - 0.5);
+  selectedIndex = null;
+  document.getElementById('pack-display').classList.add('hidden');
+  document.getElementById('back-btn').classList.add('hidden');
+  setupCards();
+}
+
+function setupCards() {
+  const container = document.getElementById('card-container');
+  container.innerHTML = '';
+  container.classList.remove('hidden');
+  const backImg = currentPack.cardBack || 'https://via.placeholder.com/160x160?text=Back';
+  cardPrizes.forEach((prize, i) => {
+    const card = document.createElement('div');
+    card.className = 'flip-card relative';
+    card.dataset.index = i;
+    card.style.opacity = '0';
+    card.style.transform = 'translateY(200px) rotate(0deg)';
+    card.style.transition = 'transform 0.6s ease, opacity 0.6s ease';
+    card.innerHTML = `
+      <div class="flip-card-inner">
+        <img class="flip-card-front w-40 h-40 object-contain rounded-xl" src="${prize.image}" alt="Front" />
+        <img class="flip-card-back w-40 h-40 object-contain rounded-xl" src="${backImg}" alt="Back" />
+      </div>`;
+    card.addEventListener('click', () => selectCard(card, i));
+    container.appendChild(card);
+    setTimeout(() => {
+      card.style.opacity = '1';
+      card.style.transform = `translateY(0) rotate(${(i-2)*10}deg)`;
+    }, i * 150);
+  });
+}
+
+function flipCard(index) {
+  const card = document.querySelector(`.flip-card[data-index="${index}"]`);
+  if (card) card.classList.add('flipped');
+}
+
+function selectCard(card, index) {
+  if (selectedIndex !== null) return;
+  selectedIndex = index;
+
+  // replace the selected card's prize with the actual winning prize
+  cardPrizes[index] = currentPrize;
+  const front = card.querySelector('.flip-card-front');
+  front.src = currentPrize.image;
+
+  // visually mark the chosen card
+  const label = document.createElement('div');
+  label.textContent = 'Your Pick';
+  label.className = 'absolute -top-6 left-1/2 -translate-x-1/2 text-xs bg-purple-600 px-2 py-1 rounded shadow';
+  card.appendChild(label);
+  card.classList.add('ring-4', 'ring-yellow-400', 'selected');
+
+  const others = cardPrizes
+    .map((p,i) => ({p,i}))
+    .filter(obj => obj.i !== index)
+    .sort((a,b) => a.p.value - b.p.value); // highest value last
+
+  const delay = 400;
+  others.forEach((obj, idx) => {
+    setTimeout(() => flipCard(obj.i), idx * delay);
+  });
+
+  setTimeout(() => {
+    flipCard(index);
+    setTimeout(showWinPopup, 600);
+  }, others.length * delay + 400);
+}
+
+function showWinPopup() {
+  document.getElementById('popup-image').src = currentPrize.image;
+  document.getElementById('popup-name').textContent = currentPrize.name;
+  document.getElementById('popup-value').textContent = currentPrize.value.toLocaleString();
+  document.getElementById('sell-value').textContent = Math.floor(currentPrize.value * 0.8).toLocaleString();
+  document.getElementById('win-popup').classList.remove('hidden');
+}
+
+async function sellPrize() {
+  const user = firebase.auth().currentUser;
+  if (!user || !currentPrize) return;
+  const sellAmount = Math.floor(currentPrize.value * 0.8);
+  const balanceRef = firebase.database().ref('users/' + user.uid + '/balance');
+  const balanceSnap = await balanceRef.once('value');
+  const currentBalance = balanceSnap.val() || 0;
+  await balanceRef.set(currentBalance + sellAmount);
+  await firebase.database().ref('users/' + user.uid + '/inventory/' + currentPrize.key).remove();
+}
+
+function resetGame() {
+  const container = document.getElementById('card-container');
+  container.classList.add('hidden');
+  container.innerHTML = '';
+  document.getElementById('pack-display').classList.remove('hidden');
+  document.getElementById('back-btn').classList.remove('hidden');
+  document.getElementById('open-pack').disabled = false;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadPack();
+  document.getElementById('open-pack').addEventListener('click', openPack);
+  document.getElementById('close-popup').addEventListener('click', () => {
+    document.getElementById('win-popup').classList.add('hidden');
+    resetGame();
+  });
+  document.getElementById('keep-btn').addEventListener('click', () => {
+    document.getElementById('win-popup').classList.add('hidden');
+    resetGame();
+  });
+  document.getElementById('sell-btn').addEventListener('click', async () => {
+    await sellPrize();
+    document.getElementById('win-popup').classList.add('hidden');
+    resetGame();
+  });
+});

--- a/scripts/vaults.js
+++ b/scripts/vaults.js
@@ -12,7 +12,7 @@ function renderActive(pack) {
   const cards = Object.values(pack.prizes || {}).slice(0,5);
   document.getElementById('card-preview').innerHTML = cards.map(c => `
     <div class="flex flex-col items-center">
-      <img src="${c.image}" class="w-20 h-24 object-contain rounded-lg bg-black/40 border-2 border-yellow-500/40 shadow-lg transform transition-transform duration-300 hover:scale-105" />
+      <img src="${c.image}" class="w-16 h-20 sm:w-20 sm:h-24 object-contain rounded-lg bg-black/40 border-2 border-yellow-500/40 shadow-lg transform transition-transform duration-300 hover:scale-105" />
       <div class="mt-1 flex items-center gap-1 text-sm">
         <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4" />
         ${Number(c.value || 0).toLocaleString()}

--- a/scripts/vaults.js
+++ b/scripts/vaults.js
@@ -1,0 +1,68 @@
+let vaults = [];
+let activeVault = null;
+let timerInterval = null;
+
+function renderActive(pack) {
+  if (!pack) return;
+  const price = parseFloat(pack.price) || 0;
+  document.getElementById('pack-name').textContent = pack.name;
+  document.getElementById('pack-image').src = pack.image;
+  document.getElementById('pack-price').textContent = price.toLocaleString();
+  document.getElementById('open-link').href = `vault.html?id=${pack.id}`;
+  const cards = Object.values(pack.prizes || {}).slice(0,5);
+  document.getElementById('card-preview').innerHTML = cards.map(c => `
+    <div class="flex flex-col items-center">
+      <img src="${c.image}" class="w-20 h-24 object-contain rounded-lg bg-black/40 border-2 border-yellow-500/40 shadow-lg transform transition-transform duration-300 hover:scale-105" />
+      <div class="mt-1 flex items-center gap-1 text-sm">
+        <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4" />
+        ${Number(c.value || 0).toLocaleString()}
+      </div>
+    </div>
+  `).join('');
+}
+
+function startTimer(expires) {
+  clearInterval(timerInterval);
+  const timerEl = document.getElementById('vault-timer');
+  function update() {
+    const diff = expires - Date.now();
+    if (diff <= 0) {
+      clearInterval(timerInterval);
+      localStorage.removeItem('vaultActive');
+      chooseActive();
+      return;
+    }
+    const mins = Math.floor(diff / 60000);
+    const secs = Math.floor((diff % 60000) / 1000);
+    timerEl.textContent = `${String(mins).padStart(2,'0')}:${String(secs).padStart(2,'0')}`;
+  }
+  update();
+  timerInterval = setInterval(update, 1000);
+}
+
+function chooseActive() {
+  if (!vaults.length) return;
+  const stored = JSON.parse(localStorage.getItem('vaultActive') || '{}');
+  const now = Date.now();
+  if (stored.expires && now < stored.expires && vaults.find(v => v.id === stored.id)) {
+    activeVault = vaults.find(v => v.id === stored.id);
+    startTimer(stored.expires);
+  } else {
+    activeVault = vaults[Math.floor(Math.random() * vaults.length)];
+    const expires = now + 30 * 60 * 1000;
+    localStorage.setItem('vaultActive', JSON.stringify({ id: activeVault.id, expires }));
+    startTimer(expires);
+  }
+  renderActive(activeVault);
+}
+
+function loadVaults() {
+  firebase.database().ref('vaults').once('value').then(snap => {
+    const data = snap.val() || {};
+    vaults = Object.entries(data).map(([id, val]) => ({ id, ...val }));
+    chooseActive();
+  });
+}
+
+document.addEventListener('DOMContentLoaded', loadVaults);
+

--- a/styles/main.css
+++ b/styles/main.css
@@ -281,6 +281,13 @@ body {
   transform: rotateY(180deg);
 }
 
+@media (max-width: 640px) {
+  .flip-card-inner {
+    width: 120px;
+    height: 120px;
+  }
+}
+
 .scrollbar-hide::-webkit-scrollbar {
   display: none;
 }

--- a/vault.html
+++ b/vault.html
@@ -39,6 +39,9 @@
     .flip-card-front, .flip-card-back { position:absolute; width:100%; height:100%; backface-visibility:hidden; border-radius:0.75rem; }
     .flip-card-front { transform:rotateY(180deg); }
     .flip-card:hover { transform:scale(1.05); }
+    @media (max-width: 640px) {
+      .flip-card-inner { width:120px; height:120px; }
+    }
   </style>
   <style>
     @keyframes win-glow {
@@ -80,7 +83,7 @@
       </div>
     </div>
 
-    <div id="card-container" class="hidden flex flex-wrap justify-center gap-4 mt-10"></div>
+    <div id="card-container" class="hidden flex flex-wrap justify-center gap-2 sm:gap-4 mt-10"></div>
 
     <div class="bg-black/30 backdrop-blur-md rounded-2xl shadow-md border border-white/10 p-6 hover:shadow-purple-500/20 transition-all duration-300 mt-10 relative">
       <img class="case-pack-image absolute -top-10 left-0 -translate-x-1/2 w-64 opacity-20 z-0 pointer-events-none -rotate-12" alt="Pack Art" />

--- a/vault.html
+++ b/vault.html
@@ -101,15 +101,17 @@
     </div>
   </section>
 
-  <div id="win-popup" class="fixed inset-0 bg-black/80 hidden items-center justify-center z-50">
-    <div class="bg-gradient-to-br from-gray-900 to-gray-800 rounded-2xl p-6 w-full max-w-sm shadow-2xl text-center relative border border-white/10">
+  <div id="win-popup" class="fixed inset-0 bg-black/80 backdrop-blur-sm hidden items-center justify-center z-50">
+    <div id="popup-card" class="premium-popup popup-box border-2 rounded-2xl p-6 w-full max-w-sm text-center relative text-white">
       <button id="close-popup" class="absolute top-2 right-3 text-gray-400 hover:text-white text-xl">&times;</button>
-      <img id="popup-image" src="" alt="Prize" class="w-40 h-40 object-contain mx-auto mb-4 rounded" />
-      <h3 id="popup-name" class="text-lg font-semibold mb-2"></h3>
-      <div class="text-yellow-300 font-bold mb-4"><span id="popup-value"></span> coins</div>
+      <img id="popup-image" src="" alt="Prize" class="w-48 h-48 object-contain mx-auto mb-4 rounded-lg premium-glow" />
+      <h3 id="popup-name" class="text-lg font-semibold mb-1"></h3>
+      <div id="popup-rarity" class="text-xs uppercase tracking-wider mb-1"></div>
+      <div class="text-yellow-300 font-bold mb-1"><span id="popup-value"></span> coins</div>
+      <div class="text-gray-400 text-xs mb-4"><span id="popup-odds"></span> chance</div>
       <div class="flex justify-center gap-4">
-        <button id="keep-btn" class="px-4 py-2 rounded-xl bg-green-600 hover:bg-green-700 text-white text-sm font-bold">Keep</button>
-      <button id="sell-btn" class="px-4 py-2 rounded-xl bg-red-600 hover:bg-red-700 text-white text-sm font-bold">Sell for <span id="sell-value"></span></button>
+        <button id="keep-btn" class="px-4 py-2 rounded-xl premium-button text-sm">Keep</button>
+        <button id="sell-btn" class="px-4 py-2 rounded-xl bg-red-600 hover:bg-red-700 text-white text-sm font-bold">Sell for <span id="sell-value"></span></button>
       </div>
     </div>
   </div>

--- a/vault.html
+++ b/vault.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en" class="overflow-x-hidden">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Packly.gg | Vault</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://js.stripe.com/v3/"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-database-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
+  <script src="scripts/firebase-config.js"></script>
+  <link rel="stylesheet" href="styles/main.css" />
+  <style>
+    .clamp-2 {
+      display: -webkit-box;
+      -webkit-line-clamp: 1;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+  </style>
+  <style>
+    #particle-canvas {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      z-index: -1;
+      pointer-events: none;
+    }
+  </style>
+  <style>
+    .flip-card { perspective:1000px; cursor:pointer; transition:transform .3s; }
+    .flip-card-inner { position:relative; width:160px; height:160px; transform-style:preserve-3d; transition:transform .6s; }
+    .flip-card.flipped .flip-card-inner { transform:rotateY(180deg); }
+    .flip-card-front, .flip-card-back { position:absolute; width:100%; height:100%; backface-visibility:hidden; border-radius:0.75rem; }
+    .flip-card-front { transform:rotateY(180deg); }
+    .flip-card:hover { transform:scale(1.05); }
+  </style>
+  <style>
+    @keyframes win-glow {
+      0%, 100% { box-shadow: 0 0 0 rgba(255,215,0,0.4); }
+      50% { box-shadow: 0 0 20px rgba(255,215,0,0.9); }
+    }
+    .flip-card.selected { animation: win-glow 1s ease-in-out; }
+  </style>
+</head>
+<body class="bg-gradient-to-br from-black via-gray-900 to-black text-white overflow-x-hidden">
+  <canvas id="particle-canvas"></canvas>
+  <header></header>
+
+  <section id="pack-section" class="relative pt-32 pb-10 px-4">
+    <div class="relative z-10 mb-6">
+      <div class="flex items-center justify-between px-4 py-2 bg-black/40 backdrop-blur-md rounded-full shadow-lg">
+        <a id="back-btn" href="vaults.html" class="flex items-center justify-center w-10 h-10 rounded-full bg-gradient-to-br from-pink-500 to-purple-500 text-white hover:scale-110 transition-transform" aria-label="Back to packs">
+          <i class="fas fa-arrow-left"></i>
+        </a>
+        <h2 id="pack-name" class="flex-1 text-center text-xl sm:text-2xl font-bold mx-4 bg-gradient-to-r from-yellow-400 via-pink-500 to-purple-500 bg-clip-text text-transparent leading-none">Loading...</h2>
+      </div>
+      <div id="case-spice" class="text-center text-xs mt-2"></div>
+    </div>
+
+    <div id="pack-display" class="flex flex-col items-center gap-4 mt-6">
+      <img id="main-pack-image" class="w-28 h-28 object-contain" alt="Pack" />
+      <button id="open-pack" class="shining-button animate-pulse relative px-6 py-3 rounded-full bg-gradient-to-r from-yellow-400 via-pink-500 to-purple-500 text-white font-extrabold flex items-center justify-center gap-2 shadow-lg transition-transform hover:scale-105 focus:outline-none overflow-hidden">
+        <span class="relative z-10 flex items-center gap-2">
+          Open for
+          <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-5 h-5" />
+          <span id="pack-price">...</span>
+        </span>
+      </button>
+      <div class="flex justify-center mt-2">
+        <button id="pf-info" class="flex items-center gap-2 text-sm font-semibold text-green-400 hover:text-green-300 transition cursor-pointer">
+          <i class="fa-solid fa-shield-halved text-green-400 text-base drop-shadow"></i>
+          <span>Provably Fair</span>
+        </button>
+      </div>
+    </div>
+
+    <div id="card-container" class="hidden flex flex-wrap justify-center gap-4 mt-10"></div>
+
+    <div class="bg-black/30 backdrop-blur-md rounded-2xl shadow-md border border-white/10 p-6 hover:shadow-purple-500/20 transition-all duration-300 mt-10 relative">
+      <img class="case-pack-image absolute -top-10 left-0 -translate-x-1/2 w-64 opacity-20 z-0 pointer-events-none -rotate-12" alt="Pack Art" />
+      <img class="case-pack-image absolute -top-10 right-0 translate-x-1/2 w-64 opacity-20 z-0 pointer-events-none rotate-12" alt="Pack Art" />
+      <div class="relative z-10">
+        <div class="text-center mb-6">
+          <div class="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-gradient-to-r from-yellow-400 via-pink-500 to-purple-500 shadow-md">
+            <img src="https://cdn-icons-png.flaticon.com/128/5172/5172637.png" alt="Rewards Icon" class="w-5 h-5" />
+            <span class="text-sm font-bold uppercase tracking-wider text-white">Rewards Table</span>
+          </div>
+          <p class="mt-2 text-sm text-gray-300">Each pack contains a mix of prizes with different rarities and values.</p>
+        </div>
+        <div id="prizes-grid" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-5 gap-4 sm:gap-6 text-sm"></div>
+      </div>
+    </div>
+  </section>
+
+  <div id="win-popup" class="fixed inset-0 bg-black/80 hidden items-center justify-center z-50">
+    <div class="bg-gradient-to-br from-gray-900 to-gray-800 rounded-2xl p-6 w-full max-w-sm shadow-2xl text-center relative border border-white/10">
+      <button id="close-popup" class="absolute top-2 right-3 text-gray-400 hover:text-white text-xl">&times;</button>
+      <img id="popup-image" src="" alt="Prize" class="w-40 h-40 object-contain mx-auto mb-4 rounded" />
+      <h3 id="popup-name" class="text-lg font-semibold mb-2"></h3>
+      <div class="text-yellow-300 font-bold mb-4"><span id="popup-value"></span> coins</div>
+      <div class="flex justify-center gap-4">
+        <button id="keep-btn" class="px-4 py-2 rounded-xl bg-green-600 hover:bg-green-700 text-white text-sm font-bold">Keep</button>
+      <button id="sell-btn" class="px-4 py-2 rounded-xl bg-red-600 hover:bg-red-700 text-white text-sm font-bold">Sell for <span id="sell-value"></span></button>
+      </div>
+    </div>
+  </div>
+
+  <footer></footer>
+
+  <script src="scripts/header.js"></script>
+  <script src="scripts/footer.js"></script>
+  <script src="scripts/navbar.js"></script>
+  <script src="scripts/topup.js"></script>
+  <script src="scripts/vault.js"></script>
+
+  <script>
+document.addEventListener('DOMContentLoaded', () => {
+  const canvas = document.getElementById('particle-canvas');
+  const ctx = canvas.getContext('2d');
+  const particles = [];
+  const count = 50;
+
+  function resize() {
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+  }
+  window.addEventListener('resize', resize);
+  resize();
+
+  for (let i = 0; i < count; i++) {
+    particles.push({
+      x: Math.random() * canvas.width,
+      y: Math.random() * canvas.height,
+      r: Math.random() * 3 + 1,
+      dx: (Math.random() - 0.5) * 0.3,
+      dy: (Math.random() - 0.5) * 0.3
+    });
+  }
+
+  function draw() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    for (const p of particles) {
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
+      ctx.fillStyle = 'rgba(255,255,255,0.5)';
+      ctx.fill();
+      p.x += p.dx;
+      p.y += p.dy;
+      if (p.x < 0) p.x = canvas.width;
+      if (p.x > canvas.width) p.x = 0;
+      if (p.y < 0) p.y = canvas.height;
+      if (p.y > canvas.height) p.y = 0;
+    }
+    requestAnimationFrame(draw);
+  }
+  draw();
+});
+  </script>
+</body>
+</html>
+

--- a/vault.html
+++ b/vault.html
@@ -101,7 +101,7 @@
     </div>
   </section>
 
-  <div id="win-popup" class="fixed inset-0 bg-black/80 backdrop-blur-sm hidden items-center justify-center z-50">
+  <div id="win-popup" class="fixed inset-0 bg-black/80 backdrop-blur-sm hidden flex items-center justify-center z-50">
     <div id="popup-card" class="premium-popup popup-box border-2 rounded-2xl p-6 w-full max-w-sm text-center relative text-white">
       <button id="close-popup" class="absolute top-2 right-3 text-gray-400 hover:text-white text-xl">&times;</button>
       <img id="popup-image" src="" alt="Prize" class="w-48 h-48 object-contain mx-auto mb-4 rounded-lg premium-glow" />

--- a/vaults.html
+++ b/vaults.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en" class="overflow-x-hidden">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Packly.gg | Vaults</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles/main.css" />
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-database-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
+  <script src="scripts/firebase-config.js"></script>
+  <script src="scripts/auth.js" type="module"></script>
+  <style>
+    .timer-badge {
+      animation: pulse 1s ease-in-out infinite alternate;
+    }
+    @keyframes pulse {
+      from { transform: scale(1); }
+      to { transform: scale(1.1); }
+    }
+  </style>
+</head>
+<body class="bg-gradient-to-br from-black via-gray-900 to-black min-h-screen text-white">
+  <header></header>
+  <section class="pt-32 pb-20 max-w-4xl mx-auto px-4">
+    <div class="text-center mb-8">
+      <h1 class="text-4xl font-bold">Vaults</h1>
+      <p class="text-gray-300 mt-2">Exclusive limited-time packs where you pick one of five cards to win its coin value.</p>
+    </div>
+    <div id="active-pick" class="relative p-8 bg-black/40 backdrop-blur rounded-3xl border border-yellow-500/40 shadow-2xl flex flex-col items-center text-center">
+      <div class="relative w-40 sm:w-56 mx-auto mb-4">
+        <img id="pack-image" alt="Vault" class="w-full h-auto object-contain mx-auto drop-shadow-xl transform transition-transform duration-300 hover:scale-105">
+        <div id="vault-timer" class="timer-badge absolute -top-4 -right-4 bg-gradient-to-r from-pink-500 to-purple-600 text-white text-sm font-bold px-3 py-1 rounded-full shadow-lg">30:00</div>
+      </div>
+      <div id="card-preview" class="flex justify-center flex-wrap gap-4 mb-6"></div>
+      <a id="open-link" href="#" class="open-button glow-button text-lg px-8 py-3 mb-6">Open for <span id="pack-price"></span> <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-5 h-5 inline-block align-[-2px]"></a>
+      <h2 id="pack-name" class="text-3xl font-bold"></h2>
+    </div>
+  </section>
+  <footer></footer>
+  <script src="scripts/header.js"></script>
+  <script src="scripts/footer.js"></script>
+  <script src="scripts/navbar.js"></script>
+  <script src="scripts/topup.js"></script>
+  <script src="scripts/vaults.js"></script>
+</body>
+</html>

--- a/vaults.html
+++ b/vaults.html
@@ -36,7 +36,7 @@
         <img id="pack-image" alt="Vault" class="w-full h-auto object-contain mx-auto drop-shadow-xl transform transition-transform duration-300 hover:scale-105">
         <div id="vault-timer" class="timer-badge absolute -top-4 -right-4 bg-gradient-to-r from-pink-500 to-purple-600 text-white text-sm font-bold px-3 py-1 rounded-full shadow-lg">30:00</div>
       </div>
-      <div id="card-preview" class="flex justify-center flex-wrap gap-4 mb-6"></div>
+      <div id="card-preview" class="flex justify-center flex-wrap gap-2 sm:gap-4 mb-6"></div>
       <a id="open-link" href="#" class="open-button glow-button text-lg px-8 py-3 mb-6">Open for <span id="pack-price"></span> <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-5 h-5 inline-block align-[-2px]"></a>
     </div>
   </section>

--- a/vaults.html
+++ b/vaults.html
@@ -31,13 +31,13 @@
       <p class="text-gray-300 mt-2">Exclusive limited-time packs where you pick one of five cards to win its coin value.</p>
     </div>
     <div id="active-pick" class="relative p-8 bg-black/40 backdrop-blur rounded-3xl border border-yellow-500/40 shadow-2xl flex flex-col items-center text-center">
+      <h2 id="pack-name" class="text-3xl font-bold mb-4"></h2>
       <div class="relative w-40 sm:w-56 mx-auto mb-4">
         <img id="pack-image" alt="Vault" class="w-full h-auto object-contain mx-auto drop-shadow-xl transform transition-transform duration-300 hover:scale-105">
         <div id="vault-timer" class="timer-badge absolute -top-4 -right-4 bg-gradient-to-r from-pink-500 to-purple-600 text-white text-sm font-bold px-3 py-1 rounded-full shadow-lg">30:00</div>
       </div>
       <div id="card-preview" class="flex justify-center flex-wrap gap-4 mb-6"></div>
       <a id="open-link" href="#" class="open-button glow-button text-lg px-8 py-3 mb-6">Open for <span id="pack-price"></span> <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-5 h-5 inline-block align-[-2px]"></a>
-      <h2 id="pack-name" class="text-3xl font-bold"></h2>
     </div>
   </section>
   <footer></footer>


### PR DESCRIPTION
## Summary
- Rename Wonder Pick mode to Vaults across pages, scripts, and admin panel
- Simplify the vault opening screen by removing card thumbnails and focusing on the pack art
- Add Vaults to the navigation menus and show a live countdown for the current vault on the mobile bottom nav

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898f41317288320a333ca19a58ab05a