### PR TITLE
Auto-rotate vault reward slider with rarity borders

### DIFF
--- a/scripts/vault.js
+++ b/scripts/vault.js
@@ -18,8 +18,26 @@ function renderPack(data) {
   document.querySelectorAll('.case-pack-image').forEach(img => img.src = data.image);
   document.getElementById('pack-price').textContent = (data.price || 0).toLocaleString();
 
-  const prizes = Object.values(data.prizes || {});
-  document.getElementById('prizes-grid').innerHTML = prizes.map(prize => {
+    const prizes = Object.values(data.prizes || {}).sort((a, b) => (b.value || 0) - (a.value || 0));
+    const topCards = prizes.slice(0,2);
+    const left = document.getElementById('top-card-1');
+    const right = document.getElementById('top-card-2');
+    [left, right].forEach(el => { el.classList.add('hidden'); el.classList.remove('legendary-spark'); });
+    if (topCards[0]) {
+      left.src = topCards[0].image;
+      left.classList.remove('hidden');
+      const rarity = (topCards[0].rarity || '').toLowerCase().replace(/\s+/g,'');
+      left.style.borderColor = rarityColors[rarity] || '#a1a1aa';
+      if (rarity === 'legendary') left.classList.add('legendary-spark');
+    }
+    if (topCards[1]) {
+      right.src = topCards[1].image;
+      right.classList.remove('hidden');
+      const rarity = (topCards[1].rarity || '').toLowerCase().replace(/\s+/g,'');
+      right.style.borderColor = rarityColors[rarity] || '#a1a1aa';
+      if (rarity === 'legendary') right.classList.add('legendary-spark');
+    }
+    document.getElementById('prizes-grid').innerHTML = prizes.map(prize => {
     const rarity = (prize.rarity || 'common').toLowerCase().replace(/\s+/g,'');
     const color = rarityColors[rarity] || '#a1a1aa';
     return `

--- a/scripts/vaults.js
+++ b/scripts/vaults.js
@@ -2,6 +2,14 @@ let vaults = [];
 let activeVault = null;
 let timerInterval = null;
 
+const rarityColors = {
+  common: '#a1a1aa',
+  uncommon: '#4ade80',
+  rare: '#60a5fa',
+  ultrarare: '#c084fc',
+  legendary: '#facc15'
+};
+
 function renderActive(pack) {
   if (!pack) return;
   const price = parseFloat(pack.price) || 0;
@@ -9,16 +17,45 @@ function renderActive(pack) {
   document.getElementById('pack-image').src = pack.image;
   document.getElementById('pack-price').textContent = price.toLocaleString();
   document.getElementById('open-link').href = `vault.html?id=${pack.id}`;
-  const cards = Object.values(pack.prizes || {}).slice(0,5);
-  document.getElementById('card-preview').innerHTML = cards.map(c => `
-    <div class="flex flex-col items-center">
-      <img src="${c.image}" class="w-16 h-20 sm:w-20 sm:h-24 object-contain rounded-lg bg-black/40 border-2 border-yellow-500/40 shadow-lg transform transition-transform duration-300 hover:scale-105" />
-      <div class="mt-1 flex items-center gap-1 text-sm">
-        <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4" />
-        ${Number(c.value || 0).toLocaleString()}
-      </div>
-    </div>
-  `).join('');
+
+  const cards = Object.values(pack.prizes || {}).sort((a,b) => (b.value || 0) - (a.value || 0));
+  const slider = document.getElementById('card-slider');
+  slider.innerHTML = '';
+  slider.scrollLeft = 0;
+  const loopCards = [...cards, ...cards];
+  loopCards.forEach(c => {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'relative flex-shrink-0 w-24 h-32 sm:w-32 sm:h-40';
+    const img = document.createElement('img');
+    img.src = c.image;
+    img.className = 'w-full h-full object-contain rounded-lg bg-black/40 border-2 shadow-lg';
+    const rarity = (c.rarity || '').toLowerCase().replace(/\s+/g,'');
+    img.style.borderColor = rarityColors[rarity] || '#a1a1aa';
+    wrapper.appendChild(img);
+    const val = document.createElement('div');
+    val.className = 'absolute bottom-1 left-1 flex items-center gap-1 text-xs bg-black/60 px-1 rounded';
+    val.innerHTML = `<img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-3 h-3" />${Number(c.value || 0).toLocaleString()}`;
+    wrapper.appendChild(val);
+    if(rarity === 'legendary') wrapper.classList.add('legendary-spark');
+    slider.appendChild(wrapper);
+  });
+  if(cards.length){
+    let paused = false;
+    slider.onmouseenter = () => paused = true;
+    slider.onmouseleave = () => paused = false;
+    slider.ontouchstart = () => paused = true;
+    slider.ontouchend = () => paused = false;
+    const step = () => {
+      if(!paused){
+        slider.scrollLeft += 0.5;
+        if(slider.scrollLeft >= slider.scrollWidth / 2){
+          slider.scrollLeft = 0;
+        }
+      }
+      requestAnimationFrame(step);
+    };
+    requestAnimationFrame(step);
+  }
 }
 
 function startTimer(expires) {

--- a/vault.html
+++ b/vault.html
@@ -43,15 +43,38 @@
       .flip-card-inner { width:120px; height:120px; }
     }
   </style>
-  <style>
-    @keyframes win-glow {
-      0%, 100% { box-shadow: 0 0 0 rgba(255,215,0,0.4); }
-      50% { box-shadow: 0 0 20px rgba(255,215,0,0.9); }
-    }
-    .flip-card.selected { animation: win-glow 1s ease-in-out; }
-  </style>
-</head>
-<body class="bg-gradient-to-br from-black via-gray-900 to-black text-white overflow-x-hidden">
+    <style>
+      @keyframes win-glow {
+        0%, 100% { box-shadow: 0 0 0 rgba(255,215,0,0.4); }
+        50% { box-shadow: 0 0 20px rgba(255,215,0,0.9); }
+      }
+      .flip-card.selected { animation: win-glow 1s ease-in-out; }
+    </style>
+    <style>
+      .legendary-spark{overflow:visible;}
+      .legendary-spark::before,
+      .legendary-spark::after{
+        content:'';
+        position:absolute;
+        top:50%;
+        left:50%;
+        width:6px;
+        height:6px;
+        background:radial-gradient(circle, rgba(250,204,21,1) 0%, rgba(250,204,21,0) 70%);
+        border-radius:50%;
+        pointer-events:none;
+        animation:spark-burst 0.8s linear infinite;
+      }
+      .legendary-spark::after{animation-delay:0.4s;}
+      @keyframes spark-burst{
+        0%{transform:translate(-50%,-50%) scale(1);opacity:1;}
+        100%{transform:translate(calc(-50% + var(--sx)),calc(-50% + var(--sy))) scale(0.2);opacity:0;}
+      }
+      .legendary-spark::before{--sx:-30px;--sy:-30px;}
+      .legendary-spark::after{--sx:30px;--sy:-30px;}
+    </style>
+  </head>
+  <body class="bg-gradient-to-br from-black via-gray-900 to-black text-white overflow-x-hidden">
   <canvas id="particle-canvas"></canvas>
   <header></header>
 
@@ -67,7 +90,11 @@
     </div>
 
     <div id="pack-display" class="flex flex-col items-center gap-4 mt-6">
-      <img id="main-pack-image" class="w-28 h-28 object-contain" alt="Pack" />
+      <div class="relative w-28 h-28 sm:w-40 sm:h-40">
+        <img id="top-card-1" class="hidden absolute z-0 -left-8 sm:-left-10 top-1/2 w-16 h-24 sm:w-20 sm:h-28 object-contain rounded-lg bg-black/40 border-2 shadow-lg transform -translate-y-1/2 -rotate-12" />
+        <img id="top-card-2" class="hidden absolute z-0 -right-8 sm:-right-10 top-1/2 w-16 h-24 sm:w-20 sm:h-28 object-contain rounded-lg bg-black/40 border-2 shadow-lg transform -translate-y-1/2 rotate-12" />
+        <img id="main-pack-image" class="relative z-10 w-full h-full object-contain" alt="Pack" />
+      </div>
       <button id="open-pack" class="shining-button animate-pulse relative px-6 py-3 rounded-full bg-gradient-to-r from-yellow-400 via-pink-500 to-purple-500 text-white font-extrabold flex items-center justify-center gap-2 shadow-lg transition-transform hover:scale-105 focus:outline-none overflow-hidden">
         <span class="relative z-10 flex items-center gap-2">
           Open for

--- a/vaults.html
+++ b/vaults.html
@@ -22,6 +22,29 @@
       to { transform: scale(1.1); }
     }
   </style>
+  <style>
+    .legendary-spark{overflow:visible;}
+    .legendary-spark::before,
+    .legendary-spark::after {
+      content:'';
+      position:absolute;
+      top:50%;
+      left:50%;
+      width:6px;
+      height:6px;
+      background:radial-gradient(circle, rgba(250,204,21,1) 0%, rgba(250,204,21,0) 70%);
+      border-radius:50%;
+      pointer-events:none;
+      animation:spark-burst 0.8s linear infinite;
+    }
+    .legendary-spark::after { animation-delay:0.4s; }
+    @keyframes spark-burst {
+      0% { transform:translate(-50%, -50%) scale(1); opacity:1; }
+      100% { transform:translate(calc(-50% + var(--sx)), calc(-50% + var(--sy))) scale(0.2); opacity:0; }
+    }
+    .legendary-spark::before { --sx:-30px; --sy:-30px; }
+    .legendary-spark::after { --sx:30px; --sy:-30px; }
+  </style>
 </head>
 <body class="bg-gradient-to-br from-black via-gray-900 to-black min-h-screen text-white">
   <header></header>
@@ -30,15 +53,18 @@
       <h1 class="text-4xl font-bold">Vaults</h1>
       <p class="text-gray-300 mt-2">Exclusive limited-time packs where you pick one of five cards to win its coin value.</p>
     </div>
-    <div id="active-pick" class="relative p-8 bg-black/40 backdrop-blur rounded-3xl border border-yellow-500/40 shadow-2xl flex flex-col items-center text-center">
-      <h2 id="pack-name" class="text-3xl font-bold mb-4"></h2>
-      <div class="relative w-40 sm:w-56 mx-auto mb-4">
-        <img id="pack-image" alt="Vault" class="w-full h-auto object-contain mx-auto drop-shadow-xl transform transition-transform duration-300 hover:scale-105">
-        <div id="vault-timer" class="timer-badge absolute -top-4 -right-4 bg-gradient-to-r from-pink-500 to-purple-600 text-white text-sm font-bold px-3 py-1 rounded-full shadow-lg">30:00</div>
+      <div id="active-pick" class="relative p-8 bg-black/40 backdrop-blur rounded-3xl border border-yellow-500/40 shadow-2xl flex flex-col items-center text-center">
+        <h2 id="pack-name" class="text-3xl font-bold mb-4"></h2>
+        <div class="relative w-56 sm:w-72 mx-auto mb-4">
+          <img id="pack-image" alt="Vault" class="relative z-10 w-full h-auto object-contain mx-auto drop-shadow-xl transform transition-transform duration-300 hover:scale-105">
+          <div id="vault-timer" class="timer-badge absolute -top-4 -right-4 bg-gradient-to-r from-pink-500 to-purple-600 text-white text-sm font-bold px-3 py-1 rounded-full shadow-lg">30:00</div>
+        </div>
+        <div class="mb-6 w-full flex flex-col items-center">
+          <h3 class="text-lg font-semibold mb-2">Possible Rewards</h3>
+          <div id="card-slider" class="relative flex overflow-x-auto gap-3 px-1 py-1 scrollbar-hide w-full h-32 sm:h-40"></div>
+        </div>
+        <a id="open-link" href="#" class="open-button glow-button text-lg px-8 py-3 mb-6">Open for <span id="pack-price"></span> <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-5 h-5 inline-block align-[-2px]"></a>
       </div>
-      <div id="card-preview" class="flex justify-center flex-wrap gap-2 sm:gap-4 mb-6"></div>
-      <a id="open-link" href="#" class="open-button glow-button text-lg px-8 py-3 mb-6">Open for <span id="pack-price"></span> <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-5 h-5 inline-block align-[-2px]"></a>
-    </div>
   </section>
   <footer></footer>
   <script src="scripts/header.js"></script>


### PR DESCRIPTION
## Summary
- Loop "Possible Rewards" slider automatically and color each card's border by rarity
- Style top two preview cards behind the pack with rarity colors and legendary spark effect

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899406fdc548320bf1896aaeb5820cf