### PR TITLE
feat: allow manual email verification

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -615,6 +615,12 @@ function cancelEdit() {
             <label class="block">Name:<input type="text" id="name-${child.key}" value="${user.name || ''}" class="p-1 rounded w-full"></label>
             <label class="block">Username:<input type="text" id="username-${child.key}" value="${user.username || ''}" class="p-1 rounded w-full"></label>
             <label class="block">Email:<input type="text" id="email-${child.key}" value="${user.email || ''}" class="p-1 rounded w-full"></label>
+            <label class="block">Email Verified:
+              <select id="verified-${child.key}" class="p-1 rounded w-full">
+                <option value="false" ${!user.emailVerified ? 'selected' : ''}>No</option>
+                <option value="true" ${user.emailVerified ? 'selected' : ''}>Yes</option>
+              </select>
+            </label>
             <label class="block">Phone:<input type="text" id="phone-${child.key}" value="${user.phone || ''}" class="p-1 rounded w-full"></label>
             <label class="block">Balance:<input type="number" step="any" id="balance-${child.key}" value="${user.balance || 0}" class="p-1 rounded w-full"></label>
             <label class="block">Role:
@@ -707,6 +713,7 @@ function saveUser(uid) {
     name: document.getElementById(`name-${uid}`).value.trim(),
     username: document.getElementById(`username-${uid}`).value.trim(),
     email: document.getElementById(`email-${uid}`).value.trim(),
+    emailVerified: document.getElementById(`verified-${uid}`).value === 'true',
     phone: document.getElementById(`phone-${uid}`).value.trim(),
     balance: parseFloat(document.getElementById(`balance-${uid}`).value) || 0,
     role: document.getElementById(`role-${uid}`).value,

--- a/auth.html
+++ b/auth.html
@@ -236,7 +236,10 @@ loginForm.addEventListener('submit', e => {
     auth.setPersistence(persistence)
       .then(() => auth.signInWithEmailAndPassword(email, password))
       .then(async () => {
-        if (!auth.currentUser.emailVerified) {
+        const userRef = firebase.database().ref('users/' + auth.currentUser.uid);
+        const snap = await userRef.once('value');
+        const userData = snap.val();
+        if (!auth.currentUser.emailVerified && !userData?.emailVerified) {
           try {
             await auth.currentUser.sendEmailVerification();
             alert('Please verify your email. A verification link has been sent.');
@@ -276,7 +279,8 @@ auth.onAuthStateChanged(async user => {
           balance: 0,
           role: 'user',
           freeCaseOpened: false,
-          emailAlerts: emailAlerts
+          emailAlerts: emailAlerts,
+          emailVerified: true
         });
         localStorage.removeItem('pendingUser');
         alert('Registration complete! You can now log in with your email and password.');

--- a/scripts/auth.js
+++ b/scripts/auth.js
@@ -15,12 +15,12 @@ window.addEventListener('DOMContentLoaded', () => {
     if (user) {
       const userRef = firebase.database().ref('users/' + user.uid);
       const snapshot = await userRef.once('value');
-      if ((!user.email || !user.emailVerified) && !snapshot.exists()) {
+      const userData = snapshot.val() || {};
+      if (!user.email || (!user.emailVerified && !userData.emailVerified)) {
         alert('Please complete registration and verify your email to continue.');
         firebase.auth().signOut();
         return;
       }
-      const userData = snapshot.val() || {};
 
       // ✅ Setup Provably Fair if missing
       if (!userData.provablyFair) {


### PR DESCRIPTION
## Summary
- let admins mark user emails as verified in the dashboard
- honor manual verification during login and auth checks
- store `emailVerified` flag when completing registration

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a0b3a75e483208501eba851e8e275