### PR TITLE
Allow unauthenticated access to terms page

### DIFF
--- a/termsandconditions.html
+++ b/termsandconditions.html
@@ -96,7 +96,7 @@
   const db = firebase.database();
 
   auth.onAuthStateChanged(async user => {
-    if (!user) return window.location.href = 'auth.html';
+    if (!user) return;
 
     const userRef = db.ref('users/' + user.uid);
     const snapshot = await userRef.once('value');


### PR DESCRIPTION
## Summary
- Remove login redirect from terms and conditions page so visitors can view it without signing in

## Testing
- `npm test` (fails: package.json not found)

------
https://chatgpt.com/codex/tasks/task_e_68998d6c83708320958866c9b4ff8e50