### PR TITLE
Add consent and email alert options to sign-up form

### DIFF
--- a/auth.html
+++ b/auth.html
@@ -72,6 +72,14 @@
         <label class="text-sm">Password</label>
         <input type="password" id="register-password" class="w-full p-3 rounded bg-gray-800 focus:outline-none focus:ring-2 focus:ring-pink-500" required />
       </div>
+      <div class="flex items-center">
+        <input type="checkbox" id="terms" class="mr-2" required />
+        <label class="text-sm" for="terms">I agree to the <a href="termsandconditions.html" class="text-purple-400 underline" target="_blank">Terms & Conditions</a> and confirm I am at least 18 years old.</label>
+      </div>
+      <div class="flex items-center">
+        <input type="checkbox" id="email-alerts" class="mr-2" checked />
+        <label class="text-sm" for="email-alerts">Subscribe to email alerts</label>
+      </div>
       <div id="recaptcha-container"></div>
       <button type="submit" id="register-submit" disabled class="w-full bg-pink-600 hover:bg-pink-700 px-4 py-2 rounded transition-colors opacity-50 cursor-not-allowed">Register</button>
     </form>
@@ -203,10 +211,11 @@ registerForm.addEventListener('submit', async e => {
   const name = document.getElementById('register-name').value;
   const username = document.getElementById('register-username').value;
   const email = document.getElementById('register-email').value;
+  const emailAlerts = document.getElementById('email-alerts').checked;
 
   try {
     await auth.currentUser.verifyBeforeUpdateEmail(email);
-    localStorage.setItem('pendingUser', JSON.stringify({ name, username, email }));
+    localStorage.setItem('pendingUser', JSON.stringify({ name, username, email, emailAlerts }));
     alert('Verification email sent! Please check your inbox.');
     await auth.signOut();
     window.location.href = 'auth.html';
@@ -248,7 +257,7 @@ loginForm.addEventListener('submit', e => {
 auth.onAuthStateChanged(async user => {
   const pending = localStorage.getItem('pendingUser');
   if (user && pending) {
-    const { name, username, email } = JSON.parse(pending);
+    const { name, username, email, emailAlerts } = JSON.parse(pending);
     if (user.emailVerified) {
       const password = prompt('Please set a password for your account:');
       if (!password) {
@@ -266,7 +275,8 @@ auth.onAuthStateChanged(async user => {
           phoneNumber: auth.currentUser.phoneNumber,
           balance: 0,
           role: 'user',
-          freeCaseOpened: false
+          freeCaseOpened: false,
+          emailAlerts: emailAlerts
         });
         localStorage.removeItem('pendingUser');
         alert('Registration complete! You can now log in with your email and password.');


### PR DESCRIPTION
## Summary
- Require users to agree to terms and confirm they are 18+ during registration.
- Add default-checked email alerts option and store preference with new users.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68998c2080fc832086ab898906cf12b1