### PR TITLE
Style Best Drops slider in futuristic container

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,13 +210,16 @@
   <div class="absolute -top-24 -left-24 w-96 h-96 bg-fuchsia-700 rounded-full blur-3xl opacity-25"></div>
   <div class="absolute -bottom-24 -right-24 w-96 h-96 bg-purple-700 rounded-full blur-3xl opacity-25"></div>
 
-  <h2 class="relative flex items-center justify-center gap-3 mb-10 text-3xl md:text-4xl font-extrabold tracking-tight">
-    <span class="animate-pulse bg-pink-600 text-xs px-3 py-1 rounded-full uppercase tracking-widest">Live</span>
-    <span class="bg-gradient-to-r from-cyan-400 via-fuchsia-500 to-purple-600 bg-clip-text text-transparent drop-shadow-[0_0_12px_rgba(168,85,247,0.6)]">Best Drops</span>
-  </h2>
-
-  <div id="recent-wins-carousel" class="relative flex overflow-x-auto gap-6 px-6 py-4 scrollbar-hide w-full scroll-smooth">
-    <!-- Cards will be injected here -->
+  <div class="mx-auto max-w-5xl px-6">
+    <div class="relative rounded-2xl bg-gradient-to-r from-cyan-500/10 via-fuchsia-500/10 to-purple-500/10 border border-fuchsia-500/20 backdrop-blur-xl shadow-[0_0_25px_rgba(168,85,247,0.3)] p-6">
+      <div class="flex items-center gap-3 mb-6">
+        <i class="fa-solid fa-bolt text-fuchsia-400 text-2xl"></i>
+        <h2 class="text-2xl md:text-3xl font-extrabold tracking-tight bg-gradient-to-r from-cyan-400 via-fuchsia-500 to-purple-600 bg-clip-text text-transparent drop-shadow-[0_0_12px_rgba(168,85,247,0.6)]">Best Drops</h2>
+      </div>
+      <div id="recent-wins-carousel" class="relative flex overflow-x-auto gap-6 py-2 scrollbar-hide w-full scroll-smooth">
+        <!-- Cards will be injected here -->
+      </div>
+    </div>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- Wrap Best Drops section with futuristic gradient container
- Add bolt icon alongside section heading
- Remove flashing "Live" badge for cleaner look

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689956da8194832087df044c763130f3