### PR TITLE
Refresh navigation styling and organize mobile menus

### DIFF
--- a/scripts/header.js
+++ b/scripts/header.js
@@ -92,13 +92,15 @@ document.addEventListener("DOMContentLoaded", () => {
             <a id="drawer-register" href="auth.html?register=true" class="w-full text-center py-2 bg-blue-600 rounded text-white">Register</a>
           </div>
           <nav class="flex flex-col gap-2">
+            <div class="text-gray-400 text-xs uppercase px-4 mt-2">Navigation</div>
             <a href="index.html" class="block px-4 py-2 text-sm text-white rounded hover:bg-gray-800 flex items-center gap-2"><i class="fas fa-cube"></i> Open Packs</a>
+            <a href="vaults.html" class="block px-4 py-2 text-sm text-yellow-400 rounded hover:bg-gray-800 flex items-center gap-2"><i class="fas fa-lock"></i> Vaults</a>
+            <a href="leaderboard.html" class="block px-4 py-2 text-sm text-blue-400 rounded hover:bg-gray-800 flex items-center gap-2"><i class="fas fa-trophy"></i> Leaderboard</a>
+            <a href="marketplace.html" class="block px-4 py-2 text-sm text-pink-400 rounded hover:bg-gray-800 flex items-center gap-2"><i class="fas fa-store"></i> Marketplace</a>
+            <div class="text-gray-400 text-xs uppercase px-4 mt-4">Account</div>
             <a id="drawer-inventory-link" href="inventory.html" class="block px-4 py-2 text-sm text-white rounded hover:bg-gray-800 flex items-center gap-2 hidden"><i class="fas fa-box-open"></i> Inventory</a>
             <a id="drawer-profile-link" href="profile.html" class="block px-4 py-2 text-sm text-white rounded hover:bg-gray-800 flex items-center gap-2 hidden"><i class="fas fa-user"></i> Profile</a>
-              <a href="how-it-works.html" class="how-it-works-link block px-4 py-2 text-sm text-white rounded hover:bg-gray-800 flex items-center gap-2"><i class="fas fa-question-circle"></i> How It Works</a>
-            <a href="vaults.html" class="block px-4 py-2 text-sm text-yellow-400 rounded hover:bg-gray-800 flex items-center gap-2"><i class="fas fa-lock"></i> Vaults</a>
-            <a href="marketplace.html" class="block px-4 py-2 text-sm text-pink-400 rounded hover:bg-gray-800 flex items-center gap-2"><i class="fas fa-store"></i> Marketplace</a>
-            <a href="leaderboard.html" class="block px-4 py-2 text-sm text-blue-400 rounded hover:bg-gray-800 flex items-center gap-2"><i class="fas fa-trophy"></i> Leaderboard</a>
+            <a href="how-it-works.html" class="how-it-works-link block px-4 py-2 text-sm text-white rounded hover:bg-gray-800 flex items-center gap-2"><i class="fas fa-question-circle"></i> How It Works</a>
             <a id="drawer-logout" href="#" class="block px-4 py-2 text-sm text-red-400 rounded hover:bg-gray-800 flex items-center gap-2 hidden"><i class="fas fa-sign-out-alt"></i> Logout</a>
           </nav>
         </div>
@@ -120,10 +122,6 @@ document.addEventListener("DOMContentLoaded", () => {
           <i class="fas fa-lock text-lg"></i>
           <span>Vaults</span>
           <span id="vault-nav-timer" class="text-[10px]">--:--</span>
-        </a>
-        <a href="marketplace.html" class="flex flex-col items-center text-xs text-pink-400">
-          <i class="fas fa-store text-lg"></i>
-          <span>Market</span>
         </a>
       </nav>
     `; // <-- closing backtick and semicolon!

--- a/styles/main.css
+++ b/styles/main.css
@@ -889,63 +889,23 @@ html {
 
 /* --- Crazy header/nav redesign --- */
   .crazy-nav {
-    background: rgba(17, 17, 23, 0.8);
+    background: rgba(17, 17, 23, 0.9);
     backdrop-filter: blur(12px);
-    border-bottom: 2px solid rgba(255, 255, 255, 0.1);
-    box-shadow: 0 0 25px rgba(236, 72, 153, 0.3), 0 0 50px rgba(147, 51, 234, 0.2);
-    position: relative;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
   }
 
-.crazy-nav::before {
-  content: '';
-  position: absolute;
-  inset: -2px;
-  background: linear-gradient(90deg, #ec4899, #9333ea, #3b82f6, #ec4899);
-  background-size: 300% 300%;
-  animation: borderDance 8s linear infinite;
-  z-index: -2;
-}
-
-.crazy-nav::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: rgba(17, 17, 23, 0.95);
-  z-index: -1;
-}
-
-@keyframes borderDance {
-  0% { background-position: 0% 50%; }
-  50% { background-position: 100% 50%; }
-  100% { background-position: 0% 50%; }
-}
-
 .nav-link {
-  position: relative;
   display: flex;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0.25rem 0.5rem;
-  border-radius: 0.5rem;
-  transition: color 0.3s, transform 0.3s;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.375rem;
+  transition: background-color 0.3s, color 0.3s;
 }
 
 .nav-link:hover {
-  transform: translateY(-2px);
-}
-
-.nav-link::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  opacity: 0;
-  box-shadow: 0 0 10px currentColor, 0 0 20px currentColor;
-  transition: opacity 0.3s;
-}
-
-.nav-link:hover::after {
-  opacity: 0.5;
+  background-color: rgba(255, 255, 255, 0.05);
 }
 
 .neon-balance {
@@ -971,6 +931,11 @@ html {
   transform: translateY(-2px);
 }
 
+@keyframes borderDance {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
 
 /* Crazy footer redesign */
 .crazy-footer {


### PR DESCRIPTION
## Summary
- Simplify and modernize desktop navigation styling
- Streamline mobile drawer menu with clear navigation and account sections
- Drop marketplace shortcut from bottom mobile nav bar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68997a2cf7ac8320bf923038376a3902