### PR TITLE
Show top vault prizes on listing

### DIFF
--- a/scripts/vault.js
+++ b/scripts/vault.js
@@ -18,7 +18,7 @@ function renderPack(data) {
   document.querySelectorAll('.case-pack-image').forEach(img => img.src = data.image);
   document.getElementById('pack-price').textContent = (data.price || 0).toLocaleString();
 
-  const prizes = Object.values(data.prizes || {});
+  const prizes = Object.values(data.prizes || {}).sort((a, b) => (b.value || 0) - (a.value || 0));
   document.getElementById('prizes-grid').innerHTML = prizes.map(prize => {
     const rarity = (prize.rarity || 'common').toLowerCase().replace(/\s+/g,'');
     const color = rarityColors[rarity] || '#a1a1aa';

--- a/scripts/vaults.js
+++ b/scripts/vaults.js
@@ -9,8 +9,26 @@ function renderActive(pack) {
   document.getElementById('pack-image').src = pack.image;
   document.getElementById('pack-price').textContent = price.toLocaleString();
   document.getElementById('open-link').href = `vault.html?id=${pack.id}`;
-  const cards = Object.values(pack.prizes || {}).slice(0,5);
-  document.getElementById('card-preview').innerHTML = cards.map(c => `
+
+  const cards = Object.values(pack.prizes || {}).sort((a,b) => (b.value || 0) - (a.value || 0));
+
+  const topCards = cards.slice(0,2);
+  const left = document.getElementById('top-card-1');
+  const right = document.getElementById('top-card-2');
+  [left, right].forEach(el => { el.classList.add('hidden'); el.classList.remove('legendary-spark'); });
+  if (topCards[0]) {
+    left.src = topCards[0].image;
+    left.classList.remove('hidden');
+    if ((topCards[0].rarity || '').toLowerCase().replace(/\s+/g,'') === 'legendary') left.classList.add('legendary-spark');
+  }
+  if (topCards[1]) {
+    right.src = topCards[1].image;
+    right.classList.remove('hidden');
+    if ((topCards[1].rarity || '').toLowerCase().replace(/\s+/g,'') === 'legendary') right.classList.add('legendary-spark');
+  }
+
+  const preview = cards.slice(0,5);
+  document.getElementById('card-preview').innerHTML = preview.map(c => `
     <div class="flex flex-col items-center">
       <img src="${c.image}" class="w-16 h-20 sm:w-20 sm:h-24 object-contain rounded-lg bg-black/40 border-2 border-yellow-500/40 shadow-lg transform transition-transform duration-300 hover:scale-105" />
       <div class="mt-1 flex items-center gap-1 text-sm">

--- a/vaults.html
+++ b/vaults.html
@@ -22,6 +22,29 @@
       to { transform: scale(1.1); }
     }
   </style>
+  <style>
+    .legendary-spark{overflow:visible;}
+    .legendary-spark::before,
+    .legendary-spark::after {
+      content:'';
+      position:absolute;
+      top:50%;
+      left:50%;
+      width:6px;
+      height:6px;
+      background:radial-gradient(circle, rgba(250,204,21,1) 0%, rgba(250,204,21,0) 70%);
+      border-radius:50%;
+      pointer-events:none;
+      animation:spark-burst 0.8s linear infinite;
+    }
+    .legendary-spark::after { animation-delay:0.4s; }
+    @keyframes spark-burst {
+      0% { transform:translate(-50%, -50%) scale(1); opacity:1; }
+      100% { transform:translate(calc(-50% + var(--sx)), calc(-50% + var(--sy))) scale(0.2); opacity:0; }
+    }
+    .legendary-spark::before { --sx:-30px; --sy:-30px; }
+    .legendary-spark::after { --sx:30px; --sy:-30px; }
+  </style>
 </head>
 <body class="bg-gradient-to-br from-black via-gray-900 to-black min-h-screen text-white">
   <header></header>
@@ -32,8 +55,10 @@
     </div>
     <div id="active-pick" class="relative p-8 bg-black/40 backdrop-blur rounded-3xl border border-yellow-500/40 shadow-2xl flex flex-col items-center text-center">
       <h2 id="pack-name" class="text-3xl font-bold mb-4"></h2>
-      <div class="relative w-40 sm:w-56 mx-auto mb-4">
-        <img id="pack-image" alt="Vault" class="w-full h-auto object-contain mx-auto drop-shadow-xl transform transition-transform duration-300 hover:scale-105">
+      <div class="relative w-56 sm:w-72 mx-auto mb-4">
+        <img id="top-card-1" class="hidden absolute z-0 -left-8 sm:-left-12 top-1/2 w-20 h-28 sm:w-24 sm:h-32 object-contain rounded-lg bg-black/40 border-2 border-yellow-500/40 shadow-lg transform -translate-y-1/2 -rotate-12" />
+        <img id="top-card-2" class="hidden absolute z-0 -right-8 sm:-right-12 top-1/2 w-20 h-28 sm:w-24 sm:h-32 object-contain rounded-lg bg-black/40 border-2 border-yellow-500/40 shadow-lg transform -translate-y-1/2 rotate-12" />
+        <img id="pack-image" alt="Vault" class="relative z-10 w-full h-auto object-contain mx-auto drop-shadow-xl transform transition-transform duration-300 hover:scale-105">
         <div id="vault-timer" class="timer-badge absolute -top-4 -right-4 bg-gradient-to-r from-pink-500 to-purple-600 text-white text-sm font-bold px-3 py-1 rounded-full shadow-lg">30:00</div>
       </div>
       <div id="card-preview" class="flex justify-center flex-wrap gap-2 sm:gap-4 mb-6"></div>


### PR DESCRIPTION
## Summary
- Enlarge the vaults listing pack and surface the two highest-value cards emerging from behind it with legendary spark effects
- Sort prize previews and the vault reward grid by coin value so top rewards appear first

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899406fdc548320bf1896aaeb5820cf