### PR TITLE
Rotate vault card previews and sort rewards

### DIFF
--- a/scripts/vault.js
+++ b/scripts/vault.js
@@ -2,6 +2,7 @@ let currentPack = null;
 let currentPrize = null;
 let cardPrizes = [];
 let selectedIndex = null;
+let sliderInterval = null;
 
 const rarityColors = {
   common: '#a1a1aa',
@@ -18,7 +19,40 @@ function renderPack(data) {
   document.querySelectorAll('.case-pack-image').forEach(img => img.src = data.image);
   document.getElementById('pack-price').textContent = (data.price || 0).toLocaleString();
 
-  const prizes = Object.values(data.prizes || {});
+  const prizes = Object.values(data.prizes || {}).sort((a,b) => (b.value||0) - (a.value||0));
+
+  const sliderWrap = document.getElementById('slider-wrapper');
+  const sliderImg = document.getElementById('slider-image');
+  sliderWrap.classList.add('hidden');
+  sliderWrap.classList.remove('legendary-spark');
+  sliderImg.classList.add('opacity-0');
+  if (sliderInterval) {
+    clearInterval(sliderInterval);
+    sliderInterval = null;
+  }
+  if (prizes.length) {
+    sliderWrap.classList.remove('hidden');
+    let currentSlide = 0;
+    sliderImg.src = prizes[currentSlide].image;
+    sliderImg.classList.remove('opacity-0');
+    if ((prizes[currentSlide].rarity || '').toLowerCase().replace(/\s+/g,'') === 'legendary') {
+      sliderWrap.classList.add('legendary-spark');
+    }
+    sliderInterval = setInterval(() => {
+      sliderImg.classList.add('opacity-0');
+      setTimeout(() => {
+        currentSlide = (currentSlide + 1) % prizes.length;
+        const nextPrize = prizes[currentSlide];
+        sliderImg.src = nextPrize.image;
+        sliderWrap.classList.remove('legendary-spark');
+        if ((nextPrize.rarity || '').toLowerCase().replace(/\s+/g,'') === 'legendary') {
+          sliderWrap.classList.add('legendary-spark');
+        }
+        sliderImg.classList.remove('opacity-0');
+      }, 700);
+    }, 2000);
+  }
+
   document.getElementById('prizes-grid').innerHTML = prizes.map(prize => {
     const rarity = (prize.rarity || 'common').toLowerCase().replace(/\s+/g,'');
     const color = rarityColors[rarity] || '#a1a1aa';

--- a/vault.html
+++ b/vault.html
@@ -50,6 +50,29 @@
     }
     .flip-card.selected { animation: win-glow 1s ease-in-out; }
   </style>
+  <style>
+    .legendary-spark{overflow:visible;}
+    .legendary-spark::before,
+    .legendary-spark::after {
+      content:'';
+      position:absolute;
+      top:50%;
+      left:50%;
+      width:6px;
+      height:6px;
+      background:radial-gradient(circle, rgba(250,204,21,1) 0%, rgba(250,204,21,0) 70%);
+      border-radius:50%;
+      pointer-events:none;
+      animation:spark-burst 0.8s linear infinite;
+    }
+    .legendary-spark::after { animation-delay:0.4s; }
+    @keyframes spark-burst {
+      0% { transform:translate(-50%, -50%) scale(1); opacity:1; }
+      100% { transform:translate(calc(-50% + var(--sx)), calc(-50% + var(--sy))) scale(0.2); opacity:0; }
+    }
+    .legendary-spark::before { --sx:-30px; --sy:-30px; }
+    .legendary-spark::after { --sx:30px; --sy:-30px; }
+  </style>
 </head>
 <body class="bg-gradient-to-br from-black via-gray-900 to-black text-white overflow-x-hidden">
   <canvas id="particle-canvas"></canvas>
@@ -67,7 +90,12 @@
     </div>
 
     <div id="pack-display" class="flex flex-col items-center gap-4 mt-6">
-      <img id="main-pack-image" class="w-28 h-28 object-contain" alt="Pack" />
+      <div class="relative w-40 sm:w-52">
+        <div id="slider-wrapper" class="hidden absolute -top-12 left-1/2 -translate-x-1/2 w-20 h-28 sm:w-24 sm:h-32 z-0 overflow-hidden rounded-lg">
+          <img id="slider-image" alt="Preview Card" class="w-full h-full object-contain opacity-0 transition-opacity duration-700" />
+        </div>
+        <img id="main-pack-image" class="relative z-10 w-full h-auto object-contain mx-auto drop-shadow-xl transform transition-transform duration-300 hover:scale-105" alt="Pack" />
+      </div>
       <button id="open-pack" class="shining-button animate-pulse relative px-6 py-3 rounded-full bg-gradient-to-r from-yellow-400 via-pink-500 to-purple-500 text-white font-extrabold flex items-center justify-center gap-2 shadow-lg transition-transform hover:scale-105 focus:outline-none overflow-hidden">
         <span class="relative z-10 flex items-center gap-2">
           Open for


### PR DESCRIPTION
## Summary
- Replace static preview thumbnails with a rotating card slider above the pack
- Continue displaying the rewards table sorted by coin value

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899406fdc548320bf1896aaeb5820cf