### PR TITLE
Disable signup popup after dismissal

### DIFF
--- a/scripts/header.js
+++ b/scripts/header.js
@@ -372,14 +372,17 @@ document.addEventListener("DOMContentLoaded", () => {
   document.body.insertAdjacentHTML('beforeend', signupPopupHtml);
 
   const signupPopup = document.getElementById('signup-popup');
-  const closeSignup = () => signupPopup.classList.add('hidden');
+  const closeSignup = () => {
+    signupPopup.classList.add('hidden');
+    sessionStorage.setItem('signupPopupClosed', 'true');
+  };
   document.getElementById('signup-popup-close')?.addEventListener('click', closeSignup);
   document.getElementById('signup-popup-dismiss')?.addEventListener('click', closeSignup);
 
   firebase.auth().onAuthStateChanged(user => {
-    if (!user) {
+    if (!user && !sessionStorage.getItem('signupPopupClosed')) {
       setTimeout(() => {
-        if (!firebase.auth().currentUser) {
+        if (!firebase.auth().currentUser && !sessionStorage.getItem('signupPopupClosed')) {
           signupPopup.classList.remove('hidden');
         }
       }, 7000);


### PR DESCRIPTION
## Summary
- Remember when the signup prompt is dismissed and hide it for the rest of the session

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899739257408320863abacf7ceda2ae