### PR TITLE
Fix multiple sell-back glitch

### DIFF
--- a/case.html
+++ b/case.html
@@ -180,6 +180,7 @@ function showMultiWinPopup(prizes) {
   const nextBtn = document.getElementById('next-win');
   const sellAllBtn = document.getElementById('sell-all-btn');
   const sellAllValue = document.getElementById('sell-all-value');
+  sellAllBtn.disabled = false;
   const processed = new Set();
   let current = 0;
 

--- a/case.html
+++ b/case.html
@@ -208,10 +208,15 @@ function showMultiWinPopup(prizes) {
       itemContainer.firstElementChild.classList.add('opacity-50');
     } else {
       keepBtn.onclick = () => {
+        keepBtn.disabled = true;
+        sellBtn.disabled = true;
         processed.add(index);
         handleDone();
       };
       sellBtn.onclick = async () => {
+        if (sellBtn.disabled) return;
+        sellBtn.disabled = true;
+        keepBtn.disabled = true;
         await sellPrize(prize);
         processed.add(index);
         handleDone();
@@ -260,6 +265,8 @@ function showMultiWinPopup(prizes) {
   });
 
   sellAllBtn.onclick = async () => {
+    if (sellAllBtn.disabled) return;
+    sellAllBtn.disabled = true;
     for (let i = 0; i < prizes.length; i++) {
       if (!processed.has(i)) {
         await sellPrize(prizes[i]);

--- a/scripts/vault.js
+++ b/scripts/vault.js
@@ -282,15 +282,23 @@ function resetGame() {
 document.addEventListener('DOMContentLoaded', () => {
   loadPack();
   document.getElementById('open-pack').addEventListener('click', openPack);
+  const keepBtn = document.getElementById('keep-btn');
+  const sellBtn = document.getElementById('sell-btn');
+
   document.getElementById('close-popup').addEventListener('click', () => {
     document.getElementById('win-popup').classList.add('hidden');
     resetGame();
   });
-  document.getElementById('keep-btn').addEventListener('click', () => {
+  keepBtn.addEventListener('click', () => {
+    keepBtn.disabled = true;
+    sellBtn.disabled = true;
     document.getElementById('win-popup').classList.add('hidden');
     resetGame();
   });
-  document.getElementById('sell-btn').addEventListener('click', async () => {
+  sellBtn.addEventListener('click', async () => {
+    if (sellBtn.disabled) return;
+    sellBtn.disabled = true;
+    keepBtn.disabled = true;
     await sellPrize();
     document.getElementById('win-popup').classList.add('hidden');
     resetGame();


### PR DESCRIPTION
## Summary
- Disable sell and keep buttons after first click in case opening popup to prevent multiple sells
- Prevent rapid repeat of "sell all" by disabling the button once activated
- Guard vault prize popup from repeated sells by disabling controls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e0832683483208eea4a305cbcbfe4