### PR TITLE
Add roll verification page and seed controls

### DIFF
--- a/case.html
+++ b/case.html
@@ -673,8 +673,8 @@ document.getElementById("open-case-button").addEventListener("click", async () =
         }, 150);
       });
   document.getElementById("pf-info").addEventListener("click", async () => {
-  const user = firebase.auth().currentUser;
-  if (!user) return;
+    const user = firebase.auth().currentUser;
+    if (!user) return;
 
   const fairSnap = await firebase.database().ref(`users/${user.uid}/provablyFair`).once("value");
   const fairData = fairSnap.val();
@@ -683,8 +683,36 @@ document.getElementById("open-case-button").addEventListener("click", async () =
   document.getElementById("pf-client-seed").textContent = fairData?.clientSeed || "Not found";
   document.getElementById("pf-nonce").textContent = fairData?.nonce ?? "Not found";
 
-  document.getElementById("provably-fair-modal").classList.remove("hidden");
-});
+    document.getElementById("provably-fair-modal").classList.remove("hidden");
+  });
+
+  document.getElementById("update-client-seed").addEventListener("click", async () => {
+    const user = firebase.auth().currentUser;
+    if (!user) return;
+    const newSeed = document.getElementById("client-seed-input").value.trim();
+    if (!newSeed) return;
+    await firebase.database().ref(`users/${user.uid}/provablyFair`).update({ clientSeed: newSeed, nonce: 0 });
+    document.getElementById("pf-client-seed").textContent = newSeed;
+    document.getElementById("pf-nonce").textContent = 0;
+    showToast("Client seed updated", "bg-green-600");
+  });
+
+  document.getElementById("new-server-seed").addEventListener("click", async () => {
+    const user = firebase.auth().currentUser;
+    if (!user) return;
+    const serverSeed = generateRandomString(64);
+    const serverSeedHash = await sha256(serverSeed);
+    const clientSeed = document.getElementById("pf-client-seed").textContent || "default";
+    await firebase.database().ref(`users/${user.uid}/provablyFair`).set({
+      serverSeed,
+      serverSeedHash,
+      clientSeed,
+      nonce: 0
+    });
+    document.getElementById("pf-server-seed").textContent = serverSeed;
+    document.getElementById("pf-nonce").textContent = 0;
+    showToast("Server seed regenerated", "bg-green-600");
+  });
 });
 function enablePrizePopups() {
   const cards = document.querySelectorAll(".prize-card");
@@ -711,6 +739,21 @@ function enablePrizePopups() {
       });
     });
 }
+
+function generateRandomString(length) {
+  const charset = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  let result = '';
+  for (let i = 0; i < length; i++) {
+    result += charset.charAt(Math.floor(Math.random() * charset.length));
+  }
+  return result;
+}
+
+async function sha256(message) {
+  const data = new TextEncoder().encode(message);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  return [...new Uint8Array(hashBuffer)].map(b => b.toString(16).padStart(2, '0')).join('');
+}
   </script>
   <!-- Provably Fair Modal -->
 <div id="provably-fair-modal" class="hidden fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-50">
@@ -722,6 +765,12 @@ function enablePrizePopups() {
       <div><strong>Server Seed:</strong> <span id="pf-server-seed">...</span></div>
       <div><strong>Client Seed:</strong> <span id="pf-client-seed">...</span></div>
       <div><strong>Nonce:</strong> <span id="pf-nonce">...</span></div>
+    </div>
+    <div class="mt-4 space-y-2 text-xs">
+      <input id="client-seed-input" type="text" placeholder="New client seed" class="w-full px-2 py-1 rounded bg-gray-800 text-white" />
+      <button id="update-client-seed" class="w-full bg-green-600 hover:bg-green-500 rounded py-2 text-white">Update Client Seed</button>
+      <button id="new-server-seed" class="w-full bg-purple-600 hover:bg-purple-500 rounded py-2 text-white">New Server Seed</button>
+      <a href="verify.html" class="block text-center text-blue-400 hover:underline mt-2">Verify a roll</a>
     </div>
   </div>
 </div>

--- a/scripts/verify.js
+++ b/scripts/verify.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('verify-form');
+  if (!form) return;
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const serverSeed = document.getElementById('verify-server-seed').value.trim();
+    const clientSeed = document.getElementById('verify-client-seed').value.trim();
+    const nonce = document.getElementById('verify-nonce').value.trim();
+    if (!serverSeed || !clientSeed || nonce === '') return;
+    const data = new TextEncoder().encode(`${serverSeed}:${clientSeed}:${nonce}`);
+    const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+    const hashHex = [...new Uint8Array(hashBuffer)].map(b => b.toString(16).padStart(2, '0')).join('');
+    const rand = parseInt(hashHex.substring(0, 8), 16) / 0xffffffff;
+    document.getElementById('verify-hash').textContent = hashHex;
+    document.getElementById('verify-output').textContent = rand;
+    document.getElementById('verify-result').classList.remove('hidden');
+  });
+});

--- a/verify.html
+++ b/verify.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Verify Roll | Packly.gg</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-database-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
+  <script src="./scripts/firebase-config.js"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles/main.css" />
+</head>
+<body class="bg-gray-900 text-white min-h-screen font-[Poppins]">
+<header></header>
+<section class="pt-32 px-6">
+  <div class="max-w-md mx-auto bg-gray-800 p-6 rounded-xl shadow-lg space-y-4">
+    <h1 class="text-xl font-bold text-center">Verify a Roll</h1>
+    <form id="verify-form" class="space-y-3">
+      <input id="verify-server-seed" type="text" placeholder="Server Seed" class="w-full p-2 rounded bg-gray-900" />
+      <input id="verify-client-seed" type="text" placeholder="Client Seed" class="w-full p-2 rounded bg-gray-900" />
+      <input id="verify-nonce" type="number" placeholder="Nonce" class="w-full p-2 rounded bg-gray-900" />
+      <button type="submit" class="w-full bg-purple-600 hover:bg-purple-500 rounded py-2">Verify</button>
+    </form>
+    <div id="verify-result" class="mt-4 text-sm break-words hidden">
+      <p><strong>Hash:</strong> <span id="verify-hash"></span></p>
+      <p><strong>Roll:</strong> <span id="verify-output"></span></p>
+    </div>
+  </div>
+</section>
+<footer></footer>
+<script src="./scripts/auth.js"></script>
+<script src="./scripts/header.js"></script>
+<script src="./scripts/navbar.js"></script>
+<script src="./scripts/footer.js"></script>
+<script src="https://js.stripe.com/v3/"></script>
+<script src="./scripts/topup.js"></script>
+<script src="./scripts/verify.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- allow changing client and server seeds from Provably Fair modal
- add standalone roll verification page for hashing rolls
## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68992b9ef3808320ada24ae0b6b860ad