### PR TITLE
Move hero spinner badge to bottom right

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
 
       <!-- Demo Spinner -->
       <div class="flex-1 md:flex-none relative w-full h-64 md:w-80 md:h-80 flex flex-col items-center justify-center gap-4">
-        <div id="hero-pack-badge" class="absolute -top-6 -left-6 flex flex-col items-center text-center pointer-events-none z-20">
+        <div id="hero-pack-badge" class="absolute -bottom-6 -right-6 flex flex-col items-center text-center pointer-events-none z-20">
           <img id="hero-pack-image" src="" alt="Heat Check pack" class="w-16 md:w-20 rounded-lg shadow-lg" />
         </div>
         <div id="spinner-border-hero" class="hero-spinner-border w-full h-full flex items-center justify-center p-4">


### PR DESCRIPTION
## Summary
- reposition hero pack image badge from top-left to bottom-right of spinner for improved layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899652ddbc88320befe931378a67f11