### PR TITLE
Send email verification after registration

### DIFF
--- a/auth.html
+++ b/auth.html
@@ -220,8 +220,10 @@ registerForm.addEventListener('submit', async e => {
       freeCaseOpened: false
     });
 
-    alert('Registration successful!');
-    window.location.href = 'index.html';
+    await auth.currentUser.sendEmailVerification();
+    alert('Registration successful! Please verify your email before logging in.');
+    await auth.signOut();
+    window.location.href = 'auth.html';
   } catch (error) {
     await auth.currentUser.delete().catch(() => {});
     await auth.signOut();

--- a/scripts/auth.js
+++ b/scripts/auth.js
@@ -13,8 +13,8 @@ window.addEventListener('DOMContentLoaded', () => {
     const usernameDisplay = document.getElementById('username-display');
 
     if (user) {
-      if (!user.email) {
-        alert('Please complete registration to continue.');
+      if (!user.email || !user.emailVerified) {
+        alert('Please complete registration and verify your email to continue.');
         firebase.auth().signOut();
         return;
       }


### PR DESCRIPTION
## Summary
- send email verification when linking email/password to phone-auth user
- block access for users without verified email

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689980ddfc1483209d0e45a393d6a704