### PR TITLE
Add demo animation for hero spinner

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,6 +101,8 @@
             <div id="spinner-container-hero" class="w-full h-full transform"></div>
           </div>
         </div>
+        <img id="demo-ship-dest" src="https://cdn-icons-png.flaticon.com/128/1041/1041916.png" class="absolute bottom-2 left-2 w-10 h-10 pointer-events-none" alt="Package" />
+        <img id="demo-sell-dest" src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="absolute bottom-2 right-2 w-10 h-10 pointer-events-none" alt="Coins" />
       </div>
     </div>
 

--- a/scripts/hero-spinner.js
+++ b/scripts/hero-spinner.js
@@ -48,11 +48,52 @@ async function initHeroSpinner() {
       )
     );
 
-    await spinToPrize(() => {}, false, 'hero');
-    setTimeout(spin, 2500);
+    const prize = await spinToPrize(() => {}, false, 'hero');
+    await demoAnimation(prize);
+    setTimeout(spin, 1000);
   }
 
   spin();
+}
+
+function demoAnimation(prize) {
+  return new Promise(resolve => {
+    const border = document.getElementById('spinner-border-hero');
+    const wrapper = border?.parentElement;
+    const sellDest = document.getElementById('demo-sell-dest');
+    const shipDest = document.getElementById('demo-ship-dest');
+    if (!wrapper || !sellDest || !shipDest || !prize) return resolve();
+
+    const action = Math.random() < 0.5 ? 'sell' : 'ship';
+    const destEl = action === 'sell' ? sellDest : shipDest;
+
+    const card = document.createElement('img');
+    card.src = prize.image || '';
+    card.className = 'demo-card absolute rounded-lg shadow-lg';
+    const width = 80;
+    const height = 100;
+    const wrapperRect = wrapper.getBoundingClientRect();
+    card.style.width = `${width}px`;
+    card.style.height = `${height}px`;
+    card.style.left = `${wrapperRect.width / 2 - width / 2}px`;
+    card.style.top = `${wrapperRect.height / 2 - height / 2}px`;
+    card.style.opacity = '1';
+    wrapper.appendChild(card);
+
+    requestAnimationFrame(() => {
+      const destRect = destEl.getBoundingClientRect();
+      const latestWrapperRect = wrapper.getBoundingClientRect();
+      const dx = destRect.left + destRect.width / 2 - (latestWrapperRect.left + latestWrapperRect.width / 2);
+      const dy = destRect.top + destRect.height / 2 - (latestWrapperRect.top + latestWrapperRect.height / 2);
+      card.style.transform = `translate(${dx}px, ${dy}px) scale(0.5)`;
+      card.style.opacity = '0';
+    });
+
+    card.addEventListener('transitionend', () => {
+      card.remove();
+      resolve();
+    }, { once: true });
+  });
 }
 
 document.addEventListener('DOMContentLoaded', initHeroSpinner);

--- a/styles/main.css
+++ b/styles/main.css
@@ -1039,3 +1039,9 @@ html {
   pointer-events: none;
 }
 
+/* Demo card animation */
+.demo-card {
+  transition: transform 1s ease, opacity 1s ease;
+  pointer-events: none;
+}
+


### PR DESCRIPTION
## Summary
- Loop hero spinner with post-spin demo animation
- Show card moving to sell or ship icons before restarting
- Add styling for demo card element

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689958780d6c8320a52007f6604d330b