### PR TITLE
feat: add mascot preloader with progress

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -43,6 +43,7 @@
   </style>
 </head>
 <body>
+<script src="scripts/preloader.js"></script>
   <div id="toast"></div>
   <nav class="w-full px-6 py-4 bg-gray-900 border-b border-gray-800 flex justify-between items-center">
     <div class="text-xl font-bold text-white">PrimePull.gg Admin</div>

--- a/auth.html
+++ b/auth.html
@@ -16,6 +16,7 @@
   </style>
 </head>
 <body class="flex items-center justify-center min-h-screen px-4 bg-gradient-to-br from-gray-900 via-purple-900 to-black">
+<script src="scripts/preloader.js"></script>
 
   <div class="bg-gray-900/80 backdrop-blur-sm p-10 rounded-xl shadow-2xl w-full max-w-md border border-gray-700">
     <h2 id="form-title" class="mb-8 text-center">

--- a/case.html
+++ b/case.html
@@ -43,6 +43,7 @@
 
 </head>
   <body class="bg-gradient-to-br from-gray-900 via-purple-900 to-black text-white overflow-x-hidden">
+<script src="scripts/preloader.js"></script>
       <canvas id="particle-canvas"></canvas>
       <header></header>
 <section id="case-content" class="relative pt-32 pb-10 px-4">

--- a/contact.html
+++ b/contact.html
@@ -36,6 +36,7 @@
   </style>
 </head>
 <body class="min-h-screen">
+<script src="scripts/preloader.js"></script>
 
 <header></header>
 

--- a/faq.html
+++ b/faq.html
@@ -41,6 +41,7 @@
   </style>
 </head>
 <body class="min-h-screen">
+<script src="scripts/preloader.js"></script>
 
 <header></header>
 

--- a/how-it-works.html
+++ b/how-it-works.html
@@ -60,6 +60,7 @@
   </style>
 </head>
 <body>
+<script src="scripts/preloader.js"></script>
   <header></header>
 
   <!-- 🔥 Upgraded How It Works Section -->

--- a/index.html
+++ b/index.html
@@ -52,6 +52,10 @@
 <link rel="stylesheet" href="styles/main.css">
 </head>
 <body>
+<div id="preloader" class="fixed inset-0 flex flex-col items-center justify-center bg-gray-900 text-white z-50 transition-opacity duration-500">
+  <img src="https://firebasestorage.googleapis.com/v0/b/cases-e5b4e.firebasestorage.app/o/ChatGPT%20Image%20Aug%2010%2C%202025%2C%2011_08_17%20PM.png?alt=media&token=4950e6a0-1cf9-4c7b-aa56-686dc42693a8" alt="Mascot" class="w-40 h-40 mb-6 animate-bounce">
+  <div id="preloader-progress" class="text-2xl font-bold">0%</div>
+</div>
 
 <header></header>
 
@@ -311,6 +315,24 @@ document.addEventListener("DOMContentLoaded", () => {
     startAutoScrollCarousel("recent-wins-carousel", 0.5);
 });
 </script>
-  <script src="scripts/header.js"></script>
+<script src="scripts/header.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const preloader = document.getElementById('preloader');
+  const progress = document.getElementById('preloader-progress');
+  let current = 0;
+  const interval = setInterval(() => {
+    current = Math.min(current + Math.random() * 10, 90);
+    progress.textContent = `${Math.floor(current)}%`;
+  }, 100);
+
+  window.addEventListener('load', () => {
+    clearInterval(interval);
+    progress.textContent = '100%';
+    preloader.classList.add('opacity-0');
+    setTimeout(() => preloader.style.display = 'none', 500);
+  });
+});
+</script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -52,11 +52,7 @@
 <link rel="stylesheet" href="styles/main.css">
 </head>
 <body>
-<div id="preloader" class="fixed inset-0 flex flex-col items-center justify-center bg-gray-900 text-white z-50 transition-opacity duration-500">
-  <img src="https://firebasestorage.googleapis.com/v0/b/cases-e5b4e.firebasestorage.app/o/ChatGPT%20Image%20Aug%2010%2C%202025%2C%2011_08_17%20PM.png?alt=media&token=4950e6a0-1cf9-4c7b-aa56-686dc42693a8" alt="Mascot" class="w-40 h-40 mb-6 animate-bounce">
-  <div id="preloader-progress" class="text-2xl font-bold">0%</div>
-</div>
-
+<script src="scripts/preloader.js"></script>
 <header></header>
 
 <!-- Hero -->
@@ -315,24 +311,6 @@ document.addEventListener("DOMContentLoaded", () => {
     startAutoScrollCarousel("recent-wins-carousel", 0.5);
 });
 </script>
-<script src="scripts/header.js"></script>
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-  const preloader = document.getElementById('preloader');
-  const progress = document.getElementById('preloader-progress');
-  let current = 0;
-  const interval = setInterval(() => {
-    current = Math.min(current + Math.random() * 10, 90);
-    progress.textContent = `${Math.floor(current)}%`;
-  }, 100);
-
-  window.addEventListener('load', () => {
-    clearInterval(interval);
-    progress.textContent = '100%';
-    preloader.classList.add('opacity-0');
-    setTimeout(() => preloader.style.display = 'none', 500);
-  });
-});
-</script>
+  <script src="scripts/header.js"></script>
 </body>
 </html>

--- a/inventory.html
+++ b/inventory.html
@@ -143,6 +143,7 @@
   </style>
 </head>
 <body class="min-h-screen">
+<script src="scripts/preloader.js"></script>
 
   <!-- Dynamic Header -->
   <header></header>

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -24,6 +24,7 @@
   </style>
 </head>
 <body class="bg-gray-900 text-white min-h-screen">
+<script src="scripts/preloader.js"></script>
   <header></header>
 
   <section class="relative pt-32 pb-24 text-center overflow-hidden">

--- a/marketplace.html
+++ b/marketplace.html
@@ -17,6 +17,7 @@
   <script src="https://js.stripe.com/v3/"></script>
 </head>
 <body class="bg-gradient-to-br from-gray-950 via-gray-900 to-black text-white min-h-screen">
+<script src="scripts/preloader.js"></script>
   <header></header>
 
   <section class="pt-32 pb-16 px-4 max-w-7xl mx-auto">

--- a/profile.html
+++ b/profile.html
@@ -31,6 +31,7 @@
   </style>
 </head>
 <body class="min-h-screen relative">
+<script src="scripts/preloader.js"></script>
   <header></header>
 
   <!-- Decorative pack images -->

--- a/rewards.html
+++ b/rewards.html
@@ -46,6 +46,7 @@
   </style>
 </head>
 <body>
+<script src="scripts/preloader.js"></script>
   <header></header>
   <main class="min-h-screen flex flex-col items-center gap-10 px-4 pt-32">
     <section class="reward-card w-full max-w-2xl flex flex-col items-center text-center gap-6">

--- a/scripts/case.html
+++ b/scripts/case.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="styles/main.css" />
 </head>
 <body class="bg-gray-900 text-white p-6">
+<script src="preloader.js"></script>
   <div class="max-w-4xl mx-auto">
     <div class="text-center mb-8">
       <h1 id="case-name" class="text-3xl font-bold mb-2"></h1>

--- a/scripts/preloader.js
+++ b/scripts/preloader.js
@@ -1,0 +1,63 @@
+(() => {
+  const style = document.createElement('style');
+  style.textContent = `
+    #preloader {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      background-color: #111827;
+      color: #ffffff;
+      z-index: 9999;
+      transition: opacity 0.5s ease;
+    }
+    #preloader.fade-out {
+      opacity: 0;
+    }
+    #preloader img {
+      width: 10rem;
+      height: 10rem;
+      margin-bottom: 1.5rem;
+      animation: bounce 1s infinite;
+    }
+    #preloader-progress {
+      font-size: 1.5rem;
+      font-weight: 700;
+    }
+    @keyframes bounce {
+      0%, 100% {
+        transform: translateY(-25%);
+        animation-timing-function: cubic-bezier(0.8,0,1,1);
+      }
+      50% {
+        transform: translateY(0);
+        animation-timing-function: cubic-bezier(0,0,0.2,1);
+      }
+    }
+  `;
+  document.head.appendChild(style);
+
+  const preloader = document.createElement('div');
+  preloader.id = 'preloader';
+  preloader.innerHTML = `
+    <img src="https://firebasestorage.googleapis.com/v0/b/cases-e5b4e.firebasestorage.app/o/ChatGPT%20Image%20Aug%2010%2C%202025%2C%2011_08_17%20PM.png?alt=media&token=4950e6a0-1cf9-4c7b-aa56-686dc42693a8" alt="Mascot">
+    <div id="preloader-progress">0%</div>
+  `;
+  document.body.appendChild(preloader);
+
+  let current = 0;
+  const progressEl = document.getElementById('preloader-progress');
+  const interval = setInterval(() => {
+    current = Math.min(current + Math.random() * 10, 90);
+    progressEl.textContent = `${Math.floor(current)}%`;
+  }, 100);
+
+  window.addEventListener('load', () => {
+    clearInterval(interval);
+    progressEl.textContent = '100%';
+    preloader.classList.add('fade-out');
+    setTimeout(() => preloader.remove(), 500);
+  });
+})();

--- a/shipping.html
+++ b/shipping.html
@@ -37,6 +37,7 @@
   </style>
 </head>
 <body class="min-h-screen">
+<script src="scripts/preloader.js"></script>
   <header></header>
   <main class="pt-32 pb-24 px-4 flex justify-center">
     <div class="panel w-full max-w-md p-6">

--- a/termsandconditions.html
+++ b/termsandconditions.html
@@ -36,6 +36,7 @@
   </style>
 </head>
 <body class="min-h-screen">
+<script src="scripts/preloader.js"></script>
 
 <header></header>
 

--- a/vault.html
+++ b/vault.html
@@ -75,6 +75,7 @@
     </style>
   </head>
   <body class="bg-gradient-to-br from-black via-gray-900 to-black text-white overflow-x-hidden">
+<script src="scripts/preloader.js"></script>
   <canvas id="particle-canvas"></canvas>
   <header></header>
 

--- a/vaults.html
+++ b/vaults.html
@@ -47,6 +47,7 @@
   </style>
 </head>
 <body class="bg-gradient-to-br from-black via-gray-900 to-black min-h-screen text-white">
+<script src="scripts/preloader.js"></script>
   <header></header>
   <section class="pt-32 pb-20 max-w-4xl mx-auto px-4">
     <div class="text-center mb-8">

--- a/verify.html
+++ b/verify.html
@@ -15,6 +15,7 @@
   <link rel="stylesheet" href="styles/main.css" />
 </head>
 <body class="bg-gray-900 text-white min-h-screen font-[Poppins]">
+<script src="scripts/preloader.js"></script>
 <header></header>
 <section class="pt-32 px-6">
   <div class="max-w-md mx-auto bg-gray-800 p-6 rounded-xl shadow-lg space-y-4">


### PR DESCRIPTION
## Summary
- add full-screen preloader with bouncing mascot and progress percent
- fade out preloader once page fully loaded

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68995ed67fb88320a67aa34cc4a38eeb