### PR TITLE
Revamp theme to clean white and blue

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -48,13 +48,13 @@
   <nav class="w-full px-6 py-4 bg-gray-900 border-b border-gray-800 flex justify-between items-center">
     <div class="text-xl font-bold text-white">PrimePull.gg Admin</div>
     <div class="space-x-4">
-      <a href="#" class="text-sm text-white hover:text-pink-400" onclick="showSection('cases')">Cases</a>
-      <a href="#" class="text-sm text-white hover:text-pink-400" onclick="showSection('shipments')">Shipments</a>
-      <a href="#" class="text-sm text-white hover:text-pink-400" onclick="showSection('support')">Support Forms</a>
-      <a href="#" class="text-sm text-white hover:text-pink-400" onclick="showSection('users')">Users</a>
-      <a href="#" class="text-sm text-white hover:text-pink-400" onclick="showSection('marketplace')">Marketplace</a>
-      <a href="#" class="text-sm text-white hover:text-pink-400" onclick="showSection('quests')">Quests</a>
-      <a href="#" class="text-sm text-white hover:text-pink-400" onclick="showSection('milestones')">Milestones</a>
+        <a href="#" class="text-sm text-white hover:text-blue-500" onclick="showSection('cases')">Cases</a>
+        <a href="#" class="text-sm text-white hover:text-blue-500" onclick="showSection('shipments')">Shipments</a>
+        <a href="#" class="text-sm text-white hover:text-blue-500" onclick="showSection('support')">Support Forms</a>
+        <a href="#" class="text-sm text-white hover:text-blue-500" onclick="showSection('users')">Users</a>
+        <a href="#" class="text-sm text-white hover:text-blue-500" onclick="showSection('marketplace')">Marketplace</a>
+        <a href="#" class="text-sm text-white hover:text-blue-500" onclick="showSection('quests')">Quests</a>
+        <a href="#" class="text-sm text-white hover:text-blue-500" onclick="showSection('milestones')">Milestones</a>
     </div>
   </nav>
 
@@ -125,7 +125,7 @@
               <button type="button" onclick="addPrize()" class="mb-2 px-4 py-2 bg-green-600 hover:bg-green-700 rounded">+ Add Prize</button>
             </div>
             <div class="flex gap-2">
-              <button type="submit" class="px-6 py-2 bg-purple-600 hover:bg-purple-700 rounded">Save Case</button>
+                <button type="submit" class="px-6 py-2 bg-blue-600 hover:bg-blue-700 rounded">Save Case</button>
               <button type="button" id="cancel-edit" class="px-6 py-2 bg-gray-600 hover:bg-gray-700 rounded hidden">Cancel Edit</button>
             </div>
           </form>
@@ -158,7 +158,7 @@
         <option value="legendary">Legendary</option>
       </select>
     </div>
-    <button type="submit" class="px-6 py-2 bg-pink-600 hover:bg-pink-700 rounded font-semibold">Add to Marketplace</button>
+    <button type="submit" class="px-6 py-2 bg-blue-600 hover:bg-blue-700 rounded font-semibold">Add to Marketplace</button>
   </form>
   <div id="market-list" class="mt-8 space-y-4"></div>
 
@@ -191,7 +191,7 @@
       <label class="block mb-1">Rare Pull Reward:</label>
       <input type="number" id="pullRare-reward" class="w-full p-2 rounded" />
     </div>
-    <button type="submit" class="px-6 py-2 bg-purple-600 hover:bg-purple-700 rounded">Save</button>
+      <button type="submit" class="px-6 py-2 bg-blue-600 hover:bg-blue-700 rounded">Save</button>
   </form>
 </section>
 
@@ -874,7 +874,7 @@ function addBadge(badge = {}) {
   div.innerHTML = `
     <input type="text" placeholder="Badge Name" class="badge-name w-full p-2 rounded" value="${badge.name || ''}">
     <input type="number" placeholder="Pack Threshold" class="badge-threshold w-32 p-2 rounded" value="${badge.threshold || ''}">
-    <input type="color" class="badge-color w-16 h-10 rounded" value="${badge.color || '#9333ea'}">
+      <input type="color" class="badge-color w-16 h-10 rounded" value="${badge.color || '#3b82f6'}">
     <button type="button" class="text-red-400 hover:text-red-600" onclick="this.parentElement.remove()">Remove</button>
   `;
   document.getElementById('badge-list').appendChild(div);
@@ -921,7 +921,7 @@ document.getElementById('milestone-config-form').addEventListener('submit', e =>
   document.querySelectorAll('#badge-list > div').forEach(div => {
     const name = div.querySelector('.badge-name').value.trim();
     const threshold = parseInt(div.querySelector('.badge-threshold').value) || 0;
-    const color = div.querySelector('.badge-color').value || '#9333ea';
+      const color = div.querySelector('.badge-color').value || '#3b82f6';
     if (name) badges.push({ name, threshold, color });
   });
   const levels = [];

--- a/case.html
+++ b/case.html
@@ -42,20 +42,20 @@
   </style>
 
 </head>
-  <body class="bg-gradient-to-br from-gray-900 via-purple-900 to-black text-white overflow-x-hidden">
+  <body class="bg-gradient-to-br from-gray-900 via-blue-900 to-black text-white overflow-x-hidden">
 <script src="scripts/preloader.js"></script>
       <canvas id="particle-canvas"></canvas>
       <header></header>
 <section id="case-content" class="relative pt-32 pb-10 px-4">
   <div class="relative z-10 mb-6">
     <div class="flex items-center justify-between px-4 py-2 bg-black/40 backdrop-blur-md rounded-full shadow-lg">
-      <a href="index.html" class="flex items-center justify-center w-10 h-10 rounded-full bg-gradient-to-br from-pink-500 to-purple-500 text-white hover:scale-110 transition-transform" aria-label="Back to packs">
+      <a href="index.html" class="flex items-center justify-center w-10 h-10 rounded-full bg-gradient-to-br from-blue-500 to-blue-700 text-white hover:scale-110 transition-transform" aria-label="Back to packs">
         <i class="fas fa-arrow-left"></i>
       </a>
-      <h2 id="case-name" class="flex-1 text-center text-xl sm:text-2xl font-bold mx-4 bg-gradient-to-r from-yellow-400 via-pink-500 to-purple-500 bg-clip-text text-transparent leading-none">Loading...</h2>
+      <h2 id="case-name" class="flex-1 text-center text-xl sm:text-2xl font-bold mx-4 bg-gradient-to-r from-blue-400 via-blue-600 to-blue-800 bg-clip-text text-transparent leading-none">Loading...</h2>
       <div class="flex items-center gap-2">
         <img id="case-image" class="w-12 h-12 sm:w-16 sm:h-16 object-contain rounded-full bg-black/40 p-2 border border-white/20 shadow-md transition-transform hover:rotate-6 hover:scale-105" alt="" />
-        <button id="mute-toggle" aria-label="Toggle sound" class="flex items-center justify-center w-10 h-10 rounded-full bg-gradient-to-br from-purple-500 to-pink-500 text-white shadow-lg hover:scale-110 transition-transform">
+        <button id="mute-toggle" aria-label="Toggle sound" class="flex items-center justify-center w-10 h-10 rounded-full bg-gradient-to-br from-blue-500 to-blue-700 text-white shadow-lg hover:scale-110 transition-transform">
           <i id="mute-icon" class="fas fa-volume-up"></i>
         </button>
       </div>
@@ -69,7 +69,7 @@
         <option value="2">2x</option>
         <option value="3">3x</option>
       </select>
-      <button id="open-case-button" class="shining-button relative px-6 py-3 rounded-full bg-gradient-to-r from-yellow-400 via-pink-500 to-purple-500 text-white font-extrabold flex items-center justify-center gap-2 shadow-lg transition-transform transform hover:scale-105 animate-pulse focus:outline-none overflow-hidden">
+      <button id="open-case-button" class="shining-button relative px-6 py-3 rounded-full bg-gradient-to-r from-blue-500 via-blue-600 to-blue-700 text-white font-extrabold flex items-center justify-center gap-2 shadow-lg transition-transform transform hover:scale-105 animate-pulse focus:outline-none overflow-hidden">
         <span class="relative z-10 flex items-center gap-2">
           Open for
           <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-5 h-5" />
@@ -93,12 +93,12 @@
 
 
 
-    <div class="bg-black/30 backdrop-blur-md rounded-2xl shadow-md border border-white/10 p-6 hover:shadow-purple-500/20 transition-all duration-300 mt-10 relative">
+    <div class="bg-black/30 backdrop-blur-md rounded-2xl shadow-md border border-white/10 p-6 hover:shadow-blue-500/20 transition-all duration-300 mt-10 relative">
       <img class="case-pack-image absolute -top-10 left-0 -translate-x-1/2 w-64 opacity-20 z-0 pointer-events-none -rotate-12" alt="Case Pack" />
       <img class="case-pack-image absolute -top-10 right-0 translate-x-1/2 w-64 opacity-20 z-0 pointer-events-none rotate-12" alt="Case Pack" />
     <div class="relative z-10">
       <div class="text-center mb-6">
-        <div class="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-gradient-to-r from-yellow-400 via-pink-500 to-purple-500 shadow-md">
+        <div class="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-gradient-to-r from-blue-500 via-blue-600 to-blue-700 shadow-md">
           <img src="https://cdn-icons-png.flaticon.com/128/5172/5172637.png" alt="Rewards Icon" class="w-5 h-5" />
           <span class="text-sm font-bold uppercase tracking-wider text-white">Rewards Table</span>
         </div>
@@ -133,7 +133,7 @@ function setupSpinners(count) {
     inner.className = `relative ${heightClass} overflow-hidden`;
 
     const line = document.createElement('div');
-    line.className = 'absolute top-0 bottom-0 w-1 bg-pink-500 left-1/2 transform -translate-x-1/2 z-10';
+    line.className = 'absolute top-0 bottom-0 w-1 bg-blue-500 left-1/2 transform -translate-x-1/2 z-10';
     const container = document.createElement('div');
     container.id = `spinner-container-${i}`;
     container.className = 'w-full h-full transform';
@@ -196,7 +196,7 @@ function showMultiWinPopup(prizes) {
         <div class="flex items-center gap-1 text-yellow-300 text-sm mb-2"><img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4" />${formatCoins(prize.value)}</div>
         <div class="flex gap-2 w-full mt-2">
           <button id="keep-btn" class="flex-1 px-3 py-2 rounded-lg bg-gradient-to-r from-emerald-500 via-green-600 to-teal-500 text-white text-sm font-bold flex items-center justify-center gap-1"><i class="fas fa-box-open"></i> Add to Inventory</button>
-          <button id="sell-btn" class="flex-1 px-3 py-2 rounded-lg bg-gradient-to-r from-red-500 via-rose-600 to-pink-500 text-white text-sm font-bold flex items-center justify-center gap-1"><img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4" />Sell for ${formatCoins(Math.floor(prize.value * 0.8))}</button>
+          <button id="sell-btn" class="flex-1 px-3 py-2 rounded-lg bg-gradient-to-r from-red-500 via-red-600 to-red-700 text-white text-sm font-bold flex items-center justify-center gap-1"><img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4" />Sell for ${formatCoins(Math.floor(prize.value * 0.8))}</button>
         </div>
       </div>`;
 
@@ -598,7 +598,7 @@ document.getElementById("open-case-button").addEventListener("click", async () =
           btn.classList.remove('cursor-not-allowed', 'opacity-60');
           btn.innerHTML = isFreeCase
             ? '<span class="relative z-10">Open for Free</span>'
-            : `<div class="absolute inset-0 rounded-full bg-gradient-to-r from-yellow-400 via-pink-500 to-purple-500 blur-xl opacity-50 z-0 animate-spin-slow"></div>
+            : `<div class="absolute inset-0 rounded-full bg-gradient-to-r from-blue-500 via-blue-600 to-blue-700 blur-xl opacity-50 z-0 animate-spin-slow"></div>
               <span class="relative z-10 flex items-center gap-2">
                 Open for
                 <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-5 h-5" />
@@ -781,7 +781,7 @@ async function sha256(message) {
     <div class="mt-4 space-y-2 text-xs">
       <input id="client-seed-input" type="text" placeholder="New client seed" class="w-full px-2 py-1 rounded bg-gray-800 text-white" />
       <button id="update-client-seed" class="w-full bg-green-600 hover:bg-green-500 rounded py-2 text-white">Update Client Seed</button>
-      <button id="new-server-seed" class="w-full bg-purple-600 hover:bg-purple-500 rounded py-2 text-white">New Server Seed</button>
+      <button id="new-server-seed" class="w-full bg-blue-600 hover:bg-blue-500 rounded py-2 text-white">New Server Seed</button>
       <a href="verify.html" class="block text-center text-blue-400 hover:underline mt-2">Verify a roll</a>
     </div>
   </div>
@@ -820,7 +820,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <button id="next-win" class="absolute right-0 top-1/2 -translate-y-1/2 bg-gray-700/60 hover:bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center"><i class="fas fa-chevron-right"></i></button>
     </div>
     <div id="win-count" class="text-sm text-gray-400 mb-2"></div>
-    <button id="sell-all-btn" class="w-full flex items-center justify-center gap-2 px-5 py-3 rounded-xl bg-gradient-to-r from-red-500 via-rose-600 to-pink-500 hover:brightness-110 text-white font-extrabold text-sm shadow-lg shadow-red-800/30 transition-all duration-200">
+    <button id="sell-all-btn" class="w-full flex items-center justify-center gap-2 px-5 py-3 rounded-xl bg-gradient-to-r from-red-500 via-red-600 to-red-700 hover:brightness-110 text-white font-extrabold text-sm shadow-lg shadow-red-800/30 transition-all duration-200">
       <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-5 h-5" />
       Sell All for <span id="sell-all-value">0</span> coins
     </button>

--- a/components/header.html
+++ b/components/header.html
@@ -12,7 +12,7 @@
     <a href="pickem.html" class="flex items-center gap-1 text-yellow-400 font-semibold hover:text-yellow-300 transition">
       <i class="fas fa-clone"></i> Pickem
     </a>
-    <a href="marketplace.html" class="flex items-center gap-1 text-pink-400 font-semibold hover:text-pink-300 transition">
+      <a href="marketplace.html" class="flex items-center gap-1 text-blue-600 font-semibold hover:text-blue-500 transition">
       <i class="fas fa-store"></i> Marketplace
     </a>
     <!-- Coin Balance -->
@@ -24,10 +24,10 @@
     </div>
     <!-- XP / Level Display -->
 <div id="level-display" class="flex items-center gap-2 bg-black/40 px-3 py-1 rounded-full border border-white/10 shadow-md text-xs">
-  <span class="text-pink-400 font-bold">Lvl <span id="level-number">1</span></span>
-  <div class="relative w-24 h-2 bg-gray-700 rounded-full overflow-hidden">
-    <div id="xp-bar" class="absolute top-0 left-0 h-full bg-gradient-to-r from-pink-500 via-yellow-400 to-purple-500 rounded-full transition-all duration-300" style="width: 0%"></div>
-  </div>
+    <span class="text-blue-600 font-bold">Lvl <span id="level-number">1</span></span>
+    <div class="relative w-24 h-2 bg-gray-200 rounded-full overflow-hidden">
+      <div id="xp-bar" class="absolute top-0 left-0 h-full bg-gradient-to-r from-blue-500 to-blue-700 rounded-full transition-all duration-300" style="width: 0%"></div>
+    </div>
 </div>
 
 
@@ -71,7 +71,7 @@
   <a href="pickem.html" class="block px-4 py-2 hover:bg-gray-700 text-yellow-400 text-sm">
     <i class="fas fa-clone mr-2"></i> Pickem
   </a>
-  <a href="marketplace.html" class="block px-4 py-2 hover:bg-gray-700 text-pink-400 text-sm">
+  <a href="marketplace.html" class="block px-4 py-2 hover:bg-gray-700 text-blue-600 text-sm">
     <i class="fas fa-store mr-2"></i> Marketplace
   </a>
   <a id="mobile-auth-button" href="auth.html" class="block px-4 py-2 hover:bg-gray-700 text-red-400 text-sm">Sign In</a>

--- a/components/nav.html
+++ b/components/nav.html
@@ -10,10 +10,10 @@
     </a>
     <div id="user-balance" class="flex items-center gap-1 bg-gray-800 text-white px-3 py-1 rounded-full text-sm hidden">
       <div id="level-display" class="flex items-center gap-2 bg-black/40 px-3 py-1 rounded-full border border-white/10 shadow-md text-xs">
-  <span class="text-pink-400 font-bold">Lvl <span id="level-number">1</span></span>
-  <div class="relative w-24 h-2 bg-gray-700 rounded-full overflow-hidden">
-    <div id="xp-bar" class="absolute top-0 left-0 h-full bg-gradient-to-r from-pink-500 via-yellow-400 to-purple-500 rounded-full transition-all duration-300" style="width: 0%"></div>
-  </div>
+    <span class="text-blue-600 font-bold">Lvl <span id="level-number">1</span></span>
+    <div class="relative w-24 h-2 bg-gray-200 rounded-full overflow-hidden">
+      <div id="xp-bar" class="absolute top-0 left-0 h-full bg-gradient-to-r from-blue-500 to-blue-700 rounded-full transition-all duration-300" style="width: 0%"></div>
+    </div>
 </div>
       <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" />
       <span id="balance-amount">0</span>

--- a/contact.html
+++ b/contact.html
@@ -14,24 +14,24 @@
   <style>
     body {
       font-family: 'Poppins', sans-serif;
-      background-color: #0f0f12;
-      color: white;
+      background-color: #ffffff;
+      color: #1f2937;
     }
     .terms-box {
-      background: linear-gradient(145deg, #1c1f26, #0e0f13);
-      border: 1px solid rgba(255, 215, 0, 0.15);
-      box-shadow: 0 0 30px rgba(255, 215, 0, 0.1);
+      background: #ffffff;
+      border: 1px solid #d1d5db;
+      box-shadow: 0 0 30px rgba(0, 0, 0, 0.05);
     }
     .terms-text p {
       margin-bottom: 1rem;
-      color: #cbd5e1;
+      color: #4b5563;
     }
     .terms-text h2 {
       margin-top: 2rem;
       margin-bottom: 1rem;
       font-size: 1.25rem;
       font-weight: 700;
-      color: #f9fafb;
+      color: #1f2937;
     }
   </style>
 </head>
@@ -44,28 +44,28 @@
 <section class="pt-32 px-6">
   <div class="max-w-3xl mx-auto text-center">
     <h1 class="text-3xl font-bold mb-6">Contact Us</h1>
-<p class="text-sm text-gray-300 mb-4">
+<p class="text-sm text-gray-700 mb-4">
   Please fill out the form or email us support@packly.gg. Typical response time is within 24 hours.
 </p>
     <div class="terms-box p-6 rounded-xl text-left terms-text">
       <form id="contact-form" class="space-y-4">
         <div>
           <label for="email" class="block text-sm font-semibold mb-1">Email</label>
-          <input type="email" id="email" class="w-full p-2 rounded bg-gray-700 text-white border border-gray-600" required />
+          <input type="email" id="email" class="w-full p-2 rounded bg-white text-gray-800 border border-gray-300" required />
         </div>
         <div>
           <label for="subject" class="block text-sm font-semibold mb-1">Subject</label>
-          <input type="text" id="subject" class="w-full p-2 rounded bg-gray-700 text-white border border-gray-600" required />
+          <input type="text" id="subject" class="w-full p-2 rounded bg-white text-gray-800 border border-gray-300" required />
         </div>
         <div>
           <label for="message" class="block text-sm font-semibold mb-1">Message</label>
-          <textarea id="message" rows="4" class="w-full p-2 rounded bg-gray-700 text-white border border-gray-600" required></textarea>
+          <textarea id="message" rows="4" class="w-full p-2 rounded bg-white text-gray-800 border border-gray-300" required></textarea>
         </div>
-        <button type="submit" class="bg-yellow-400 text-black font-bold px-6 py-2 rounded hover:bg-yellow-300 transition">Submit</button>
+        <button type="submit" class="bg-blue-600 text-white font-bold px-6 py-2 rounded hover:bg-blue-500 transition">Submit</button>
       </form>
 
       <div class="mt-12">
-        <h2 class="text-2xl font-bold mb-4 text-white">Your Support Conversations</h2>
+        <h2 class="text-2xl font-bold mb-4 text-gray-900">Your Support Conversations</h2>
         <div id="user-cases" class="space-y-6"></div>
       </div>
     </div>
@@ -123,18 +123,18 @@ await formRef.set({
       snapshot.forEach(child => {
         const data = child.val();
 const messagesHtml = Object.values(data.messages || {}).map(msg => {
-          const color = msg.sender === 'admin' ? 'text-yellow-300' : 'text-white';
+          const color = msg.sender === 'admin' ? 'text-blue-600' : 'text-gray-900';
           return `<p class="text-sm ${color}"><strong>${msg.sender}:</strong> ${msg.text}</p>`;
         }).join('');
 
         container.innerHTML += `
-          <div class="p-4 bg-gray-800 border border-gray-700 rounded-lg">
-            <h3 class="font-semibold text-yellow-300 mb-2">${data.subject}</h3>
+          <div class="p-4 bg-gray-100 border border-gray-300 rounded-lg">
+            <h3 class="font-semibold text-blue-600 mb-2">${data.subject}</h3>
             ${messagesHtml}
-            <p class="text-sm text-green-400 font-semibold mt-2">Status: ${data.status}</p>
+            <p class="text-sm text-green-600 font-semibold mt-2">Status: ${data.status}</p>
             <form onsubmit="sendReply(event, '${child.key}')" class="mt-4 space-y-2">
-              <textarea placeholder="Reply..." rows="2" class="w-full p-2 rounded bg-gray-700 text-white border border-gray-600 reply-message"></textarea>
-              <button type="submit" class="bg-blue-500 text-white px-4 py-1 rounded hover:bg-blue-600">Send Reply</button>
+              <textarea placeholder="Reply..." rows="2" class="w-full p-2 rounded bg-white text-gray-800 border border-gray-300 reply-message"></textarea>
+              <button type="submit" class="bg-blue-600 text-white px-4 py-1 rounded hover:bg-blue-500">Send Reply</button>
             </form>
           </div>`;
       });

--- a/faq.html
+++ b/faq.html
@@ -14,17 +14,17 @@
   <style>
     body {
       font-family: 'Poppins', sans-serif;
-      background-color: #0f0f12;
-      color: white;
+      background-color: #ffffff;
+      color: #1f2937;
     }
     .premium-box {
-      background: linear-gradient(145deg, #1c1f26, #0e0f13);
-      border: 1px solid rgba(255, 215, 0, 0.15);
-      box-shadow: 0 0 30px rgba(255, 215, 0, 0.1);
+      background: #ffffff;
+      border: 1px solid #e5e7eb;
+      box-shadow: 0 0 30px rgba(59, 130, 246, 0.1);
     }
     .faq-item {
-      background-color: #1f1f2b;
-      border-left: 4px solid #ec4899;
+      background-color: #f3f4f6;
+      border-left: 4px solid #3b82f6;
       padding: 1.5rem;
       border-radius: 0.75rem;
       margin-bottom: 1.5rem;
@@ -32,10 +32,10 @@
     .faq-question {
       font-size: 1.125rem;
       font-weight: 600;
-      color: #f9fafb;
+      color: #1e3a8a;
     }
     .faq-answer {
-      color: #cbd5e1;
+      color: #4b5563;
       margin-top: 0.5rem;
     }
   </style>

--- a/index.html
+++ b/index.html
@@ -8,9 +8,9 @@
     tailwind.config = {
       safelist: [
         'bg-gradient-to-r',
-        'from-purple-600',
-        'to-pink-500',
-        'bg-pink-600',
+        'from-blue-600',
+        'to-blue-400',
+        'bg-blue-600',
         'bg-black/50',
         'right-2',
         'left-2',
@@ -27,8 +27,8 @@
         'bg-[#12121b]',
         'shadow-[0_0_20px_4px_rgba(255,215,0,0.5)]',
         'border-yellow-400',
-        'shadow-[0_0_16px_3px_rgba(186,85,211,0.5)]',
-        'border-purple-500',
+        'shadow-[0_0_16px_3px_rgba(37,99,235,0.5)]',
+        'border-blue-500',
         'shadow-[0_0_12px_2px_rgba(30,144,255,0.5)]',
         'border-blue-500',
         'shadow-[0_0_8px_1px_rgba(50,205,50,0.4)]',
@@ -56,17 +56,17 @@
 <header></header>
 
 <!-- Hero -->
-<section id="hero" class="relative overflow-hidden bg-gradient-to-b from-gray-900 to-gray-800">
+<section id="hero" class="relative overflow-hidden bg-gradient-to-b from-blue-50 to-white">
   <!-- Subtle background accents -->
   <div class="absolute inset-0 pointer-events-none">
-    <div class="absolute -top-32 -left-32 w-96 h-96 bg-purple-700 opacity-30 blur-3xl rounded-full"></div>
-    <div class="absolute -bottom-32 -right-32 w-96 h-96 bg-pink-600 opacity-30 blur-3xl rounded-full"></div>
+    <div class="absolute -top-32 -left-32 w-96 h-96 bg-blue-300 opacity-30 blur-3xl rounded-full"></div>
+    <div class="absolute -bottom-32 -right-32 w-96 h-96 bg-blue-400 opacity-30 blur-3xl rounded-full"></div>
   </div>
 
   <div class="container mx-auto max-w-6xl px-6 pt-20 pb-24 flex flex-col gap-10 relative">
 
     <!-- Updates Bar -->
-    <div class="w-full bg-gradient-to-r from-yellow-500 via-pink-500 to-purple-600 text-white py-2 overflow-hidden rounded-xl shadow-md">
+    <div class="w-full bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 text-white py-2 overflow-hidden rounded-xl shadow-md">
       <div class="animate-marquee whitespace-nowrap text-sm font-medium flex items-center gap-12 px-4">
         <span>📦 All cards are near mint unless specified otherwise</span>
         <span class="flex items-center gap-1">
@@ -79,13 +79,13 @@
     <div class="flex flex-col md:flex-row items-center gap-12">
       <!-- Text -->
       <div class="flex-1 text-center md:text-left">
-        <h1 class="text-5xl md:text-6xl font-extrabold mb-6 text-white tracking-tight leading-tight opacity-0 animate-fade-up">
+        <h1 class="text-5xl md:text-6xl font-extrabold mb-6 text-blue-800 tracking-tight leading-tight opacity-0 animate-fade-up">
           Virtual packs,<br>real cards. <span class="emoji-sparkle">✨</span>
         </h1>
-        <p class="text-lg text-gray-300 mb-8 leading-relaxed opacity-0 animate-fade-up">
+        <p class="text-lg text-gray-700 mb-8 leading-relaxed opacity-0 animate-fade-up">
           Open digital packs. Win real cards. Start ripping in seconds. Packly.gg.
         </p>
-        <a href="#cases" class="inline-block px-8 py-3 bg-yellow-400 text-black rounded-full font-semibold border border-yellow-500 hover:bg-yellow-300 transition-all duration-200 shadow-md hover:scale-105 opacity-0 animate-fade-up">
+        <a href="#cases" class="inline-block px-8 py-3 bg-blue-600 text-white rounded-full font-semibold border border-blue-700 hover:bg-blue-500 transition-all duration-200 shadow-md hover:scale-105 opacity-0 animate-fade-up">
           Grab A Pack
         </a>
       </div>
@@ -126,7 +126,7 @@
   <span style="top:95%; left:15%; animation-delay:4.5s;"></span>
 </div>
 
-<div class="flex flex-col items-center text-center gap-2 p-4 bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 rounded-2xl shadow-lg mb-6">
+<div class="flex flex-col items-center text-center gap-2 p-4 bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 rounded-2xl shadow-lg mb-6">
   <img src="https://cdn-icons-png.flaticon.com/128/5966/5966817.png" alt="Pack Icon" class="w-12 h-12" />
   <h2 class="text-xl font-bold text-white">Available Packs</h2>
   <p class="text-sm text-white/80">Rip, collect, and uncover what’s inside 🔥</p>
@@ -134,43 +134,43 @@
 
 <!-- Filter Toggle Button (Mobile Only) -->
 <div class="sm:hidden mb-4">
-  <button id="filter-toggle" class="text-sm bg-gray-800 text-white px-4 py-2 rounded-md border border-gray-600 w-full">
+  <button id="filter-toggle" class="text-sm bg-gray-100 text-gray-800 px-4 py-2 rounded-md border border-gray-300 w-full">
     Show Filters
   </button>
 </div>
 
 <!-- Filter Panel -->
-<div id="filter-panel" class="hidden sm:flex flex-wrap gap-4 mb-6 items-center">
+<div id="filter-panel" class="hidden sm:flex flex-wrap gap-4 mb-6 items-center text-gray-800">
   <!-- Search -->
-  <input id="search-box" type="text" placeholder="Search packs" class="px-3 py-2 rounded bg-gray-800 text-white placeholder-gray-400 w-48" />
+  <input id="search-box" type="text" placeholder="Search packs" class="px-3 py-2 rounded bg-white text-gray-800 placeholder-gray-400 border border-gray-300 w-48" />
 
   <!-- Min Price -->
-  <input id="min-price" type="number" placeholder="Min" class="px-3 py-2 rounded bg-gray-800 text-white placeholder-gray-400 w-24" />
+  <input id="min-price" type="number" placeholder="Min" class="px-3 py-2 rounded bg-white text-gray-800 placeholder-gray-400 border border-gray-300 w-24" />
 
   <!-- Max Price -->
-  <input id="max-price" type="number" placeholder="Max" class="px-3 py-2 rounded bg-gray-800 text-white placeholder-gray-400 w-24" />
+  <input id="max-price" type="number" placeholder="Max" class="px-3 py-2 rounded bg-white text-gray-800 placeholder-gray-400 border border-gray-300 w-24" />
 
   <!-- Affordable Only Toggle -->
-  <div class="flex items-center gap-3 px-3 py-2 rounded bg-gray-800 border border-gray-700 hover:border-yellow-400 transition-all">
+  <div class="flex items-center gap-3 px-3 py-2 rounded bg-gray-100 border border-gray-300 hover:border-blue-400 transition-all">
     <label for="affordable-only" class="flex items-center cursor-pointer select-none">
       <div class="relative">
         <input type="checkbox" id="affordable-only" class="sr-only peer">
-        <div class="w-11 h-6 bg-gray-600 rounded-full peer-checked:bg-yellow-400 transition-all duration-300"></div>
+        <div class="w-11 h-6 bg-gray-300 rounded-full peer-checked:bg-blue-500 transition-all duration-300"></div>
         <div class="absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full peer-checked:translate-x-full transform transition-transform duration-300"></div>
       </div>
-      <span class="ml-3 text-sm text-white">Enough coins to buy</span>
+      <span class="ml-3 text-sm text-gray-800">Enough coins to buy</span>
     </label>
   </div>
 
   <!-- Sort Dropdown -->
-  <select id="sort-select" class="px-3 py-2 rounded bg-gray-800 text-white">
+  <select id="sort-select" class="px-3 py-2 rounded bg-white text-gray-800 border border-gray-300">
     <option value="default">Sorting</option>
     <option value="asc">Ascending</option>
     <option value="desc">Descending</option>
   </select>
 
   <!-- Clear Filters Button -->
-  <button id="clear-filters" class="text-sm text-gray-400 hover:text-white ml-auto">Clear Filters</button>
+  <button id="clear-filters" class="text-sm text-gray-500 hover:text-gray-700 ml-auto">Clear Filters</button>
 </div>
 
  <!-- Category Tabs -->
@@ -202,24 +202,24 @@
 
     <!-- See More Button -->
     <div class="flex justify-center mt-6">
-      <button id="see-more-cases" class="px-4 py-2 bg-gray-800 text-white rounded-md border border-gray-600 hidden">See more</button>
+      <button id="see-more-cases" class="px-4 py-2 bg-gray-100 text-gray-800 rounded-md border border-gray-300 hidden">See more</button>
     </div>
   </div>
 </section>
 
 <!-- Best Drops -->
-<section id="best-drops" class="relative py-16 overflow-hidden bg-gradient-to-br from-[#050510] via-[#0b0f2c] to-[#050510]">
+<section id="best-drops" class="relative py-16 overflow-hidden bg-gradient-to-br from-blue-50 via-blue-100 to-blue-50">
   <!-- Futuristic grid background -->
   <div class="absolute inset-0 -z-10 opacity-30 bg-[linear-gradient(to_right,#2e2e3a_1px,transparent_1px),linear-gradient(to_bottom,#2e2e3a_1px,transparent_1px)] bg-[size:40px_40px]"></div>
   <!-- Glowing gradient orbs -->
-  <div class="absolute -top-24 -left-24 w-96 h-96 bg-fuchsia-700 rounded-full blur-3xl opacity-25"></div>
-  <div class="absolute -bottom-24 -right-24 w-96 h-96 bg-purple-700 rounded-full blur-3xl opacity-25"></div>
+  <div class="absolute -top-24 -left-24 w-96 h-96 bg-blue-300 rounded-full blur-3xl opacity-25"></div>
+  <div class="absolute -bottom-24 -right-24 w-96 h-96 bg-blue-400 rounded-full blur-3xl opacity-25"></div>
 
   <div class="mx-auto max-w-5xl px-6">
-    <div class="relative rounded-2xl bg-gradient-to-r from-cyan-500/10 via-fuchsia-500/10 to-purple-500/10 border border-fuchsia-500/20 backdrop-blur-xl shadow-[0_0_25px_rgba(168,85,247,0.3)] p-6">
+    <div class="relative rounded-2xl bg-gradient-to-r from-blue-400/10 via-blue-300/10 to-blue-500/10 border border-blue-500/20 backdrop-blur-xl shadow-[0_0_25px_rgba(37,99,235,0.3)] p-6">
       <div class="flex items-center gap-3 mb-6">
-        <i class="fa-solid fa-bolt text-fuchsia-400 text-2xl"></i>
-        <h2 class="text-2xl md:text-3xl font-extrabold tracking-tight bg-gradient-to-r from-cyan-400 via-fuchsia-500 to-purple-600 bg-clip-text text-transparent drop-shadow-[0_0_12px_rgba(168,85,247,0.6)]">Best Drops</h2>
+        <i class="fa-solid fa-bolt text-blue-500 text-2xl"></i>
+        <h2 class="text-2xl md:text-3xl font-extrabold tracking-tight bg-gradient-to-r from-blue-400 via-blue-500 to-blue-600 bg-clip-text text-transparent drop-shadow-[0_0_12px_rgba(37,99,235,0.6)]">Best Drops</h2>
       </div>
       <div id="recent-wins-carousel" class="relative flex overflow-x-auto gap-6 py-2 scrollbar-hide w-full scroll-smooth">
         <!-- Cards will be injected here -->

--- a/inventory.html
+++ b/inventory.html
@@ -17,10 +17,10 @@
       margin: 0;
       padding: 0;
       font-family: 'Poppins', sans-serif;
-      background: linear-gradient(135deg, #3b0764, #9333ea, #ec4899);
+      background: linear-gradient(135deg, #ffffff, #e0f2fe, #3b82f6);
       background-size: 300% 300%;
       animation: gradientMove 15s ease infinite;
-      color: #fff;
+      color: #1f2937;
       overflow-x: hidden;
     }
 
@@ -39,22 +39,22 @@
     }
 
     .panel {
-      background: rgba(255, 255, 255, 0.15);
-      border: 2px solid rgba(255, 255, 255, 0.25);
+      background: rgba(255, 255, 255, 0.9);
+      border: 1px solid rgba(209, 213, 219, 0.5);
       backdrop-filter: blur(10px);
       border-radius: 1.5rem;
     }
 
     .item-card {
-      background: rgba(255, 255, 255, 0.1);
-      border: 2px solid rgba(255, 255, 255, 0.25);
+      background: rgba(255, 255, 255, 0.9);
+      border: 1px solid rgba(209, 213, 219, 0.5);
       backdrop-filter: blur(10px);
       transition: transform 0.3s ease, box-shadow 0.3s ease;
     }
 
     .item-card:hover {
       transform: translateY(-6px) rotate(1deg);
-      box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5);
+      box-shadow: 0 20px 40px rgba(59, 130, 246, 0.3);
     }
 
     .btn {
@@ -64,7 +64,7 @@
 
     .btn:hover {
       transform: scale(1.05);
-      box-shadow: 0 0 10px rgba(255, 255, 255, 0.5);
+      box-shadow: 0 0 10px rgba(59, 130, 246, 0.5);
     }
 
     select {
@@ -97,16 +97,16 @@
       backdrop-filter: blur(4px);
     }
 
-    #popup-rotator {
-      max-width: 90vw;
-      max-height: 80vh;
-      border-radius: 0.5rem;
-      box-shadow: 0 0 25px rgba(236,72,153,0.5), 0 0 50px rgba(236,72,153,0.3);
-      cursor: grab;
-      touch-action: none;
-      will-change: transform;
-      position: relative;
-    }
+      #popup-rotator {
+        max-width: 90vw;
+        max-height: 80vh;
+        border-radius: 0.5rem;
+        box-shadow: 0 0 25px rgba(59,130,246,0.5), 0 0 50px rgba(59,130,246,0.3);
+        cursor: grab;
+        touch-action: none;
+        will-change: transform;
+        position: relative;
+      }
 
     #popup-rotator.grabbing {
       cursor: grabbing;
@@ -155,15 +155,15 @@
 
   <!-- Hero -->
   <section class="pt-32 pb-32 px-4 text-center relative overflow-hidden">
-    <div class="absolute -top-10 -left-10 w-52 h-52 bg-pink-500 rounded-full mix-blend-screen filter blur-3xl opacity-70 animate-blob"></div>
-    <div class="absolute -bottom-16 -right-16 w-64 h-64 bg-purple-600 rounded-full mix-blend-screen filter blur-3xl opacity-70 animate-blob animation-delay-2000"></div>
-    <div class="absolute top-1/2 left-1/2 w-40 h-40 bg-yellow-400 rounded-full mix-blend-screen filter blur-3xl opacity-60 animate-blob animation-delay-4000"></div>
+      <div class="absolute -top-10 -left-10 w-52 h-52 bg-blue-200 rounded-full mix-blend-screen filter blur-3xl opacity-70 animate-blob"></div>
+      <div class="absolute -bottom-16 -right-16 w-64 h-64 bg-blue-400 rounded-full mix-blend-screen filter blur-3xl opacity-70 animate-blob animation-delay-2000"></div>
+      <div class="absolute top-1/2 left-1/2 w-40 h-40 bg-blue-100 rounded-full mix-blend-screen filter blur-3xl opacity-60 animate-blob animation-delay-4000"></div>
     <div class="max-w-4xl mx-auto relative">
-      <h1 class="text-5xl md:text-6xl font-extrabold mb-6 flex items-center justify-center gap-3">
-        <i class="fas fa-box-open text-yellow-300 animate-bounce"></i>
-        <span class="bg-gradient-to-r from-yellow-300 via-pink-500 to-purple-500 bg-clip-text text-transparent drop-shadow-lg">Inventory</span>
-      </h1>
-      <p class="mt-2 text-pink-200 text-lg">Ship out your pulls or sell them back for coins — manage your inventory with flair.</p>
+        <h1 class="text-5xl md:text-6xl font-extrabold mb-6 flex items-center justify-center gap-3">
+          <i class="fas fa-box-open text-blue-500 animate-bounce"></i>
+          <span class="bg-gradient-to-r from-blue-400 via-blue-500 to-blue-700 bg-clip-text text-transparent drop-shadow-lg">Inventory</span>
+        </h1>
+        <p class="mt-2 text-blue-600 text-lg">Ship out your pulls or sell them back for coins — manage your inventory with flair.</p>
     </div>
     <svg class="absolute bottom-0 left-0 w-full" viewBox="0 0 1440 320" xmlns="http://www.w3.org/2000/svg"><path fill="rgba(255,255,255,0.1)" d="M0,224L80,229.3C160,235,320,245,480,234.7C640,224,800,192,960,186.7C1120,181,1280,203,1360,213.3L1440,224V320H0Z"></path></svg>
   </section>
@@ -171,14 +171,14 @@
   <!-- Tabs & Content -->
   <main class="max-w-6xl mx-auto px-4 pb-24">
     <div class="flex justify-center gap-4 mb-12 pt-6">
-      <button id="inventory-tab" class="px-6 py-2 rounded-full font-semibold text-white bg-gradient-to-r from-fuchsia-500 via-pink-500 to-amber-400">Inventory</button>
+        <button id="inventory-tab" class="px-6 py-2 rounded-full font-semibold text-white bg-gradient-to-r from-blue-500 to-blue-700">Inventory</button>
       <button id="orders-tab" class="px-6 py-2 rounded-full font-semibold text-white bg-white/20 hover:bg-white/30 transition">Recent Orders</button>
     </div>
 
     <section id="inventory-section">
       <div class="panel flex flex-col md:flex-row justify-between items-center gap-4 p-6 mb-12">
       <div class="flex flex-wrap items-center gap-4 text-sm">
-        <label class="flex items-center gap-2"><input type="checkbox" id="select-all-checkbox" class="accent-pink-500">Select All</label>
+          <label class="flex items-center gap-2"><input type="checkbox" id="select-all-checkbox" class="accent-blue-500">Select All</label>
         <div class="flex items-center gap-2">
           <label for="sort-select" class="whitespace-nowrap">Sort by:</label>
           <select id="sort-select" class="text-black rounded px-3 py-1">
@@ -190,18 +190,18 @@
       </div>
       <div class="flex flex-col sm:flex-row items-center gap-3">
         <span id="selected-total" class="text-sm text-gray-200">Total: 0 coins</span>
-        <button onclick="sellSelected()" class="px-6 py-2 rounded-full font-semibold text-white bg-gradient-to-r from-fuchsia-500 via-pink-500 to-amber-400 hover:from-amber-400 hover:via-pink-500 hover:to-fuchsia-500 transition btn">Sell Selected</button>
-        <button onclick="shipSelected()" class="px-6 py-2 rounded-full font-semibold text-white bg-gradient-to-r from-fuchsia-500 via-pink-500 to-amber-400 hover:from-amber-400 hover:via-pink-500 hover:to-fuchsia-500 transition btn">Ship Selected</button>
+          <button onclick="sellSelected()" class="px-6 py-2 rounded-full font-semibold text-white bg-gradient-to-r from-blue-500 to-blue-700 hover:from-blue-600 hover:to-blue-800 transition btn">Sell Selected</button>
+          <button onclick="shipSelected()" class="px-6 py-2 rounded-full font-semibold text-white bg-gradient-to-r from-blue-500 to-blue-700 hover:from-blue-600 hover:to-blue-800 transition btn">Ship Selected</button>
       </div>
     </div>
       <div id="inventory-container" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6"></div>
     </section>
 
     <section id="orders-section" class="hidden">
-      <div class="text-center mb-8">
-        <h2 class="text-3xl font-bold mb-2 bg-gradient-to-r from-yellow-300 via-pink-500 to-purple-500 bg-clip-text text-transparent flex items-center justify-center"><i class="fas fa-truck mr-2"></i>Your Recent Orders</h2>
-        <p class="text-sm text-pink-200">Below are your previous shipment requests and their current status.</p>
-      </div>
+        <div class="text-center mb-8">
+          <h2 class="text-3xl font-bold mb-2 bg-gradient-to-r from-blue-400 via-blue-500 to-blue-700 bg-clip-text text-transparent flex items-center justify-center"><i class="fas fa-truck mr-2"></i>Your Recent Orders</h2>
+          <p class="text-sm text-blue-600">Below are your previous shipment requests and their current status.</p>
+        </div>
       <div id="orders-container" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6"></div>
     </section>
   </main>

--- a/profile.html
+++ b/profile.html
@@ -17,8 +17,8 @@
       margin: 0;
       padding: 0;
       font-family: 'Poppins', sans-serif;
-      background: linear-gradient(135deg, #1e1e2f 0%, #3b0764 100%);
-      color: white;
+      background: linear-gradient(135deg, #ffffff 0%, #e0f2fe 100%);
+      color: #1f2937;
       overflow-x: hidden;
     }
     header {
@@ -39,90 +39,90 @@
   <img src="https://source.unsplash.com/300x400/?trading-card,pack" alt="pack" class="hidden lg:block absolute bottom-0 -right-10 w-40 opacity-20 rotate-12 pointer-events-none" />
 
   <section class="mt-20 px-4 relative z-10">
-    <div id="find-users-section" class="max-w-lg mx-auto mb-8 bg-gradient-to-br from-gray-900/80 via-gray-800/80 to-gray-900/80 backdrop-blur-xl rounded-3xl p-6 shadow-2xl border border-purple-600/30">
-      <h2 class="text-xl font-bold mb-4 text-center bg-gradient-to-r from-pink-400 to-purple-500 bg-clip-text text-transparent">Find Other Users</h2>
-      <input id="user-search" type="text" placeholder="Search users..." class="w-full px-4 py-2 rounded bg-gray-900/60 text-white border border-purple-600/40 focus:outline-none" />
-      <ul id="user-list" class="mt-2 bg-gray-900/60 rounded-lg divide-y divide-gray-700"></ul>
-      <h3 id="top-users-title" class="text-lg font-semibold mt-4 text-center text-pink-300">Top Users</h3>
-      <ul id="top-users" class="mt-2 bg-gray-900/60 rounded-lg divide-y divide-gray-700"></ul>
-    </div>
-
-    <div class="max-w-lg mx-auto bg-gradient-to-br from-gray-900/80 via-gray-800/80 to-gray-900/80 backdrop-blur-xl rounded-3xl p-6 shadow-2xl border border-purple-600/30">
-      <h2 id="profile-title" class="text-3xl font-extrabold mb-6 text-center bg-gradient-to-r from-pink-400 to-purple-500 bg-clip-text text-transparent">Your Profile</h2>
-      <div class="mb-8 text-center">
-        <div id="profile-pic" class="w-28 h-28 rounded-full bg-gradient-to-br from-pink-500 to-purple-600 text-white text-3xl font-bold flex items-center justify-center mx-auto border-4 border-purple-400 shadow-2xl"></div>
+      <div id="find-users-section" class="max-w-lg mx-auto mb-8 bg-white backdrop-blur-xl rounded-3xl p-6 shadow-2xl border border-blue-200">
+        <h2 class="text-xl font-bold mb-4 text-center bg-gradient-to-r from-blue-400 to-blue-600 bg-clip-text text-transparent">Find Other Users</h2>
+        <input id="user-search" type="text" placeholder="Search users..." class="w-full px-4 py-2 rounded bg-gray-100 text-gray-900 border border-blue-200 focus:outline-none" />
+        <ul id="user-list" class="mt-2 bg-gray-100 rounded-lg divide-y divide-gray-200"></ul>
+        <h3 id="top-users-title" class="text-lg font-semibold mt-4 text-center text-blue-600">Top Users</h3>
+        <ul id="top-users" class="mt-2 bg-gray-100 rounded-lg divide-y divide-gray-200"></ul>
       </div>
 
-      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mb-8 text-center">
-        <div class="bg-gradient-to-br from-purple-700/40 to-pink-700/40 backdrop-blur-md p-4 rounded-xl border border-purple-500/30 shadow-lg">
-          <i class="fa-solid fa-star text-pink-300 text-2xl mb-1"></i>
-          <p class="text-sm text-pink-200">Level</p>
-          <p id="level-number" class="text-2xl font-bold">1</p>
+      <div class="max-w-lg mx-auto bg-white backdrop-blur-xl rounded-3xl p-6 shadow-2xl border border-blue-200">
+        <h2 id="profile-title" class="text-3xl font-extrabold mb-6 text-center bg-gradient-to-r from-blue-400 to-blue-600 bg-clip-text text-transparent">Your Profile</h2>
+        <div class="mb-8 text-center">
+          <div id="profile-pic" class="w-28 h-28 rounded-full bg-gradient-to-br from-blue-500 to-blue-600 text-white text-3xl font-bold flex items-center justify-center mx-auto border-4 border-blue-300 shadow-2xl"></div>
         </div>
-        <div class="bg-gradient-to-br from-purple-700/40 to-pink-700/40 backdrop-blur-md p-4 rounded-xl border border-purple-500/30 shadow-lg">
-          <i class="fa-solid fa-box-open text-pink-300 text-2xl mb-1"></i>
-          <p class="text-sm text-pink-200">Packs Opened</p>
-          <p id="packs-opened" class="text-2xl font-bold">0</p>
-        </div>
-        <div class="bg-gradient-to-br from-purple-700/40 to-pink-700/40 backdrop-blur-md p-4 rounded-xl border border-purple-500/30 shadow-lg">
-          <i class="fa-solid fa-coins text-pink-300 text-2xl mb-1"></i>
-          <p class="text-sm text-pink-200">Total Spent</p>
-          <p id="total-spent" class="text-2xl font-bold">0</p>
-        </div>
-        <div class="bg-gradient-to-br from-purple-700/40 to-pink-700/40 backdrop-blur-md p-4 rounded-xl border border-purple-500/30 shadow-lg">
-          <i class="fa-solid fa-trophy text-pink-300 text-2xl mb-1"></i>
-          <p class="text-sm text-pink-200">Total Won</p>
-          <p id="total-won" class="text-2xl font-bold">0</p>
-        </div>
-        <div class="bg-gradient-to-br from-purple-700/40 to-pink-700/40 backdrop-blur-md p-4 rounded-xl border border-purple-500/30 shadow-lg sm:col-span-2 md:col-span-1">
-          <i class="fa-solid fa-gem text-pink-300 text-2xl mb-1"></i>
-          <p class="text-sm text-pink-200">Rarest Pull</p>
-          <div id="rarest-pull" class="text-sm text-gray-200"></div>
-        </div>
-      </div>
 
-      <div class="mb-8">
-        <p class="text-sm text-center text-pink-200 mb-1">Progress to Next Level</p>
-        <div class="w-full bg-gray-700 rounded-full h-4">
-          <div id="level-progress" class="bg-pink-500 h-4 rounded-full" style="width:0%"></div>
+        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mb-8 text-center">
+          <div class="bg-gradient-to-br from-blue-200/40 to-blue-400/40 backdrop-blur-md p-4 rounded-xl border border-blue-300/30 shadow-lg">
+            <i class="fa-solid fa-star text-blue-500 text-2xl mb-1"></i>
+            <p class="text-sm text-blue-400">Level</p>
+            <p id="level-number" class="text-2xl font-bold">1</p>
+          </div>
+          <div class="bg-gradient-to-br from-blue-200/40 to-blue-400/40 backdrop-blur-md p-4 rounded-xl border border-blue-300/30 shadow-lg">
+            <i class="fa-solid fa-box-open text-blue-500 text-2xl mb-1"></i>
+            <p class="text-sm text-blue-400">Packs Opened</p>
+            <p id="packs-opened" class="text-2xl font-bold">0</p>
+          </div>
+          <div class="bg-gradient-to-br from-blue-200/40 to-blue-400/40 backdrop-blur-md p-4 rounded-xl border border-blue-300/30 shadow-lg">
+            <i class="fa-solid fa-coins text-blue-500 text-2xl mb-1"></i>
+            <p class="text-sm text-blue-400">Total Spent</p>
+            <p id="total-spent" class="text-2xl font-bold">0</p>
+          </div>
+          <div class="bg-gradient-to-br from-blue-200/40 to-blue-400/40 backdrop-blur-md p-4 rounded-xl border border-blue-300/30 shadow-lg">
+            <i class="fa-solid fa-trophy text-blue-500 text-2xl mb-1"></i>
+            <p class="text-sm text-blue-400">Total Won</p>
+            <p id="total-won" class="text-2xl font-bold">0</p>
+          </div>
+          <div class="bg-gradient-to-br from-blue-200/40 to-blue-400/40 backdrop-blur-md p-4 rounded-xl border border-blue-300/30 shadow-lg sm:col-span-2 md:col-span-1">
+            <i class="fa-solid fa-gem text-blue-500 text-2xl mb-1"></i>
+            <p class="text-sm text-blue-400">Rarest Pull</p>
+            <div id="rarest-pull" class="text-sm text-gray-600"></div>
+          </div>
         </div>
-        <p id="progress-text" class="text-xs text-center text-gray-400 mt-1"></p>
-      </div>
 
-      <div class="mb-8">
-        <h3 class="text-lg font-semibold text-center text-pink-300 mb-2">Recent Pulls</h3>
-        <ul id="recent-pulls" class="bg-gray-900/60 rounded-lg divide-y divide-gray-700"></ul>
-      </div>
+        <div class="mb-8">
+          <p class="text-sm text-center text-blue-400 mb-1">Progress to Next Level</p>
+          <div class="w-full bg-gray-200 rounded-full h-4">
+            <div id="level-progress" class="bg-blue-500 h-4 rounded-full" style="width:0%"></div>
+          </div>
+          <p id="progress-text" class="text-xs text-center text-gray-500 mt-1"></p>
+        </div>
+
+        <div class="mb-8">
+          <h3 class="text-lg font-semibold text-center text-blue-600 mb-2">Recent Pulls</h3>
+          <ul id="recent-pulls" class="bg-gray-100 rounded-lg divide-y divide-gray-200"></ul>
+        </div>
 
       <div id="badge-container" class="flex flex-wrap justify-center gap-2 mb-8"></div>
 
       <div class="mb-4 text-center">
-        <label class="block text-sm font-medium text-gray-200 mb-1">Username</label>
-        <input id="username-input" type="text" class="w-full px-4 py-2 rounded bg-gray-900/60 text-white border border-purple-600/40 text-center focus:outline-none" />
+          <label class="block text-sm font-medium text-gray-700 mb-1">Username</label>
+          <input id="username-input" type="text" class="w-full px-4 py-2 rounded bg-gray-100 text-gray-900 border border-blue-200 text-center focus:outline-none" />
       </div>
 
-      <button onclick="updateProfile()" class="w-full bg-gradient-to-r from-purple-500 via-pink-500 to-indigo-500 hover:from-purple-600 hover:via-pink-600 hover:to-indigo-600 text-white font-bold py-2 px-4 rounded-full transition transform hover:scale-105 mb-4">
+        <button onclick="updateProfile()" class="w-full bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700 text-white font-bold py-2 px-4 rounded-full transition transform hover:scale-105 mb-4">
         Save Changes
       </button>
 
       <div class="mb-4">
-        <label class="block text-sm font-medium text-gray-200 mb-1">Email</label>
-        <input id="email" type="text" class="w-full px-4 py-2 rounded bg-gray-900/60 text-white border border-purple-600/40" disabled />
+          <label class="block text-sm font-medium text-gray-700 mb-1">Email</label>
+          <input id="email" type="text" class="w-full px-4 py-2 rounded bg-gray-100 text-gray-900 border border-blue-200" disabled />
       </div>
 
       <div class="mb-4">
-        <label class="block text-sm font-medium text-gray-200 mb-1">Current Password</label>
-        <input id="current-password" type="password" placeholder="Enter current password" class="w-full px-4 py-2 rounded bg-gray-900/60 text-white border border-purple-600/40" />
+          <label class="block text-sm font-medium text-gray-700 mb-1">Current Password</label>
+          <input id="current-password" type="password" placeholder="Enter current password" class="w-full px-4 py-2 rounded bg-gray-100 text-gray-900 border border-blue-200" />
       </div>
       <div class="mb-6">
-        <label class="block text-sm font-medium text-gray-200 mb-1">New Password</label>
-        <input id="new-password" type="password" placeholder="Enter new password" class="w-full px-4 py-2 rounded bg-gray-900/60 text-white border border-purple-600/40" />
+          <label class="block text-sm font-medium text-gray-700 mb-1">New Password</label>
+          <input id="new-password" type="password" placeholder="Enter new password" class="w-full px-4 py-2 rounded bg-gray-100 text-gray-900 border border-blue-200" />
       </div>
 
-      <button onclick="changePassword()" class="w-full bg-gradient-to-r from-pink-500 to-purple-500 hover:from-pink-600 hover:to-purple-600 text-white font-bold py-2 px-4 rounded-full transition transform hover:scale-105">
-        Change Password
-      </button>
-    </div>
+        <button onclick="changePassword()" class="w-full bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700 text-white font-bold py-2 px-4 rounded-full transition transform hover:scale-105">
+          Change Password
+        </button>
+      </div>
   </section>
 
   <footer></footer>

--- a/scripts/header.js
+++ b/scripts/header.js
@@ -20,7 +20,7 @@ document.addEventListener("DOMContentLoaded", () => {
       <div class="hidden items-center gap-6 relative">
         <a href="pickem.html" class="nav-link text-yellow-400"><i class="fas fa-clone"></i><span>Pickem</span><span id="pickem-nav-timer-desktop" class="ml-1 text-xs">--:--</span></a>
         <a href="leaderboard.html" class="nav-link text-blue-400"><i class="fas fa-trophy"></i><span>Leaderboard</span></a>
-        <a href="marketplace.html" class="nav-link text-pink-400"><i class="fas fa-store"></i><span>Marketplace</span></a>
+          <a href="marketplace.html" class="nav-link text-blue-600"><i class="fas fa-store"></i><span>Marketplace</span></a>
         <div id="user-balance" class="hidden flex items-center neon-balance rounded-full overflow-hidden text-sm">
           <div class="flex items-center gap-1 px-3 py-1">
             <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" />
@@ -67,12 +67,12 @@ document.addEventListener("DOMContentLoaded", () => {
           >
             <span id="drawer-username" class="font-semibold"></span>
             <div class="flex items-center gap-2 text-xs">
-              <div id="drawer-badge" class="px-2 py-0.5 rounded-full bg-purple-600"></div>
+              <div id="drawer-badge" class="px-2 py-0.5 rounded-full bg-blue-600"></div>
               <span class="text-gray-400">Lvl <span id="drawer-level"></span></span>
             </div>
             <div class="w-full mt-2 px-4">
               <div class="relative w-full h-2 bg-gray-700 rounded-full overflow-hidden">
-                <div id="drawer-xp-bar" class="absolute top-0 left-0 h-full bg-gradient-to-r from-pink-500 via-yellow-400 to-purple-500 rounded-full transition-all duration-300" style="width:0%"></div>
+                <div id="drawer-xp-bar" class="absolute top-0 left-0 h-full bg-gradient-to-r from-blue-500 to-blue-700 rounded-full transition-all duration-300" style="width:0%"></div>
               </div>
               <div id="drawer-progress-text" class="text-[10px] text-gray-400 mt-1"></div>
               <div id="drawer-next-reward" class="text-[10px] text-yellow-400"></div>
@@ -96,7 +96,7 @@ document.addEventListener("DOMContentLoaded", () => {
             <a href="index.html" class="block px-4 py-2 text-sm text-white rounded hover:bg-gray-800 flex items-center gap-2"><i class="fas fa-cube"></i> Open Packs</a>
             <a href="pickem.html" class="block px-4 py-2 text-sm text-yellow-400 rounded hover:bg-gray-800 flex items-center gap-2"><i class="fas fa-clone"></i> Pickem</a>
             <a href="leaderboard.html" class="block px-4 py-2 text-sm text-blue-400 rounded hover:bg-gray-800 flex items-center gap-2"><i class="fas fa-trophy"></i> Leaderboard</a>
-            <a href="marketplace.html" class="block px-4 py-2 text-sm text-pink-400 rounded hover:bg-gray-800 flex items-center gap-2"><i class="fas fa-store"></i> Marketplace</a>
+            <a href="marketplace.html" class="block px-4 py-2 text-sm text-blue-600 rounded hover:bg-gray-800 flex items-center gap-2"><i class="fas fa-store"></i> Marketplace</a>
             <div class="text-gray-400 text-xs uppercase px-4 mt-4">Account</div>
             <a id="drawer-inventory-link" href="inventory.html" class="block px-4 py-2 text-sm text-white rounded hover:bg-gray-800 flex items-center gap-2 hidden"><i class="fas fa-box-open"></i> Inventory</a>
             <a id="drawer-profile-link" href="profile.html" class="block px-4 py-2 text-sm text-white rounded hover:bg-gray-800 flex items-center gap-2 hidden"><i class="fas fa-user"></i> Profile</a>
@@ -273,8 +273,8 @@ document.addEventListener("DOMContentLoaded", () => {
     if (drawerLevel) drawerLevel.innerText = levelInfo.level;
     if (drawerBadge) {
       if (currentBadge) {
-        drawerBadge.innerText = currentBadge.name;
-        drawerBadge.style.backgroundColor = currentBadge.color || "#9333ea";
+          drawerBadge.innerText = currentBadge.name;
+          drawerBadge.style.backgroundColor = currentBadge.color || "#3b82f6";
         drawerBadge.classList.remove("hidden");
       } else {
         drawerBadge.classList.add("hidden");

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -54,10 +54,10 @@ async function loadProfile(uid, currentUid) {
     });
   }
   const badgeContainer = document.getElementById('badge-container');
-  if (currentBadge) {
-    const color = currentBadge.color || '#9333ea';
-    badgeContainer.innerHTML = `<span class="text-white text-xs px-2 py-1 rounded-full" style="background-color:${color}">${currentBadge.name}</span>`;
-  } else {
+    if (currentBadge) {
+      const color = currentBadge.color || '#3b82f6';
+      badgeContainer.innerHTML = `<span class="text-white text-xs px-2 py-1 rounded-full" style="background-color:${color}">${currentBadge.name}</span>`;
+    } else {
     badgeContainer.innerHTML = '<p class="text-sm text-gray-400">No badge yet.</p>';
   }
 

--- a/shipping.html
+++ b/shipping.html
@@ -17,10 +17,10 @@
       margin: 0;
       padding: 0;
       font-family: 'Poppins', sans-serif;
-      background: linear-gradient(135deg, #3b0764, #9333ea, #ec4899);
+      background: linear-gradient(135deg, #ffffff, #e0f2fe, #3b82f6);
       background-size: 300% 300%;
       animation: gradientMove 15s ease infinite;
-      color: #fff;
+      color: #1f2937;
       overflow-x: hidden;
     }
     @keyframes gradientMove {
@@ -29,8 +29,8 @@
       100% { background-position: 0% 50%; }
     }
     .panel {
-      background: rgba(255,255,255,0.15);
-      border: 2px solid rgba(255,255,255,0.25);
+      background: rgba(255,255,255,0.9);
+      border: 1px solid rgba(209,213,219,0.5);
       backdrop-filter: blur(10px);
       border-radius: 1.5rem;
     }
@@ -42,20 +42,20 @@
   <main class="pt-32 pb-24 px-4 flex justify-center">
     <div class="panel w-full max-w-md p-6">
       <h1 class="text-2xl font-bold mb-4 text-center">Enter Shipping Info</h1>
-      <input id="ship-username" type="text" placeholder="Username" class="w-full mb-2 px-4 py-2 rounded bg-gray-700 text-gray-400 cursor-not-allowed" disabled />
-      <input id="ship-name" type="text" placeholder="Full Name" autocomplete="shipping name" class="w-full mb-2 px-4 py-2 rounded bg-gray-700" />
+        <input id="ship-username" type="text" placeholder="Username" class="w-full mb-2 px-4 py-2 rounded bg-gray-100 text-gray-500 cursor-not-allowed" disabled />
+        <input id="ship-name" type="text" placeholder="Full Name" autocomplete="shipping name" class="w-full mb-2 px-4 py-2 rounded bg-gray-100" />
       <div class="mb-2">
-        <input id="ship-address" type="text" placeholder="Address" autocomplete="shipping address-line1" class="w-full px-4 py-2 rounded bg-gray-700" />
+          <input id="ship-address" type="text" placeholder="Address" autocomplete="shipping address-line1" class="w-full px-4 py-2 rounded bg-gray-100" />
       </div>
-      <input id="ship-address2" type="text" placeholder="Address 2 (Apt, Suite, etc)" autocomplete="shipping address-line2" class="w-full mb-2 px-4 py-2 rounded bg-gray-700" />
-      <input id="ship-city" type="text" placeholder="City" autocomplete="shipping address-level2" class="w-full mb-2 px-4 py-2 rounded bg-gray-700" />
-      <input id="ship-zip" type="text" placeholder="Zip Code" autocomplete="shipping postal-code" class="w-full mb-2 px-4 py-2 rounded bg-gray-700" />
-      <input id="ship-phone" type="text" placeholder="Phone Number" autocomplete="shipping tel" class="w-full mb-4 px-4 py-2 rounded bg-gray-700" />
-      <p id="shipment-cost" class="text-sm text-pink-300 mb-4"></p>
-      <div class="flex justify-end gap-3">
-        <button onclick="cancelShipping()" class="px-4 py-2 bg-gray-600 hover:bg-gray-700 rounded-full">Cancel</button>
-        <button onclick="submitShipmentRequest()" class="px-4 py-2 rounded-full bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700">Confirm</button>
-      </div>
+        <input id="ship-address2" type="text" placeholder="Address 2 (Apt, Suite, etc)" autocomplete="shipping address-line2" class="w-full mb-2 px-4 py-2 rounded bg-gray-100" />
+        <input id="ship-city" type="text" placeholder="City" autocomplete="shipping address-level2" class="w-full mb-2 px-4 py-2 rounded bg-gray-100" />
+        <input id="ship-zip" type="text" placeholder="Zip Code" autocomplete="shipping postal-code" class="w-full mb-2 px-4 py-2 rounded bg-gray-100" />
+        <input id="ship-phone" type="text" placeholder="Phone Number" autocomplete="shipping tel" class="w-full mb-4 px-4 py-2 rounded bg-gray-100" />
+        <p id="shipment-cost" class="text-sm text-blue-600 mb-4"></p>
+        <div class="flex justify-end gap-3">
+          <button onclick="cancelShipping()" class="px-4 py-2 bg-gray-200 hover:bg-gray-300 rounded-full">Cancel</button>
+          <button onclick="submitShipmentRequest()" class="px-4 py-2 rounded-full bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700">Confirm</button>
+        </div>
     </div>
   </main>
   <footer></footer>

--- a/styles/main.css
+++ b/styles/main.css
@@ -2,8 +2,8 @@
 
 body {
   font-family: 'Poppins', sans-serif;
-  background-color: #0f0f12;
-  color: white;
+  background-color: #ffffff;
+  color: #1f2937;
 }
 
 .case-card-img {
@@ -60,18 +60,18 @@ body {
 }
 
 .glow-button {
-  box-shadow: 0 0 10px rgba(236, 72, 153, 0.7), 0 0 20px rgba(147, 51, 234, 0.5);
+  box-shadow: 0 0 10px rgba(59, 130, 246, 0.7), 0 0 20px rgba(30, 58, 138, 0.5);
   transition: box-shadow 0.3s ease, transform 0.3s ease;
 }
 
 .glow-button:hover {
   transform: scale(1.05);
-  box-shadow: 0 0 15px rgba(236, 72, 153, 0.9), 0 0 30px rgba(147, 51, 234, 0.7);
+  box-shadow: 0 0 15px rgba(59, 130, 246, 0.9), 0 0 30px rgba(30, 58, 138, 0.7);
 }
 
 .frost-hero {
   backdrop-filter: blur(16px);
-  background: linear-gradient(270deg, rgba(147, 51, 234, 0.4), rgba(236, 72, 153, 0.4));
+  background: linear-gradient(270deg, rgba(59, 130, 246, 0.3), rgba(191, 219, 254, 0.3));
   background-size: 400% 400%;
   animation: gradientMove 15s ease infinite;
 }
@@ -197,7 +197,7 @@ body {
   inset: 0;
   padding: 3px;
   border-radius: inherit;
-  background: linear-gradient(90deg, #ec4899, #8b5cf6);
+  background: linear-gradient(90deg, #3b82f6, #1e40af);
   -webkit-mask: linear-gradient(#0000 0 0) content-box, linear-gradient(#000 0 0);
   -webkit-mask-composite: xor;
   mask-composite: exclude;
@@ -209,8 +209,8 @@ body {
 }
 
 .hero-pointer {
-  background: linear-gradient(to bottom, #ec4899, #8b5cf6);
-  box-shadow: 0 0 8px rgba(236, 72, 153, 0.8);
+  background: linear-gradient(to bottom, #3b82f6, #1e40af);
+  box-shadow: 0 0 8px rgba(59, 130, 246, 0.8);
 }
 
 @keyframes overlay-zoom {
@@ -307,7 +307,7 @@ body {
   box-shadow: 0 0 20px 6px rgba(59, 130, 246, 0.6); /* blue */
 }
 .glow-ultra {
-  box-shadow: 0 0 25px 7px rgba(168, 85, 247, 0.6); /* purple */
+  box-shadow: 0 0 25px 7px rgba(30, 58, 138, 0.6); /* navy */
 }
 .glow-legendary {
   box-shadow: 0 0 30px 10px rgba(250, 204, 21, 0.8); /* yellow */
@@ -733,7 +733,7 @@ html {
   right: -4px;
   bottom: -4px;
   border-radius: 9999px;
-  background: conic-gradient(from 0deg, #facc15, #ec4899, #8b5cf6, #facc15);
+  background: conic-gradient(from 0deg, #facc15, #3b82f6, #1e40af, #facc15);
   z-index: -1;
   animation: rotate-light 2s linear infinite;
   filter: blur(6px);
@@ -803,7 +803,7 @@ html {
   position: absolute;
   top: 0.5rem;
   left: 0.5rem;
-  background-color: #db2777;
+    background-color: #3b82f6;
   color: #fff;
   font-size: 0.75rem;
   padding: 0.25rem 0.5rem;
@@ -838,9 +838,9 @@ html {
   color: #fff;
   font-weight: 600;
   border-radius: 0.5rem;
-  background: #db2777;
-  background: -webkit-linear-gradient(left, #9333ea, #ec4899);
-  background: linear-gradient(to right, #9333ea, #ec4899);
+    background: #3b82f6;
+    background: -webkit-linear-gradient(left, #3b82f6, #1e40af);
+    background: linear-gradient(to right, #3b82f6, #1e40af);
 }
 
 @media (max-width: 640px) {
@@ -908,18 +908,18 @@ html {
   background-color: rgba(255, 255, 255, 0.05);
 }
 
-.neon-balance {
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  box-shadow: 0 0 10px rgba(236, 72, 153, 0.3), 0 0 20px rgba(147, 51, 234, 0.2);
-}
+  .neon-balance {
+    background: rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    box-shadow: 0 0 10px rgba(59, 130, 246, 0.3), 0 0 20px rgba(30, 58, 138, 0.2);
+  }
 
-.crazy-bottom-nav {
-  background: rgba(17, 17, 23, 0.8);
-  backdrop-filter: blur(10px);
-  border-top: 2px solid rgba(255, 255, 255, 0.1);
-  box-shadow: 0 0 20px rgba(236, 72, 153, 0.3);
-}
+  .crazy-bottom-nav {
+    background: rgba(255, 255, 255, 0.8);
+    backdrop-filter: blur(10px);
+    border-top: 2px solid rgba(209, 213, 219, 0.5);
+    box-shadow: 0 0 20px rgba(59, 130, 246, 0.3);
+  }
 
 .crazy-bottom-nav a,
 .crazy-bottom-nav button {
@@ -938,20 +938,20 @@ html {
 }
 
 /* Crazy footer redesign */
-.crazy-footer {
-  background: rgba(17, 17, 23, 0.8);
-  backdrop-filter: blur(12px);
-  border-top: 2px solid rgba(255, 255, 255, 0.1);
-  box-shadow: 0 0 25px rgba(236, 72, 153, 0.3), 0 0 50px rgba(147, 51, 234, 0.2);
-  position: relative;
-  overflow: hidden;
-}
+  .crazy-footer {
+    background: rgba(255, 255, 255, 0.8);
+    backdrop-filter: blur(12px);
+    border-top: 2px solid rgba(209, 213, 219, 0.5);
+    box-shadow: 0 0 25px rgba(59, 130, 246, 0.3), 0 0 50px rgba(30, 58, 138, 0.2);
+    position: relative;
+    overflow: hidden;
+  }
 
 .crazy-footer::before {
   content: '';
   position: absolute;
   inset: -2px;
-  background: linear-gradient(90deg, #ec4899, #9333ea, #3b82f6, #ec4899);
+    background: linear-gradient(90deg, #3b82f6, #1e40af, #93c5fd, #3b82f6);
   background-size: 300% 300%;
   animation: borderDance 8s linear infinite;
   z-index: -2;


### PR DESCRIPTION
## Summary
- finalize landing page hero, filters, and best-drop showcase with white and blue palette
- restyle contact page forms and support messages around a light theme
- bring case opening interface in line with blue accent design

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e6f2c823c8320b3ca99cd9fa8cd18