### PR TITLE
Allow legacy users without email verification

### DIFF
--- a/scripts/auth.js
+++ b/scripts/auth.js
@@ -13,14 +13,13 @@ window.addEventListener('DOMContentLoaded', () => {
     const usernameDisplay = document.getElementById('username-display');
 
     if (user) {
-      if (!user.email || !user.emailVerified) {
+      const userRef = firebase.database().ref('users/' + user.uid);
+      const snapshot = await userRef.once('value');
+      if ((!user.email || !user.emailVerified) && !snapshot.exists()) {
         alert('Please complete registration and verify your email to continue.');
         firebase.auth().signOut();
         return;
       }
-
-      const userRef = firebase.database().ref('users/' + user.uid);
-      const snapshot = await userRef.once('value');
       const userData = snapshot.val() || {};
 
       // ✅ Setup Provably Fair if missing


### PR DESCRIPTION
## Summary
- Permit existing unverified accounts to sign in by checking for an existing database record before enforcing email verification.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a07395b008320807bb7bbbc5c01d4