### PR TITLE
feat: add holographic rotate effect

### DIFF
--- a/inventory.html
+++ b/inventory.html
@@ -97,14 +97,44 @@
       backdrop-filter: blur(4px);
     }
 
-    #popup-item-image {
+    #popup-rotator {
       max-width: 90vw;
       max-height: 80vh;
       border-radius: 0.5rem;
       box-shadow: 0 0 25px rgba(236,72,153,0.5), 0 0 50px rgba(236,72,153,0.3);
+      cursor: grab;
+      touch-action: none;
+      transition: transform 0.1s ease-out;
+      position: relative;
     }
 
-    .popup-card {}
+    #popup-rotator.grabbing {
+      cursor: grabbing;
+    }
+
+    #popup-item-image {
+      display: block;
+      width: 100%;
+      height: auto;
+      border-radius: inherit;
+    }
+
+    #holo-overlay {
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      mix-blend-mode: screen;
+      pointer-events: none;
+      background:
+        radial-gradient(circle at var(--x,50%) var(--y,50%), rgba(255,255,255,0.9), rgba(255,255,255,0) 40%),
+        linear-gradient(135deg, rgba(255,0,255,0.4), rgba(0,255,255,0.4), rgba(255,255,0,0.4));
+      opacity: 0.9;
+      filter: brightness(1.2);
+    }
+
+    .popup-card {
+      perspective: 1000px;
+    }
 
     .popup-card.animate {
       animation: popIn 0.3s ease;
@@ -115,31 +145,6 @@
       to { transform: scale(1); opacity: 1; }
     }
 
-    .shimmer {
-      position: relative;
-      overflow: hidden;
-    }
-
-    .shimmer::after {
-      content: "";
-      position: absolute;
-      top: 0;
-      left: -100%;
-      width: 200%;
-      height: 100%;
-      background: linear-gradient(
-        120deg,
-        rgba(255,255,255,0) 0%,
-        rgba(255,255,255,0.4) 50%,
-        rgba(255,255,255,0) 100%
-      );
-      animation: shimmer 2s infinite;
-    }
-
-    @keyframes shimmer {
-      0% { transform: translateX(0); }
-      100% { transform: translateX(-50%); }
-    }
   </style>
 </head>
 <body class="min-h-screen">
@@ -204,7 +209,13 @@
   <!-- Item Preview Popup -->
   <div id="item-popup" class="fixed inset-0 hidden flex items-center justify-center z-50">
     <div class="popup-card relative">
-      <img id="popup-item-image" class="shimmer rounded-lg" src="" alt="Item preview" />
+      <div id="popup-rotator">
+        <img id="popup-item-image" src="" alt="Item preview" />
+        <div id="holo-overlay"></div>
+      </div>
+      <div id="rotate-hint" class="absolute bottom-2 right-2 text-white opacity-80 pointer-events-none">
+        <i class="fa-solid fa-arrows-rotate text-2xl animate-spin" style="animation-duration:3s;"></i>
+      </div>
       <button id="close-item-popup" class="absolute -top-4 -right-4 w-8 h-8 rounded-full bg-gray-800 text-white flex items-center justify-center">&times;</button>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add holographic overlay that shifts while dragging inventory card preview
- clamp popup rotation to keep card front-facing
- boost overlay colors and brightness for a more intense holographic sheen

## Testing
- `node --check scripts/inventory.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bdb3eba4c8320a35d40970d433aa1