### PR TITLE
Ensure spin outcomes use server-side randomness

### DIFF
--- a/api/spin.js
+++ b/api/spin.js
@@ -1,0 +1,45 @@
+const crypto = require('crypto');
+
+module.exports = (req, res) => {
+  if (req.method !== 'POST') {
+    res.statusCode = 405;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ error: 'Method not allowed' }));
+    return;
+  }
+
+  let body = req.body;
+  if (typeof body === 'string') {
+    try { body = JSON.parse(body); } catch { body = {}; }
+  }
+  const prizes = Array.isArray(body.prizes) ? body.prizes : [];
+  if (prizes.length === 0) {
+    res.statusCode = 400;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ error: 'No prizes provided' }));
+    return;
+  }
+
+  const totalOdds = prizes.reduce((sum, p) => sum + (p.odds || 0), 0);
+  if (!totalOdds) {
+    res.statusCode = 400;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ error: 'Invalid prize odds' }));
+    return;
+  }
+
+  const rand = crypto.randomInt(totalOdds);
+  let cumulative = 0;
+  let winningPrize = prizes[prizes.length - 1];
+  for (const prize of prizes) {
+    cumulative += prize.odds || 0;
+    if (rand < cumulative) {
+      winningPrize = prize;
+      break;
+    }
+  }
+
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/json');
+  res.end(JSON.stringify({ prize: winningPrize }));
+};

--- a/case.html
+++ b/case.html
@@ -525,11 +525,11 @@ document.getElementById("open-case-button").addEventListener("click", async () =
 
   for (let s = 0; s < spinCount; s++) {
     // Request a cryptographically secure spin result from the server
-    const res = await fetch('api/spin', {
+    const res = await fetch('/api/spin', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
-      body: JSON.stringify({ caseId })
+      body: JSON.stringify({ caseId, prizes: prizeList })
     });
     if (!res.ok) {
       console.error('Spin request failed');

--- a/case.html
+++ b/case.html
@@ -525,7 +525,7 @@ document.getElementById("open-case-button").addEventListener("click", async () =
 
   for (let s = 0; s < spinCount; s++) {
     // Request a cryptographically secure spin result from the server
-    const res = await fetch('/api/spin', {
+    const res = await fetch('api/spin', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',

--- a/case.html
+++ b/case.html
@@ -508,7 +508,7 @@ document.getElementById("open-case-button").addEventListener("click", async () =
     if (spinSelect) spinSelect.disabled = false;
     return alert("Provably fair data missing.");
   }
-  const { serverSeed, clientSeed, nonce } = fairData;
+  const { nonce } = fairData;
 
   setupSpinners(spinCount);
 
@@ -524,20 +524,18 @@ document.getElementById("open-case-button").addEventListener("click", async () =
   }
 
   for (let s = 0; s < spinCount; s++) {
-    const currentNonce = (nonce || 0) + s;
-    const hashBuffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(`${serverSeed}:${clientSeed}:${currentNonce}`));
-    const hashHex = [...new Uint8Array(hashBuffer)].map(b => b.toString(16).padStart(2, '0')).join('');
-    const rand = parseInt(hashHex.substring(0, 8), 16) / 0xffffffff;
-
-    let cumulative = 0;
-    let winningPrize = prizes[prizes.length - 1];
-    for (let p of prizes) {
-      cumulative += p.odds || 0;
-      if (rand * totalOdds < cumulative) {
-        winningPrize = p;
-        break;
-      }
+    // Request a cryptographically secure spin result from the server
+    const res = await fetch('/api/spin', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ caseId })
+    });
+    if (!res.ok) {
+      console.error('Spin request failed');
+      continue;
     }
+    const { prize: winningPrize } = await res.json();
 
     const unboxData = {
       name: winningPrize.name,

--- a/scripts/vault.js
+++ b/scripts/vault.js
@@ -96,11 +96,11 @@ async function openPack() {
   await firebase.database().ref('users/' + user.uid + '/balance').set(balance - price);
 
   // Request a secure outcome from the server instead of computing locally
-  const res = await fetch('api/spin', {
+  const res = await fetch('/api/spin', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     credentials: 'include',
-    body: JSON.stringify({ packId: currentPackId })
+    body: JSON.stringify({ packId: currentPackId, prizes: Object.values(currentPack.prizes || {}) })
   });
   if (!res.ok) {
     console.error('Spin request failed');

--- a/scripts/vault.js
+++ b/scripts/vault.js
@@ -96,7 +96,7 @@ async function openPack() {
   await firebase.database().ref('users/' + user.uid + '/balance').set(balance - price);
 
   // Request a secure outcome from the server instead of computing locally
-  const res = await fetch('/api/spin', {
+  const res = await fetch('api/spin', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     credentials: 'include',


### PR DESCRIPTION
## Summary
- Request spin results from the server instead of computing outcomes in the browser
- Track vault pack identifiers for secure server-side draws

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e09f88460832095f1ebd072d6c253