### PR TITLE
Show top vault cards and sort rewards

### DIFF
--- a/scripts/vault.js
+++ b/scripts/vault.js
@@ -18,7 +18,14 @@ function renderPack(data) {
   document.querySelectorAll('.case-pack-image').forEach(img => img.src = data.image);
   document.getElementById('pack-price').textContent = (data.price || 0).toLocaleString();
 
-  const prizes = Object.values(data.prizes || {});
+  const prizes = Object.values(data.prizes || {}).sort((a,b) => (b.value||0) - (a.value||0));
+
+  const top1El = document.getElementById('top-card-1');
+  const top2El = document.getElementById('top-card-2');
+  [top1El, top2El].forEach(el => { el.classList.add('hidden'); el.src = ''; });
+  if (prizes[0]) { top1El.src = prizes[0].image; top1El.classList.remove('hidden'); }
+  if (prizes[1]) { top2El.src = prizes[1].image; top2El.classList.remove('hidden'); }
+
   document.getElementById('prizes-grid').innerHTML = prizes.map(prize => {
     const rarity = (prize.rarity || 'common').toLowerCase().replace(/\s+/g,'');
     const color = rarityColors[rarity] || '#a1a1aa';

--- a/vault.html
+++ b/vault.html
@@ -67,7 +67,11 @@
     </div>
 
     <div id="pack-display" class="flex flex-col items-center gap-4 mt-6">
-      <img id="main-pack-image" class="w-28 h-28 object-contain" alt="Pack" />
+      <div class="relative w-40 sm:w-52">
+        <img id="top-card-1" alt="Top Card" class="hidden absolute -left-10 sm:-left-12 top-1/2 -translate-y-1/2 w-20 h-28 sm:w-24 sm:h-32 object-contain rounded-lg -rotate-6 z-0" />
+        <img id="top-card-2" alt="Top Card" class="hidden absolute -right-10 sm:-right-12 top-1/2 -translate-y-1/2 w-20 h-28 sm:w-24 sm:h-32 object-contain rounded-lg rotate-6 z-0" />
+        <img id="main-pack-image" class="relative z-10 w-full h-auto object-contain mx-auto drop-shadow-xl transform transition-transform duration-300 hover:scale-105" alt="Pack" />
+      </div>
       <button id="open-pack" class="shining-button animate-pulse relative px-6 py-3 rounded-full bg-gradient-to-r from-yellow-400 via-pink-500 to-purple-500 text-white font-extrabold flex items-center justify-center gap-2 shadow-lg transition-transform hover:scale-105 focus:outline-none overflow-hidden">
         <span class="relative z-10 flex items-center gap-2">
           Open for


### PR DESCRIPTION
## Summary
- Enlarge vault pack display and reveal two highest-value cards behind the pack on the vault page
- Display rewards table sorted by coin value
- Restore vaults listing to its original layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899406fdc548320bf1896aaeb5820cf