### PR TITLE
Secure spin endpoint uses server-side case data

### DIFF
--- a/api/cases.json
+++ b/api/cases.json
@@ -1,0 +1,6 @@
+{
+  "-OPvvJ3oF4Bxp8QF7zC2": [
+    { "name": "Sticker Pack", "image": "images/sticker-pack.png", "rarity": "common", "value": 1, "odds": 90 },
+    { "name": "Gem Pack", "image": "images/gem-pack.png", "rarity": "rare", "value": 5, "odds": 10 }
+  ]
+}

--- a/case.html
+++ b/case.html
@@ -533,9 +533,13 @@ document.getElementById("open-case-button").addEventListener("click", async () =
 
   for (let s = 0; s < spinCount; s++) {
     // Request a cryptographically secure spin result from the server
+    const token = await firebase.auth().currentUser.getIdToken();
     const res = await fetch('/api/spin', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer ' + token
+      },
       credentials: 'include',
       body: JSON.stringify({ caseId })
     });

--- a/scripts/vault.js
+++ b/scripts/vault.js
@@ -96,9 +96,13 @@ async function openPack() {
   await firebase.database().ref('users/' + user.uid + '/balance').set(balance - price);
 
   // Request a secure outcome from the server instead of computing locally
+  const token = await firebase.auth().currentUser.getIdToken();
   const res = await fetch('/api/spin', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer ' + token
+    },
     credentials: 'include',
     body: JSON.stringify({ caseId: currentPackId })
   });


### PR DESCRIPTION
## Summary
- Authenticate spin requests using Firebase ID tokens
- Fetch prizes by case ID on the server rather than accepting client lists
- Update front-end spin calls to send only a case identifier

## Testing
- `node -p "typeof require('./api/spin.js')"` *(fails: Cannot find module 'firebase-admin')*
- `npm install firebase-admin --no-save` *(fails: 403 Forbidden - cannot access registry)*

------
https://chatgpt.com/codex/tasks/task_e_68a36d2624a88320a40796ae52a246ef