### PR TITLE
Refactor leaderboard to light minimalist style

### DIFF
--- a/leaderboard.html
+++ b/leaderboard.html
@@ -13,49 +13,85 @@
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <style>
     body { font-family: 'Poppins', sans-serif; }
-    @keyframes blob {
-      0%,100% { transform: translate(0,0); }
-      33% { transform: translate(30px,-20px); }
-      66% { transform: translate(-20px,30px); }
+
+    /* Top-three podium layout */
+    #top-three {
+      display: grid;
+      gap: 1rem;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      align-items: flex-end;
     }
-    .animate-blob { animation: blob 8s infinite; }
-    .animation-delay-2000 { animation-delay: 2s; }
-    .animation-delay-4000 { animation-delay: 4s; }
+    #top-three > div {
+      background: #ffffff !important;
+      border: 1px solid rgba(0,0,0,0.1) !important;
+      box-shadow: 0 1px 2px rgba(0,0,0,0.05) !important;
+      border-radius: 1rem !important;
+      padding: 1.5rem !important;
+      text-align: center;
+    }
+    #top-three > div:nth-child(1) { order: 2; transform: translateY(-0.5rem); }
+    #top-three > div:nth-child(2) { order: 1; }
+    #top-three > div:nth-child(3) { order: 3; }
+
+    /* Leaderboard rows */
+    #leaderboard-body tr {
+      border-bottom: 1px solid rgba(0,0,0,0.05);
+      transition: background-color .15s ease;
+    }
+    #leaderboard-body tr:nth-child(odd) { background-color: rgba(249,250,251,1); }
+    #leaderboard-body tr:hover { background-color: rgba(243,244,246,1); }
+
+    @media (prefers-color-scheme: dark) {
+      body { background-color: #111827; color: #f3f4f6; }
+      #top-three > div {
+        background: #1f2937 !important;
+        border-color: rgba(255,255,255,0.1) !important;
+        box-shadow: 0 1px 2px rgba(0,0,0,0.5) !important;
+      }
+      #leaderboard-body tr { border-color: rgba(255,255,255,0.1); }
+      #leaderboard-body tr:nth-child(odd) { background-color: rgba(31,41,55,1); }
+      #leaderboard-body tr:hover { background-color: rgba(55,65,81,1); }
+    }
   </style>
 </head>
-<body class="bg-gray-900 text-white min-h-screen">
+<body class="bg-gray-50 text-gray-900 min-h-screen dark:bg-gray-900 dark:text-gray-100">
 <script src="scripts/preloader.js"></script>
   <header></header>
 
-  <section class="relative pt-32 pb-24 text-center overflow-hidden">
-    <div class="absolute inset-0 bg-gradient-to-br from-indigo-900 via-purple-800 to-pink-700"></div>
-    <div class="absolute -top-20 -left-20 w-72 h-72 bg-pink-500 rounded-full mix-blend-multiply filter blur-3xl opacity-70 animate-blob"></div>
-    <div class="absolute top-1/3 -right-10 w-72 h-72 bg-yellow-400 rounded-full mix-blend-multiply filter blur-3xl opacity-70 animate-blob animation-delay-2000"></div>
-    <div class="absolute -bottom-8 left-1/2 w-72 h-72 bg-purple-500 rounded-full mix-blend-multiply filter blur-3xl opacity-70 animate-blob animation-delay-4000"></div>
-    <div class="relative z-10 max-w-4xl mx-auto px-4">
-      <h1 class="text-5xl md:text-6xl font-extrabold mb-6 drop-shadow-lg">Weekly Leaderboard</h1>
-      <p class="text-xl md:text-2xl mb-2">Top 3 players earn <span class="text-yellow-300 font-bold">500 coins</span></p>
-      <p class="text-gray-200 mb-4">Leaderboard resets every 7 days.</p>
-      <p id="reset-timer" class="text-lg text-gray-200"></p>
+  <section class="pt-24 pb-12 text-center">
+    <div class="max-w-5xl mx-auto px-4">
+      <h1 class="text-4xl md:text-5xl font-bold mb-2">Weekly Leaderboard</h1>
+      <p class="text-lg text-gray-600 dark:text-gray-300 mb-1">Track the top pack rippers.</p>
+      <p id="reset-timer" class="text-sm text-gray-500 dark:text-gray-400"></p>
     </div>
   </section>
 
-  <section class="px-4 py-12">
+  <section class="px-4 pb-16">
     <div class="max-w-5xl mx-auto">
-      <div id="top-three" class="grid grid-cols-1 sm:grid-cols-3 gap-6 mb-12"></div>
+      <div id="top-three" class="mb-12"></div>
 
-      <div class="overflow-x-auto bg-gray-800/70 rounded-xl shadow-xl backdrop-blur">
-        <table class="w-full text-left min-w-[500px]">
-          <thead class="bg-gray-700/80">
-            <tr>
-              <th class="py-3 px-4">Rank</th>
-              <th class="py-3 px-4">Player</th>
-              <th class="py-3 px-4 text-center">Packs</th>
-              <th class="py-3 px-4 text-center">Card Value</th>
-              <th class="py-3 px-4 text-center">Wins</th>
+      <div class="flex items-center justify-between mb-2">
+        <div class="inline-flex gap-2 rounded-full bg-gray-100 p-1 text-sm text-gray-600 dark:bg-gray-800 dark:text-gray-300" role="tablist" aria-label="Leaderboard range">
+          <span class="px-3 py-1.5 rounded-full bg-white shadow dark:bg-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" role="tab" aria-selected="true" tabindex="0">This Week</span>
+          <span class="px-3 py-1.5 rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" role="tab" aria-selected="false" tabindex="-1">All Time</span>
+        </div>
+      </div>
+
+      <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">Earn points by ripping packs—bigger packs mean more points.</p>
+
+      <div class="relative overflow-x-auto rounded-2xl bg-white border border-gray-200 shadow-sm dark:bg-gray-800 dark:border-gray-700">
+        <div class="absolute inset-y-0 right-0 w-8 pointer-events-none bg-gradient-to-l from-white to-transparent dark:from-gray-800 rounded-r-2xl"></div>
+        <table class="w-full text-left min-w-[600px]">
+          <thead class="sticky top-0 z-10 bg-white/90 dark:bg-gray-800/90 backdrop-blur">
+            <tr class="text-sm text-gray-500 dark:text-gray-300">
+              <th class="py-3 px-4 font-medium">Rank</th>
+              <th class="py-3 px-4 font-medium">Player</th>
+              <th class="py-3 px-4 font-medium text-center">Packs</th>
+              <th class="py-3 px-4 font-medium text-center">Card Value</th>
+              <th class="py-3 px-4 font-medium text-center">Wins</th>
             </tr>
           </thead>
-          <tbody id="leaderboard-body"></tbody>
+          <tbody id="leaderboard-body" class="bg-white dark:bg-gray-800 text-sm"></tbody>
         </table>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Replace dark gradient hero with clean light section and timer
- Add top-three podium layout, toolbar tabs, and informational legend
- Wrap leaderboard table in card with sticky header, zebra rows, and hover states

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a404efc28c8320b3d620821d1a8eec