### PR TITLE
Add Provably Fair badge and functionality to vault pages

### DIFF
--- a/scripts/vault.js
+++ b/scripts/vault.js
@@ -278,4 +278,62 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('win-popup').classList.add('hidden');
     resetGame();
   });
+
+  const pfBtn = document.getElementById('pf-info');
+  if (pfBtn) {
+    pfBtn.addEventListener('click', async () => {
+      const user = firebase.auth().currentUser;
+      if (!user) return;
+
+      const fairSnap = await firebase.database().ref(`users/${user.uid}/provablyFair`).once('value');
+      const fairData = fairSnap.val();
+
+      document.getElementById('pf-server-seed').textContent = fairData?.serverSeed || 'Not found';
+      document.getElementById('pf-client-seed').textContent = fairData?.clientSeed || 'Not found';
+      document.getElementById('pf-nonce').textContent = fairData?.nonce ?? 'Not found';
+
+      document.getElementById('provably-fair-modal').classList.remove('hidden');
+    });
+
+    document.getElementById('update-client-seed').addEventListener('click', async () => {
+      const user = firebase.auth().currentUser;
+      if (!user) return;
+      const newSeed = document.getElementById('client-seed-input').value.trim();
+      if (!newSeed) return;
+      await firebase.database().ref(`users/${user.uid}/provablyFair`).update({ clientSeed: newSeed, nonce: 0 });
+      document.getElementById('pf-client-seed').textContent = newSeed;
+      document.getElementById('pf-nonce').textContent = 0;
+    });
+
+    document.getElementById('new-server-seed').addEventListener('click', async () => {
+      const user = firebase.auth().currentUser;
+      if (!user) return;
+      const serverSeed = generateRandomString(64);
+      const serverSeedHash = await sha256(serverSeed);
+      const clientSeed = document.getElementById('pf-client-seed').textContent || 'default';
+      await firebase.database().ref(`users/${user.uid}/provablyFair`).set({
+        serverSeed,
+        serverSeedHash,
+        clientSeed,
+        nonce: 0
+      });
+      document.getElementById('pf-server-seed').textContent = serverSeed;
+      document.getElementById('pf-nonce').textContent = 0;
+    });
+  }
 });
+
+function generateRandomString(length) {
+  const charset = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  let result = '';
+  for (let i = 0; i < length; i++) {
+    result += charset.charAt(Math.floor(Math.random() * charset.length));
+  }
+  return result;
+}
+
+async function sha256(message) {
+  const data = new TextEncoder().encode(message);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  return [...new Uint8Array(hashBuffer)].map(b => b.toString(16).padStart(2, '0')).join('');
+}

--- a/scripts/vaults.js
+++ b/scripts/vaults.js
@@ -105,5 +105,65 @@ function loadVaults() {
   });
 }
 
-document.addEventListener('DOMContentLoaded', loadVaults);
+document.addEventListener('DOMContentLoaded', () => {
+  loadVaults();
+
+  const pfBtn = document.getElementById('pf-info');
+  if (pfBtn) {
+    pfBtn.addEventListener('click', async () => {
+      const user = firebase.auth().currentUser;
+      if (!user) return;
+
+      const fairSnap = await firebase.database().ref(`users/${user.uid}/provablyFair`).once('value');
+      const fairData = fairSnap.val();
+
+      document.getElementById('pf-server-seed').textContent = fairData?.serverSeed || 'Not found';
+      document.getElementById('pf-client-seed').textContent = fairData?.clientSeed || 'Not found';
+      document.getElementById('pf-nonce').textContent = fairData?.nonce ?? 'Not found';
+
+      document.getElementById('provably-fair-modal').classList.remove('hidden');
+    });
+
+    document.getElementById('update-client-seed').addEventListener('click', async () => {
+      const user = firebase.auth().currentUser;
+      if (!user) return;
+      const newSeed = document.getElementById('client-seed-input').value.trim();
+      if (!newSeed) return;
+      await firebase.database().ref(`users/${user.uid}/provablyFair`).update({ clientSeed: newSeed, nonce: 0 });
+      document.getElementById('pf-client-seed').textContent = newSeed;
+      document.getElementById('pf-nonce').textContent = 0;
+    });
+
+    document.getElementById('new-server-seed').addEventListener('click', async () => {
+      const user = firebase.auth().currentUser;
+      if (!user) return;
+      const serverSeed = generateRandomString(64);
+      const serverSeedHash = await sha256(serverSeed);
+      const clientSeed = document.getElementById('pf-client-seed').textContent || 'default';
+      await firebase.database().ref(`users/${user.uid}/provablyFair`).set({
+        serverSeed,
+        serverSeedHash,
+        clientSeed,
+        nonce: 0
+      });
+      document.getElementById('pf-server-seed').textContent = serverSeed;
+      document.getElementById('pf-nonce').textContent = 0;
+    });
+  }
+});
+
+function generateRandomString(length) {
+  const charset = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  let result = '';
+  for (let i = 0; i < length; i++) {
+    result += charset.charAt(Math.floor(Math.random() * charset.length));
+  }
+  return result;
+}
+
+async function sha256(message) {
+  const data = new TextEncoder().encode(message);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  return [...new Uint8Array(hashBuffer)].map(b => b.toString(16).padStart(2, '0')).join('');
+}
 

--- a/vault.html
+++ b/vault.html
@@ -143,6 +143,26 @@
     </div>
   </div>
 
+  <!-- Provably Fair Modal -->
+  <div id="provably-fair-modal" class="hidden fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-50">
+    <div class="bg-gray-900 p-4 rounded-xl w-full max-w-sm text-white relative border border-white/10">
+      <button onclick="document.getElementById('provably-fair-modal').classList.add('hidden')" class="absolute top-2 right-3 text-white text-xl">&times;</button>
+      <h3 class="text-lg font-bold mb-3">Provably Fair</h3>
+      <p class="text-xs text-gray-300 mb-4">All outcomes are generated using your client seed, our server seed, and a nonce. The resulting roll is compared against the case odds to decide the prize, ensuring every spin is fair and verifiable.</p>
+      <div class="text-left text-xs space-y-2 font-mono text-gray-100 break-words">
+        <div><strong>Server Seed:</strong> <span id="pf-server-seed">...</span></div>
+        <div><strong>Client Seed:</strong> <span id="pf-client-seed">...</span></div>
+        <div><strong>Nonce:</strong> <span id="pf-nonce">...</span></div>
+      </div>
+      <div class="mt-4 space-y-2 text-xs">
+        <input id="client-seed-input" type="text" placeholder="New client seed" class="w-full px-2 py-1 rounded bg-gray-800 text-white" />
+        <button id="update-client-seed" class="w-full bg-green-600 hover:bg-green-500 rounded py-2 text-white">Update Client Seed</button>
+        <button id="new-server-seed" class="w-full bg-purple-600 hover:bg-purple-500 rounded py-2 text-white">New Server Seed</button>
+        <a href="verify.html" class="block text-center text-blue-400 hover:underline mt-2">Verify a roll</a>
+      </div>
+    </div>
+  </div>
+
   <footer></footer>
 
   <script src="scripts/header.js"></script>

--- a/vaults.html
+++ b/vaults.html
@@ -59,6 +59,12 @@
           <img id="pack-image" alt="Vault" class="relative z-10 w-full h-auto object-contain mx-auto drop-shadow-xl transform transition-transform duration-300 hover:scale-105">
           <div id="vault-timer" class="timer-badge absolute -top-4 -right-4 bg-gradient-to-r from-pink-500 to-purple-600 text-white text-sm font-bold px-3 py-1 rounded-full shadow-lg">30:00</div>
         </div>
+        <div class="flex justify-center mb-4">
+          <button id="pf-info" class="flex items-center gap-2 text-sm font-semibold text-green-400 hover:text-green-300 transition cursor-pointer">
+            <i class="fa-solid fa-shield-halved text-green-400 text-base drop-shadow"></i>
+            <span>Provably Fair</span>
+          </button>
+        </div>
         <div class="mb-6 w-full flex flex-col items-center">
           <h3 class="text-lg font-semibold mb-2">Possible Rewards</h3>
           <div id="card-slider" class="relative flex overflow-x-auto gap-3 px-1 py-1 scrollbar-hide w-full h-32 sm:h-40"></div>
@@ -66,6 +72,25 @@
         <a id="open-link" href="#" class="open-button glow-button text-lg px-8 py-3 mb-6">Open for <span id="pack-price"></span> <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-5 h-5 inline-block align-[-2px]"></a>
       </div>
   </section>
+  <!-- Provably Fair Modal -->
+  <div id="provably-fair-modal" class="hidden fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-50">
+    <div class="bg-gray-900 p-4 rounded-xl w-full max-w-sm text-white relative border border-white/10">
+      <button onclick="document.getElementById('provably-fair-modal').classList.add('hidden')" class="absolute top-2 right-3 text-white text-xl">&times;</button>
+      <h3 class="text-lg font-bold mb-3">Provably Fair</h3>
+      <p class="text-xs text-gray-300 mb-4">All outcomes are generated using your client seed, our server seed, and a nonce. The resulting roll is compared against the case odds to decide the prize, ensuring every spin is fair and verifiable.</p>
+      <div class="text-left text-xs space-y-2 font-mono text-gray-100 break-words">
+        <div><strong>Server Seed:</strong> <span id="pf-server-seed">...</span></div>
+        <div><strong>Client Seed:</strong> <span id="pf-client-seed">...</span></div>
+        <div><strong>Nonce:</strong> <span id="pf-nonce">...</span></div>
+      </div>
+      <div class="mt-4 space-y-2 text-xs">
+        <input id="client-seed-input" type="text" placeholder="New client seed" class="w-full px-2 py-1 rounded bg-gray-800 text-white" />
+        <button id="update-client-seed" class="w-full bg-green-600 hover:bg-green-500 rounded py-2 text-white">Update Client Seed</button>
+        <button id="new-server-seed" class="w-full bg-purple-600 hover:bg-purple-500 rounded py-2 text-white">New Server Seed</button>
+        <a href="verify.html" class="block text-center text-blue-400 hover:underline mt-2">Verify a roll</a>
+      </div>
+    </div>
+  </div>
   <footer></footer>
   <script src="scripts/header.js"></script>
   <script src="scripts/footer.js"></script>


### PR DESCRIPTION
## Summary
- show Provably Fair badge under vault pack and add modal with seed info
- enable Provably Fair seed management on vault listing and detail pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68995f3d02088320b082ba17e0bbed70