### PR TITLE
Add See More button to manage long pack lists

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,6 +199,11 @@
 
     <!-- Cases Grid -->
     <div id="cases-container" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 sm:gap-6"></div>
+
+    <!-- See More Button -->
+    <div class="flex justify-center mt-6">
+      <button id="see-more-cases" class="px-4 py-2 bg-gray-800 text-white rounded-md border border-gray-600 hidden">See more</button>
+    </div>
   </div>
 </section>
 

--- a/scripts/packs.js
+++ b/scripts/packs.js
@@ -1,6 +1,9 @@
 import { setupFilters } from './filters.js';
 
 let allCases = [];
+const INITIAL_CASE_LIMIT = 20;
+let displayLimit = INITIAL_CASE_LIMIT;
+let currentCases = [];
 function getPepperHTML(spiceLevel) {
   const map = {
     easy: { class: "spice-label spice-easy" },
@@ -13,7 +16,7 @@ function getPepperHTML(spiceLevel) {
   const { class: cls } = map[spiceLevel];
   return `<div class="${cls}" aria-label="${spiceLevel} pepper"><i class="fa-solid fa-pepper-hot"></i></div>`;
 }
-function renderCases(caseList) {
+function renderCases(caseList, reset = true) {
   const casesContainer = document.getElementById("cases-container");
   casesContainer.innerHTML = "";
 
@@ -21,7 +24,14 @@ function renderCases(caseList) {
   const paidCases = caseList.filter(c => !c.isFree);
   const orderedCases = [...freeCases, ...paidCases];
 
-  orderedCases.forEach(c => {
+  if (reset) {
+    currentCases = orderedCases;
+    displayLimit = INITIAL_CASE_LIMIT;
+  }
+
+  const toRender = currentCases.slice(0, displayLimit);
+
+  toRender.forEach(c => {
     const tagHTML = c.tag ? `<div class="pack-tag">${c.tag}</div>` : "";
     const pepperHTML = getPepperHTML(c.spiceLevel);
 
@@ -68,6 +78,13 @@ function renderCases(caseList) {
   document.querySelectorAll(".open-case").forEach(btn => {
     btn.onclick = openCasePopup;
   });
+
+  const seeMoreBtn = document.getElementById('see-more-cases');
+  if (currentCases.length > displayLimit) {
+    seeMoreBtn.classList.remove('hidden');
+  } else {
+    seeMoreBtn.classList.add('hidden');
+  }
 }
 
 function setupCategoryTabs(filterControls) {
@@ -125,5 +142,10 @@ function loadCases() {
 }
 
 window.addEventListener("DOMContentLoaded", () => {
+  const seeMoreBtn = document.getElementById('see-more-cases');
+  seeMoreBtn?.addEventListener('click', () => {
+    displayLimit += INITIAL_CASE_LIMIT;
+    renderCases(currentCases, false);
+  });
   loadCases();
 });

--- a/scripts/packs.js
+++ b/scripts/packs.js
@@ -1,8 +1,9 @@
 import { setupFilters } from './filters.js';
 
 let allCases = [];
-const INITIAL_CASE_LIMIT = 20;
-let displayLimit = INITIAL_CASE_LIMIT;
+const ROW_LIMIT = 3;
+let casesPerPage = 0;
+let displayLimit = 0;
 let currentCases = [];
 function getPepperHTML(spiceLevel) {
   const map = {
@@ -16,6 +17,13 @@ function getPepperHTML(spiceLevel) {
   const { class: cls } = map[spiceLevel];
   return `<div class="${cls}" aria-label="${spiceLevel} pepper"><i class="fa-solid fa-pepper-hot"></i></div>`;
 }
+function calculateCasesPerPage() {
+  const container = document.getElementById("cases-container");
+  if (!container) return ROW_LIMIT * 5;
+  const columns = getComputedStyle(container).gridTemplateColumns.split(" ").filter(Boolean).length;
+  return columns * ROW_LIMIT;
+}
+
 function renderCases(caseList, reset = true) {
   const casesContainer = document.getElementById("cases-container");
   casesContainer.innerHTML = "";
@@ -26,7 +34,8 @@ function renderCases(caseList, reset = true) {
 
   if (reset) {
     currentCases = orderedCases;
-    displayLimit = INITIAL_CASE_LIMIT;
+    casesPerPage = calculateCasesPerPage();
+    displayLimit = casesPerPage;
   }
 
   const toRender = currentCases.slice(0, displayLimit);
@@ -144,7 +153,8 @@ function loadCases() {
 window.addEventListener("DOMContentLoaded", () => {
   const seeMoreBtn = document.getElementById('see-more-cases');
   seeMoreBtn?.addEventListener('click', () => {
-    displayLimit += INITIAL_CASE_LIMIT;
+    casesPerPage = calculateCasesPerPage();
+    displayLimit += casesPerPage;
     renderCases(currentCases, false);
   });
   loadCases();


### PR DESCRIPTION
## Summary
- Show only a limited number of packs initially on the home page
- Add a `See more` button to reveal additional packs
- Track pack counts in `packs.js` to toggle the button dynamically

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68997b36eeb083208c9c9e2a35f9237f