### PR TITLE
Show top vault cards and sort rewards

### DIFF
--- a/scripts/vault.js
+++ b/scripts/vault.js
@@ -18,7 +18,7 @@ function renderPack(data) {
   document.querySelectorAll('.case-pack-image').forEach(img => img.src = data.image);
   document.getElementById('pack-price').textContent = (data.price || 0).toLocaleString();
 
-  const prizes = Object.values(data.prizes || {});
+  const prizes = Object.values(data.prizes || {}).sort((a,b) => (b.value||0) - (a.value||0));
   document.getElementById('prizes-grid').innerHTML = prizes.map(prize => {
     const rarity = (prize.rarity || 'common').toLowerCase().replace(/\s+/g,'');
     const color = rarityColors[rarity] || '#a1a1aa';

--- a/scripts/vaults.js
+++ b/scripts/vaults.js
@@ -9,7 +9,23 @@ function renderActive(pack) {
   document.getElementById('pack-image').src = pack.image;
   document.getElementById('pack-price').textContent = price.toLocaleString();
   document.getElementById('open-link').href = `vault.html?id=${pack.id}`;
-  const cards = Object.values(pack.prizes || {}).slice(0,5);
+
+  const allCards = Object.values(pack.prizes || {}).sort((a,b) => (b.value||0) - (a.value||0));
+
+  const topCards = allCards.slice(0,2);
+  const top1El = document.getElementById('top-card-1');
+  const top2El = document.getElementById('top-card-2');
+  [top1El, top2El].forEach(el => { el.classList.add('hidden'); el.src = ''; });
+  if (topCards[0]) {
+    top1El.src = topCards[0].image;
+    top1El.classList.remove('hidden');
+  }
+  if (topCards[1]) {
+    top2El.src = topCards[1].image;
+    top2El.classList.remove('hidden');
+  }
+
+  const cards = allCards.slice(0,5);
   document.getElementById('card-preview').innerHTML = cards.map(c => `
     <div class="flex flex-col items-center">
       <img src="${c.image}" class="w-16 h-20 sm:w-20 sm:h-24 object-contain rounded-lg bg-black/40 border-2 border-yellow-500/40 shadow-lg transform transition-transform duration-300 hover:scale-105" />

--- a/vaults.html
+++ b/vaults.html
@@ -32,8 +32,10 @@
     </div>
     <div id="active-pick" class="relative p-8 bg-black/40 backdrop-blur rounded-3xl border border-yellow-500/40 shadow-2xl flex flex-col items-center text-center">
       <h2 id="pack-name" class="text-3xl font-bold mb-4"></h2>
-      <div class="relative w-40 sm:w-56 mx-auto mb-4">
-        <img id="pack-image" alt="Vault" class="w-full h-auto object-contain mx-auto drop-shadow-xl transform transition-transform duration-300 hover:scale-105">
+      <div class="relative w-52 sm:w-72 mx-auto mb-4">
+        <img id="top-card-1" alt="Top Card" class="hidden absolute -left-10 sm:-left-12 top-1/2 -translate-y-1/2 w-20 h-28 sm:w-24 sm:h-32 object-contain rounded-lg -rotate-6 z-0" />
+        <img id="top-card-2" alt="Top Card" class="hidden absolute -right-10 sm:-right-12 top-1/2 -translate-y-1/2 w-20 h-28 sm:w-24 sm:h-32 object-contain rounded-lg rotate-6 z-0" />
+        <img id="pack-image" alt="Vault" class="relative z-10 w-full h-auto object-contain mx-auto drop-shadow-xl transform transition-transform duration-300 hover:scale-105">
         <div id="vault-timer" class="timer-badge absolute -top-4 -right-4 bg-gradient-to-r from-pink-500 to-purple-600 text-white text-sm font-bold px-3 py-1 rounded-full shadow-lg">30:00</div>
       </div>
       <div id="card-preview" class="flex justify-center flex-wrap gap-2 sm:gap-4 mb-6"></div>


### PR DESCRIPTION
## Summary
- Enlarge vault pack display and reveal two highest-value cards behind the pack
- Display top card preview based on prize values
- Sort rewards table on vault page from highest to lowest value

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899406fdc548320bf1896aaeb5820cf