### PR TITLE
feat: add drag rotate effect to inventory popup

### DIFF
--- a/inventory.html
+++ b/inventory.html
@@ -102,9 +102,18 @@
       max-height: 80vh;
       border-radius: 0.5rem;
       box-shadow: 0 0 25px rgba(236,72,153,0.5), 0 0 50px rgba(236,72,153,0.3);
+      cursor: grab;
+      touch-action: none;
+      transition: transform 0.1s ease-out;
     }
 
-    .popup-card {}
+    #popup-item-image.grabbing {
+      cursor: grabbing;
+    }
+
+    .popup-card {
+      perspective: 1000px;
+    }
 
     .popup-card.animate {
       animation: popIn 0.3s ease;
@@ -205,6 +214,9 @@
   <div id="item-popup" class="fixed inset-0 hidden flex items-center justify-center z-50">
     <div class="popup-card relative">
       <img id="popup-item-image" class="shimmer rounded-lg" src="" alt="Item preview" />
+      <div id="rotate-hint" class="absolute bottom-2 right-2 text-white opacity-80 pointer-events-none">
+        <i class="fa-solid fa-arrows-rotate text-2xl animate-spin" style="animation-duration:3s;"></i>
+      </div>
       <button id="close-item-popup" class="absolute -top-4 -right-4 w-8 h-8 rounded-full bg-gray-800 text-white flex items-center justify-center">&times;</button>
     </div>
   </div>

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -2,11 +2,47 @@
 
 const selectedItems = new Set();
 let currentItems = [];
+let popupRotX = 0;
+let popupRotY = 0;
+let isDragging = false;
+let startX = 0;
+let startY = 0;
 
 document.addEventListener('DOMContentLoaded', () => {
   const itemPopup = document.getElementById('item-popup');
+  const popupImage = document.getElementById('popup-item-image');
   document.getElementById('close-item-popup')?.addEventListener('click', closeItemPopup);
   itemPopup?.addEventListener('click', e => { if (e.target === itemPopup) closeItemPopup(); });
+
+  popupImage?.addEventListener('pointerdown', e => {
+    isDragging = true;
+    startX = e.clientX;
+    startY = e.clientY;
+    popupImage.setPointerCapture(e.pointerId);
+    popupImage.classList.add('grabbing');
+    e.preventDefault();
+  });
+
+  popupImage?.addEventListener('pointermove', e => {
+    if (!isDragging) return;
+    const dx = e.clientX - startX;
+    const dy = e.clientY - startY;
+    popupImage.style.transform = `rotateY(${popupRotY + dx / 2}deg) rotateX(${popupRotX - dy / 2}deg)`;
+    e.preventDefault();
+  });
+
+  const endDrag = e => {
+    if (!isDragging) return;
+    const dx = e.clientX - startX;
+    const dy = e.clientY - startY;
+    popupRotY += dx / 2;
+    popupRotX -= dy / 2;
+    isDragging = false;
+    popupImage.classList.remove('grabbing');
+    e.preventDefault();
+  };
+  popupImage?.addEventListener('pointerup', endDrag);
+  popupImage?.addEventListener('pointerleave', endDrag);
 
   const inventoryTab = document.getElementById('inventory-tab');
   const ordersTab = document.getElementById('orders-tab');
@@ -311,6 +347,10 @@ function showItemPopup(encodedSrc) {
   const img = document.getElementById('popup-item-image');
   if (!img) return;
   img.src = src;
+  popupRotX = 0;
+  popupRotY = 0;
+  img.style.transform = 'rotateY(0deg) rotateX(0deg)';
+  img.classList.remove('grabbing');
   const popup = document.getElementById('item-popup');
   const card = popup?.querySelector('.popup-card');
   popup?.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- allow rotating inventory card preview by dragging or swiping
- show rotating icon hint on popup

## Testing
- `node --check scripts/inventory.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bdb3eba4c8320a35d40970d433aa1