### PR TITLE
Add demo animation for hero spinner

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,8 @@
         'shadow-[0_0_8px_1px_rgba(50,205,50,0.4)]',
         'border-green-500',
         'shadow-[0_0_6px_1px_rgba(255,255,255,0.1)]',
-        'border-gray-700'
+        'border-gray-700',
+        'animate-pulse'
       ]
     }
   </script>
@@ -101,6 +102,9 @@
             <div id="spinner-container-hero" class="w-full h-full transform"></div>
           </div>
         </div>
+        <div id="demo-label" class="absolute bottom-16 left-1/2 -translate-x-1/2 text-xs text-gray-200 opacity-0 transition-opacity duration-500 pointer-events-none"></div>
+        <img id="demo-ship-dest" src="https://cdn-icons-png.flaticon.com/128/1041/1041916.png" class="absolute bottom-2 left-2 w-10 h-10 pointer-events-none" alt="Package" />
+        <img id="demo-sell-dest" src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="absolute bottom-2 right-2 w-10 h-10 pointer-events-none" alt="Coins" />
       </div>
     </div>
 

--- a/scripts/hero-spinner.js
+++ b/scripts/hero-spinner.js
@@ -48,11 +48,65 @@ async function initHeroSpinner() {
       )
     );
 
-    await spinToPrize(() => {}, false, 'hero');
-    setTimeout(spin, 2500);
+    const prize = await spinToPrize(() => {}, false, 'hero');
+    await demoAnimation(prize);
+    setTimeout(spin, 1000);
   }
 
   spin();
+}
+
+async function demoAnimation(prize) {
+  const border = document.getElementById('spinner-border-hero');
+  const wrapper = border?.parentElement;
+  const sellDest = document.getElementById('demo-sell-dest');
+  const shipDest = document.getElementById('demo-ship-dest');
+  const labelEl = document.getElementById('demo-label');
+  if (!wrapper || !sellDest || !shipDest || !prize || !labelEl) return;
+
+  await animateTo(shipDest, 'Ship to you');
+  await animateTo(sellDest, 'Sell back for coins');
+
+  function animateTo(destEl, text) {
+    return new Promise(resolve => {
+      const card = document.createElement('img');
+      card.src = prize.image || '';
+      card.className = 'demo-card absolute rounded-lg shadow-lg';
+      const width = 80;
+      const height = 100;
+      const wrapperRect = wrapper.getBoundingClientRect();
+      card.style.width = `${width}px`;
+      card.style.height = `${height}px`;
+      card.style.left = `${wrapperRect.width / 2 - width / 2}px`;
+      card.style.top = `${wrapperRect.height / 2 - height / 2}px`;
+      card.style.opacity = '1';
+      wrapper.appendChild(card);
+
+      labelEl.textContent = text;
+      labelEl.style.opacity = '1';
+      destEl.classList.add('animate-pulse');
+
+      requestAnimationFrame(() => {
+        const destRect = destEl.getBoundingClientRect();
+        const latestWrapperRect = wrapper.getBoundingClientRect();
+        const dx = destRect.left + destRect.width / 2 - (latestWrapperRect.left + latestWrapperRect.width / 2);
+        const dy = destRect.top + destRect.height / 2 - (latestWrapperRect.top + latestWrapperRect.height / 2);
+        card.style.transform = `translate(${dx}px, ${dy}px) scale(0.5)`;
+        card.style.opacity = '0';
+      });
+
+      card.addEventListener(
+        'transitionend',
+        () => {
+          destEl.classList.remove('animate-pulse');
+          labelEl.style.opacity = '0';
+          card.remove();
+          setTimeout(resolve, 500);
+        },
+        { once: true }
+      );
+    });
+  }
 }
 
 document.addEventListener('DOMContentLoaded', initHeroSpinner);

--- a/styles/main.css
+++ b/styles/main.css
@@ -1039,3 +1039,9 @@ html {
   pointer-events: none;
 }
 
+/* Demo card animation */
+.demo-card {
+  transition: transform 1s ease, opacity 1s ease;
+  pointer-events: none;
+}
+


### PR DESCRIPTION
## Summary
- Loop hero spinner with step-by-step demo after each spin
- Show card moving to ship and sell icons with explanatory label
- Safelist animate-pulse class for runtime highlighting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689958780d6c8320a52007f6604d330b