### PR TITLE
Display precise prize odds

### DIFF
--- a/case.html
+++ b/case.html
@@ -154,6 +154,11 @@ const formatCoins = (num) => {
   return num.toLocaleString();
 };
 
+const formatOdds = (odds) => {
+  const decimals = odds < 1 ? 3 : 1;
+  return parseFloat((odds || 0).toFixed(decimals));
+};
+
 async function sellPrize(prize) {
   const user = firebase.auth().currentUser;
   if (!user || !prize) return;
@@ -432,7 +437,7 @@ if (spinSelect) {
       ${formatCoins(prize.value || 0)}
     </div>
     <div class="absolute bottom-2 right-2 text-white/70 bg-black/40 px-2 py-[2px] text-xs rounded-full">
-      ${(prize.odds || 0).toFixed(1)}%
+      ${formatOdds(prize.odds)}%
     </div>
   </div>
   `;


### PR DESCRIPTION
## Summary
- format odds with up to three decimals when below 1%
- display formatted odds in case rewards table

## Testing
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689964dd6c8c832090f54cc2bcd6c71f