### PR TITLE
Align profile page with site theme

### DIFF
--- a/leaderboard.html
+++ b/leaderboard.html
@@ -11,42 +11,28 @@
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
-  <style>
-    body { font-family: 'Poppins', sans-serif; }
-    @keyframes blob {
-      0%,100% { transform: translate(0,0); }
-      33% { transform: translate(30px,-20px); }
-      66% { transform: translate(-20px,30px); }
-    }
-    .animate-blob { animation: blob 8s infinite; }
-    .animation-delay-2000 { animation-delay: 2s; }
-    .animation-delay-4000 { animation-delay: 4s; }
-  </style>
+  <link rel="stylesheet" href="styles/main.css">
 </head>
-<body class="bg-gray-900 text-white min-h-screen">
+<body class="min-h-screen bg-gray-50 text-gray-900">
 <script src="scripts/preloader.js"></script>
   <header></header>
 
-  <section class="relative pt-32 pb-24 text-center overflow-hidden">
-    <div class="absolute inset-0 bg-gradient-to-br from-indigo-900 via-purple-800 to-pink-700"></div>
-    <div class="absolute -top-20 -left-20 w-72 h-72 bg-pink-500 rounded-full mix-blend-multiply filter blur-3xl opacity-70 animate-blob"></div>
-    <div class="absolute top-1/3 -right-10 w-72 h-72 bg-yellow-400 rounded-full mix-blend-multiply filter blur-3xl opacity-70 animate-blob animation-delay-2000"></div>
-    <div class="absolute -bottom-8 left-1/2 w-72 h-72 bg-purple-500 rounded-full mix-blend-multiply filter blur-3xl opacity-70 animate-blob animation-delay-4000"></div>
-    <div class="relative z-10 max-w-4xl mx-auto px-4">
-      <h1 class="text-5xl md:text-6xl font-extrabold mb-6 drop-shadow-lg">Weekly Leaderboard</h1>
-      <p class="text-xl md:text-2xl mb-2">Top 3 players earn <span class="text-yellow-300 font-bold">500 coins</span></p>
-      <p class="text-gray-200 mb-4">Leaderboard resets every 7 days.</p>
-      <p id="reset-timer" class="text-lg text-gray-200"></p>
+  <section class="pt-32 pb-16 text-center px-4">
+    <div class="max-w-4xl mx-auto">
+      <h1 class="text-5xl md:text-6xl font-extrabold mb-4 gradient-text">Weekly Leaderboard</h1>
+      <p class="text-xl md:text-2xl mb-2 text-gray-700">Top 3 players earn <span class="text-indigo-600 font-bold">500 coins</span></p>
+      <p class="text-gray-600 mb-4">Leaderboard resets every 7 days.</p>
+      <p id="reset-timer" class="text-lg text-gray-600"></p>
     </div>
   </section>
 
-  <section class="px-4 py-12">
+  <section class="px-4 pb-16">
     <div class="max-w-5xl mx-auto">
-      <div id="top-three" class="grid grid-cols-1 sm:grid-cols-3 gap-6 mb-12"></div>
+      <div id="top-three" class="grid grid-cols-1 sm:grid-cols-3 gap-6 mb-8"></div>
 
-      <div class="overflow-x-auto bg-gray-800/70 rounded-xl shadow-xl backdrop-blur">
+      <div class="overflow-x-auto bg-white border border-gray-200 rounded-xl shadow-md">
         <table class="w-full text-left min-w-[500px]">
-          <thead class="bg-gray-700/80">
+          <thead class="bg-gray-100">
             <tr>
               <th class="py-3 px-4">Rank</th>
               <th class="py-3 px-4">Player</th>

--- a/marketplace.html
+++ b/marketplace.html
@@ -16,66 +16,66 @@
   <script src="scripts/auth.js" type="module"></script>
   <script src="https://js.stripe.com/v3/"></script>
 </head>
-<body class="bg-gradient-to-br from-gray-950 via-gray-900 to-black text-white min-h-screen">
+<body class="min-h-screen bg-gray-50 text-gray-900">
 <script src="scripts/preloader.js"></script>
   <header></header>
 
   <section class="pt-32 pb-16 px-4 max-w-7xl mx-auto">
     <div class="text-center mb-12">
-      <h1 class="text-5xl font-extrabold bg-gradient-to-r from-yellow-300 via-pink-400 to-purple-500 bg-clip-text text-transparent drop-shadow-sm mb-3">🛒 Marketplace</h1>
-      <p class="text-gray-400 text-sm max-w-xl mx-auto">Browse and buy premium cards with your coins. All purchases go straight to your inventory.</p>
+      <h1 class="text-5xl font-extrabold gradient-text drop-shadow-sm mb-3">🛒 Marketplace</h1>
+      <p class="text-gray-600 text-sm max-w-xl mx-auto">Browse and buy premium cards with your coins. All purchases go straight to your inventory.</p>
     </div>
 
-    <div class="bg-black/40 border border-white/10 p-4 rounded-lg mb-8 flex flex-wrap items-center gap-4">
-      <input type="text" id="search-input" placeholder="Search by name..." class="p-2 rounded bg-gray-800 text-white w-full sm:w-48">
-      <input type="number" id="min-price" placeholder="Min coins" class="p-2 rounded bg-gray-800 text-white w-full sm:w-32">
-      <input type="number" id="max-price" placeholder="Max coins" class="p-2 rounded bg-gray-800 text-white w-full sm:w-32">
+    <div class="bg-white border border-gray-200 p-4 rounded-lg mb-8 flex flex-wrap items-center gap-4">
+      <input type="text" id="search-input" placeholder="Search by name..." class="p-2 rounded bg-gray-100 text-gray-900 border border-gray-300 w-full sm:w-48">
+      <input type="number" id="min-price" placeholder="Min coins" class="p-2 rounded bg-gray-100 text-gray-900 border border-gray-300 w-full sm:w-32">
+      <input type="number" id="max-price" placeholder="Max coins" class="p-2 rounded bg-gray-100 text-gray-900 border border-gray-300 w-full sm:w-32">
       <div class="flex items-center gap-2">
-        <span class="text-sm text-white">Enough coins</span>
+        <span class="text-sm text-gray-900">Enough coins</span>
         <label class="inline-flex relative items-center cursor-pointer">
           <input type="checkbox" id="enough-coins" class="sr-only peer">
-          <div class="w-11 h-6 bg-gray-600 rounded-full peer-checked:bg-pink-600 transition-all"></div>
+          <div class="w-11 h-6 bg-gray-300 rounded-full peer-checked:bg-indigo-600 transition-all"></div>
           <div class="absolute left-0.5 top-0.5 bg-white w-5 h-5 rounded-full shadow transform peer-checked:translate-x-full transition-transform"></div>
         </label>
       </div>
-      <select id="sort-select" class="p-2 rounded bg-gray-800 text-white w-full sm:w-48">
+      <select id="sort-select" class="p-2 rounded bg-gray-100 text-gray-900 border border-gray-300 w-full sm:w-48">
         <option value="">Sort by</option>
         <option value="low">Price: Low to High</option>
         <option value="high">Price: High to Low</option>
       </select>
-      <button onclick="applyFilters()" class="px-4 py-2 bg-pink-600 hover:bg-pink-700 rounded text-white text-sm">Apply</button>
-      <button onclick="resetFilters()" class="px-4 py-2 bg-gray-600 hover:bg-gray-700 rounded text-white text-sm">Clear</button>
+      <button onclick="applyFilters()" class="px-4 py-2 bg-indigo-600 hover:bg-indigo-700 rounded text-white text-sm">Apply</button>
+      <button onclick="resetFilters()" class="px-4 py-2 bg-gray-300 hover:bg-gray-400 rounded text-gray-900 text-sm">Clear</button>
     </div>
 
     <div id="market-grid" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-5 gap-6"></div>
   </section>
 
   <template id="market-card-template">
-    <div class="bg-black/40 border border-white/10 rounded-xl p-4 text-white text-sm shadow-lg hover:shadow-pink-500/40 transition cursor-pointer group flex flex-col items-center relative">
+    <div class="bg-white border border-gray-200 rounded-xl p-4 text-gray-900 text-sm shadow-lg hover:shadow-indigo-500/40 transition cursor-pointer group flex flex-col items-center relative">
       <div class="w-full h-40 flex items-center justify-center">
         <img src="" class="max-h-full object-contain rounded drop-shadow-md transition-transform duration-300 group-hover:scale-105" alt="Card Image">
       </div>
-      <div class="font-semibold text-center leading-tight mt-2 name text-white line-clamp-2 break-words"></div>
-      <div class="text-yellow-300 font-bold mt-1 value"></div>
-      <div class="text-xs opacity-70 mt-1 rarity"></div>
-      <button class="mt-4 px-4 py-1.5 bg-pink-600 hover:bg-pink-700 text-white rounded-full text-xs font-bold uppercase tracking-wide transition buy-btn">Buy</button>
+      <div class="font-semibold text-center leading-tight mt-2 name text-gray-900 line-clamp-2 break-words"></div>
+      <div class="text-yellow-600 font-bold mt-1 value"></div>
+      <div class="text-xs text-gray-500 mt-1 rarity"></div>
+      <button class="mt-4 px-4 py-1.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-full text-xs font-bold uppercase tracking-wide transition buy-btn">Buy</button>
     </div>
   </template>
 
   <!-- Item Detail Popup -->
   <div id="item-popup" class="fixed inset-0 flex bg-black/80 hidden items-center justify-center z-50">
-    <div class="bg-gradient-to-br from-gray-800 to-black p-6 rounded-2xl shadow-2xl border border-pink-600 max-w-sm w-full text-center relative animate-fade-in">
-      <button onclick="document.getElementById('item-popup').classList.add('hidden')" class="absolute top-2 right-3 text-white text-lg">&times;</button>
+    <div class="bg-white p-6 rounded-2xl shadow-2xl border border-gray-200 max-w-sm w-full text-center relative animate-fade-in text-gray-900">
+      <button onclick="document.getElementById('item-popup').classList.add('hidden')" class="absolute top-2 right-3 text-gray-600 text-lg">&times;</button>
       <div class="relative mb-4 w-full flex justify-center">
-        <img id="item-popup-image" src="" alt="Card" class="max-h-40 rounded shadow-lg border border-white/10">
+        <img id="item-popup-image" src="" alt="Card" class="max-h-40 rounded shadow-lg border border-gray-200">
       </div>
-      <div class="text-white font-semibold text-lg mb-1" id="item-popup-name"></div>
-      <div class="text-yellow-300 font-bold text-sm" id="item-popup-value"></div>
-      <div id="item-popup-condition" class="inline-block mt-2 px-3 py-1 text-xs font-semibold text-green-300 bg-green-900 rounded-full shadow-md">
+      <div class="text-gray-900 font-semibold text-lg mb-1" id="item-popup-name"></div>
+      <div class="text-yellow-600 font-bold text-sm" id="item-popup-value"></div>
+      <div id="item-popup-condition" class="inline-block mt-2 px-3 py-1 text-xs font-semibold text-green-700 bg-green-100 rounded-full shadow-md">
   Condition: Near Mint
 </div>
-            <p class="text-xs text-gray-400 italic mt-1">Item will be added to your inventory</p>
-      <button id="item-popup-buy" class="mt-5 px-6 py-2 bg-gradient-to-r from-pink-600 to-purple-600 hover:from-pink-700 hover:to-purple-700 rounded-full text-white text-sm font-bold shadow-md">Buy</button>
+            <p class="text-xs text-gray-500 italic mt-1">Item will be added to your inventory</p>
+      <button id="item-popup-buy" class="mt-5 px-6 py-2 bg-gradient-to-r from-indigo-600 to-purple-600 hover:from-indigo-700 hover:to-purple-700 rounded-full text-white text-sm font-bold shadow-md">Buy</button>
     </div>
   </div>
   <script>

--- a/pickem.html
+++ b/pickem.html
@@ -46,23 +46,23 @@
     .legendary-spark::after { --sx:30px; --sy:-30px; }
   </style>
 </head>
-<body class="bg-gradient-to-br from-black via-gray-900 to-black min-h-screen text-white">
+<body class="min-h-screen bg-gray-50 text-gray-900">
 <script src="scripts/preloader.js"></script>
   <header></header>
   <section class="pt-32 pb-20 max-w-4xl mx-auto px-4">
     <div class="text-center mb-8">
-      <h1 class="text-4xl font-bold">Pickem</h1>
-      <p class="text-gray-300 mt-2">Exclusive limited-time packs where you pick one of five cards to win its coin value.</p>
+      <h1 class="text-4xl font-bold gradient-text">Pickem</h1>
+      <p class="text-gray-600 mt-2">Exclusive limited-time packs where you pick one of five cards to win its coin value.</p>
     </div>
-      <div id="active-pick" class="relative p-8 bg-black/40 backdrop-blur rounded-3xl border border-yellow-500/40 shadow-2xl flex flex-col items-center text-center">
-        <h2 id="pack-name" class="text-3xl font-bold mb-4"></h2>
+      <div id="active-pick" class="relative p-8 bg-white rounded-3xl border border-gray-200 shadow-lg flex flex-col items-center text-center">
+        <h2 id="pack-name" class="text-3xl font-bold mb-4 text-gray-900"></h2>
         <div class="relative w-56 sm:w-72 mx-auto mb-4">
           <img id="pack-image" alt="Pickem" class="relative z-10 w-full h-auto object-contain mx-auto drop-shadow-xl transform transition-transform duration-300 hover:scale-105">
           <div id="pickem-timer" class="timer-badge absolute -top-4 -right-4 bg-gradient-to-r from-pink-500 to-purple-600 text-white text-sm font-bold px-3 py-1 rounded-full shadow-lg">30:00</div>
         </div>
         <div class="flex justify-center mb-4">
-          <button id="pf-info" class="flex items-center gap-2 text-sm font-semibold text-green-400 hover:text-green-300 transition cursor-pointer">
-            <i class="fa-solid fa-shield-halved text-green-400 text-base drop-shadow"></i>
+          <button id="pf-info" class="flex items-center gap-2 text-sm font-semibold text-green-600 hover:text-green-500 transition cursor-pointer">
+            <i class="fa-solid fa-shield-halved text-green-600 text-base drop-shadow"></i>
             <span>Provably Fair</span>
           </button>
         </div>
@@ -75,20 +75,20 @@
   </section>
   <!-- Provably Fair Modal -->
   <div id="provably-fair-modal" class="hidden fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-50">
-    <div class="bg-gray-900 p-4 rounded-xl w-full max-w-sm text-white relative border border-white/10">
-      <button onclick="document.getElementById('provably-fair-modal').classList.add('hidden')" class="absolute top-2 right-3 text-white text-xl">&times;</button>
+    <div class="bg-white p-4 rounded-xl w-full max-w-sm text-gray-900 relative border border-gray-200">
+      <button onclick="document.getElementById('provably-fair-modal').classList.add('hidden')" class="absolute top-2 right-3 text-gray-500 text-xl">&times;</button>
       <h3 class="text-lg font-bold mb-3">Provably Fair</h3>
-      <p class="text-xs text-gray-300 mb-4">All outcomes are generated using your client seed, our server seed, and a nonce. The resulting roll is compared against the case odds to decide the prize, ensuring every spin is fair and verifiable.</p>
-      <div class="text-left text-xs space-y-2 font-mono text-gray-100 break-words">
+      <p class="text-xs text-gray-600 mb-4">All outcomes are generated using your client seed, our server seed, and a nonce. The resulting roll is compared against the case odds to decide the prize, ensuring every spin is fair and verifiable.</p>
+      <div class="text-left text-xs space-y-2 font-mono text-gray-800 break-words">
         <div><strong>Server Seed:</strong> <span id="pf-server-seed">...</span></div>
         <div><strong>Client Seed:</strong> <span id="pf-client-seed">...</span></div>
         <div><strong>Nonce:</strong> <span id="pf-nonce">...</span></div>
       </div>
       <div class="mt-4 space-y-2 text-xs">
-        <input id="client-seed-input" type="text" placeholder="New client seed" class="w-full px-2 py-1 rounded bg-gray-800 text-white" />
+        <input id="client-seed-input" type="text" placeholder="New client seed" class="w-full px-2 py-1 rounded bg-gray-100 text-gray-900" />
         <button id="update-client-seed" class="w-full bg-green-600 hover:bg-green-500 rounded py-2 text-white">Update Client Seed</button>
         <button id="new-server-seed" class="w-full bg-purple-600 hover:bg-purple-500 rounded py-2 text-white">New Server Seed</button>
-        <a href="verify.html" class="block text-center text-blue-400 hover:underline mt-2">Verify a roll</a>
+        <a href="verify.html" class="block text-center text-blue-600 hover:underline mt-2">Verify a roll</a>
       </div>
     </div>
   </div>

--- a/profile.html
+++ b/profile.html
@@ -12,111 +12,91 @@
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-storage-compat.js"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
-  <style>
-    body {
-      margin: 0;
-      padding: 0;
-      font-family: 'Poppins', sans-serif;
-      background: linear-gradient(135deg, #1e1e2f 0%, #3b0764 100%);
-      color: white;
-      overflow-x: hidden;
-    }
-    header {
-      position: fixed;
-      top: 0;
-      left: 0;
-      width: 100%;
-      z-index: 50;
-    }
-  </style>
+  <link rel="stylesheet" href="styles/main.css">
 </head>
-<body class="min-h-screen relative">
+<body class="min-h-screen bg-gray-50 text-gray-900">
 <script src="scripts/preloader.js"></script>
   <header></header>
 
-  <!-- Decorative pack images -->
-  <img src="https://source.unsplash.com/300x400/?pokemon,pack" alt="pack" class="hidden lg:block absolute -top-10 -left-10 w-40 opacity-20 -rotate-12 pointer-events-none" />
-  <img src="https://source.unsplash.com/300x400/?trading-card,pack" alt="pack" class="hidden lg:block absolute bottom-0 -right-10 w-40 opacity-20 rotate-12 pointer-events-none" />
-
-  <section class="mt-20 px-4 relative z-10">
-    <div id="find-users-section" class="max-w-lg mx-auto mb-8 bg-gradient-to-br from-gray-900/80 via-gray-800/80 to-gray-900/80 backdrop-blur-xl rounded-3xl p-6 shadow-2xl border border-purple-600/30">
-      <h2 class="text-xl font-bold mb-4 text-center bg-gradient-to-r from-pink-400 to-purple-500 bg-clip-text text-transparent">Find Other Users</h2>
-      <input id="user-search" type="text" placeholder="Search users..." class="w-full px-4 py-2 rounded bg-gray-900/60 text-white border border-purple-600/40 focus:outline-none" />
-      <ul id="user-list" class="mt-2 bg-gray-900/60 rounded-lg divide-y divide-gray-700"></ul>
-      <h3 id="top-users-title" class="text-lg font-semibold mt-4 text-center text-pink-300">Top Users</h3>
-      <ul id="top-users" class="mt-2 bg-gray-900/60 rounded-lg divide-y divide-gray-700"></ul>
+  <section class="mt-20 px-4">
+    <div id="find-users-section" class="max-w-lg mx-auto mb-8 bg-white rounded-xl p-6 shadow-md border border-gray-200">
+      <h2 class="text-xl font-bold mb-4 text-center gradient-text">Find Other Users</h2>
+      <input id="user-search" type="text" placeholder="Search users..." class="w-full px-4 py-2 rounded bg-gray-100 text-gray-900 border border-gray-300 focus:outline-none" />
+      <ul id="user-list" class="mt-2 bg-white rounded-lg divide-y divide-gray-200"></ul>
+      <h3 id="top-users-title" class="text-lg font-semibold mt-4 text-center text-gray-900">Top Users</h3>
+      <ul id="top-users" class="mt-2 bg-white rounded-lg divide-y divide-gray-200"></ul>
     </div>
 
-    <div class="max-w-lg mx-auto bg-gradient-to-br from-gray-900/80 via-gray-800/80 to-gray-900/80 backdrop-blur-xl rounded-3xl p-6 shadow-2xl border border-purple-600/30">
-      <h2 id="profile-title" class="text-3xl font-extrabold mb-6 text-center bg-gradient-to-r from-pink-400 to-purple-500 bg-clip-text text-transparent">Your Profile</h2>
+    <div class="max-w-lg mx-auto bg-white rounded-xl p-6 shadow-md border border-gray-200">
+      <h2 id="profile-title" class="text-3xl font-extrabold mb-6 text-center gradient-text">Your Profile</h2>
       <div class="mb-8 text-center">
-        <div id="profile-pic" class="w-28 h-28 rounded-full bg-gradient-to-br from-pink-500 to-purple-600 text-white text-3xl font-bold flex items-center justify-center mx-auto border-4 border-purple-400 shadow-2xl"></div>
+        <div id="profile-pic" class="w-28 h-28 rounded-full bg-indigo-500 text-white text-3xl font-bold flex items-center justify-center mx-auto border-4 border-white shadow"></div>
       </div>
 
       <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mb-8 text-center">
-        <div class="bg-gradient-to-br from-purple-700/40 to-pink-700/40 backdrop-blur-md p-4 rounded-xl border border-purple-500/30 shadow-lg">
-          <i class="fa-solid fa-star text-pink-300 text-2xl mb-1"></i>
-          <p class="text-sm text-pink-200">Level</p>
+        <div class="bg-gray-50 p-4 rounded-xl border border-gray-200 shadow">
+          <i class="fa-solid fa-star text-indigo-500 text-2xl mb-1"></i>
+          <p class="text-sm text-gray-600">Level</p>
           <p id="level-number" class="text-2xl font-bold">1</p>
         </div>
-        <div class="bg-gradient-to-br from-purple-700/40 to-pink-700/40 backdrop-blur-md p-4 rounded-xl border border-purple-500/30 shadow-lg">
-          <i class="fa-solid fa-box-open text-pink-300 text-2xl mb-1"></i>
-          <p class="text-sm text-pink-200">Packs Opened</p>
+        <div class="bg-gray-50 p-4 rounded-xl border border-gray-200 shadow">
+          <i class="fa-solid fa-box-open text-indigo-500 text-2xl mb-1"></i>
+          <p class="text-sm text-gray-600">Packs Opened</p>
           <p id="packs-opened" class="text-2xl font-bold">0</p>
         </div>
-        <div class="bg-gradient-to-br from-purple-700/40 to-pink-700/40 backdrop-blur-md p-4 rounded-xl border border-purple-500/30 shadow-lg">
-          <i class="fa-solid fa-coins text-pink-300 text-2xl mb-1"></i>
-          <p class="text-sm text-pink-200">Total Spent</p>
+        <div class="bg-gray-50 p-4 rounded-xl border border-gray-200 shadow">
+          <i class="fa-solid fa-coins text-indigo-500 text-2xl mb-1"></i>
+          <p class="text-sm text-gray-600">Total Spent</p>
           <p id="total-spent" class="text-2xl font-bold">0</p>
         </div>
-        <div class="bg-gradient-to-br from-purple-700/40 to-pink-700/40 backdrop-blur-md p-4 rounded-xl border border-purple-500/30 shadow-lg">
-          <i class="fa-solid fa-trophy text-pink-300 text-2xl mb-1"></i>
-          <p class="text-sm text-pink-200">Total Won</p>
+        <div class="bg-gray-50 p-4 rounded-xl border border-gray-200 shadow">
+          <i class="fa-solid fa-trophy text-indigo-500 text-2xl mb-1"></i>
+          <p class="text-sm text-gray-600">Total Won</p>
           <p id="total-won" class="text-2xl font-bold">0</p>
         </div>
-        <div class="bg-gradient-to-br from-purple-700/40 to-pink-700/40 backdrop-blur-md p-4 rounded-xl border border-purple-500/30 shadow-lg sm:col-span-2 md:col-span-1">
-          <i class="fa-solid fa-gem text-pink-300 text-2xl mb-1"></i>
-          <p class="text-sm text-pink-200">Rarest Pull</p>
-          <div id="rarest-pull" class="text-sm text-gray-200"></div>
+        <div class="bg-gray-50 p-4 rounded-xl border border-gray-200 shadow sm:col-span-2 md:col-span-1">
+          <i class="fa-solid fa-gem text-indigo-500 text-2xl mb-1"></i>
+          <p class="text-sm text-gray-600">Rarest Pull</p>
+          <div id="rarest-pull" class="text-sm text-gray-700"></div>
         </div>
       </div>
 
       <div class="mb-8">
-        <p class="text-sm text-center text-pink-200 mb-1">Progress to Next Level</p>
-        <div class="w-full bg-gray-700 rounded-full h-4">
-          <div id="level-progress" class="bg-pink-500 h-4 rounded-full" style="width:0%"></div>
+        <p class="text-sm text-center text-gray-600 mb-1">Progress to Next Level</p>
+        <div class="w-full bg-gray-200 rounded-full h-4">
+          <div id="level-progress" class="bg-indigo-500 h-4 rounded-full" style="width:0%"></div>
         </div>
-        <p id="progress-text" class="text-xs text-center text-gray-400 mt-1"></p>
+        <p id="progress-text" class="text-xs text-center text-gray-500 mt-1"></p>
       </div>
 
       <div class="mb-8">
-        <h3 class="text-lg font-semibold text-center text-pink-300 mb-2">Recent Pulls</h3>
-        <ul id="recent-pulls" class="bg-gray-900/60 rounded-lg divide-y divide-gray-700"></ul>
+        <h3 class="text-lg font-semibold text-center text-gray-900 mb-2">Recent Pulls</h3>
+        <ul id="recent-pulls" class="bg-white rounded-lg divide-y divide-gray-200"></ul>
       </div>
 
       <div id="badge-container" class="flex flex-wrap justify-center gap-2 mb-8"></div>
 
       <div class="mb-4 text-center">
-        <label class="block text-sm font-medium text-gray-200 mb-1">Username</label>
-        <input id="username-input" type="text" class="w-full px-4 py-2 rounded bg-gray-900/60 text-white border border-purple-600/40 text-center focus:outline-none" />
+        <label class="block text-sm font-medium text-gray-700 mb-1">Username</label>
+        <input id="username-input" type="text" class="w-full px-4 py-2 rounded bg-gray-100 text-gray-900 border border-gray-300 text-center focus:outline-none" />
       </div>
 
-      <button onclick="updateProfile()" class="w-full bg-gradient-to-r from-purple-500 via-pink-500 to-indigo-500 hover:from-purple-600 hover:via-pink-600 hover:to-indigo-600 text-white font-bold py-2 px-4 rounded-full transition transform hover:scale-105 mb-4">
+      <button onclick="updateProfile()" class="w-full bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 hover:from-indigo-600 hover:via-purple-600 hover:to-pink-600 text-white font-bold py-2 px-4 rounded-full transition transform hover:scale-105 mb-4">
         Save Changes
       </button>
 
       <div class="mb-4">
-        <label class="block text-sm font-medium text-gray-200 mb-1">Email</label>
-        <input id="email" type="text" class="w-full px-4 py-2 rounded bg-gray-900/60 text-white border border-purple-600/40" disabled />
+        <label class="block text-sm font-medium text-gray-700 mb-1">Email</label>
+        <input id="email" type="text" class="w-full px-4 py-2 rounded bg-gray-100 text-gray-900 border border-gray-300" disabled />
       </div>
 
       <div class="mb-4">
-        <label class="block text-sm font-medium text-gray-200 mb-1">Current Password</label>
-        <input id="current-password" type="password" placeholder="Enter current password" class="w-full px-4 py-2 rounded bg-gray-900/60 text-white border border-purple-600/40" />
+        <label class="block text-sm font-medium text-gray-700 mb-1">Current Password</label>
+        <input id="current-password" type="password" placeholder="Enter current password" class="w-full px-4 py-2 rounded bg-gray-100 text-gray-900 border border-gray-300" />
       </div>
       <div class="mb-6">
-        <label class="block text-sm font-medium text-gray-200 mb-1">New Password</label>
-        <input id="new-password" type="password" placeholder="Enter new password" class="w-full px-4 py-2 rounded bg-gray-900/60 text-white border border-purple-600/40" />
+        <label class="block text-sm font-medium text-gray-700 mb-1">New Password</label>
+        <input id="new-password" type="password" placeholder="Enter new password" class="w-full px-4 py-2 rounded bg-gray-100 text-gray-900 border border-gray-300" />
       </div>
 
       <button onclick="changePassword()" class="w-full bg-gradient-to-r from-pink-500 to-purple-500 hover:from-pink-600 hover:to-purple-600 text-white font-bold py-2 px-4 rounded-full transition transform hover:scale-105">

--- a/scripts/leaderboard.js
+++ b/scripts/leaderboard.js
@@ -109,14 +109,14 @@ document.addEventListener('DOMContentLoaded', async () => {
             <div class="text-sm">Packs: ${data.packsOpened || 0}</div>
           </div>`;
       } else {
-        tbody.innerHTML += `
-          <tr class="border-b border-gray-700 hover:bg-gray-700/40 transition">
-            <td class="py-2 px-4 text-center">${rank}</td>
-            <td class="py-2 px-4">${data.username || 'Anonymous'}</td>
-            <td class="py-2 px-4 text-center">${data.packsOpened || 0}</td>
-            <td class="py-2 px-4 text-center">${(data.cardValue || 0).toLocaleString()}</td>
-            <td class="py-2 px-4 text-center">${wins} Win${wins === 1 ? '' : 's'}</td>
-          </tr>`;
+          tbody.innerHTML += `
+            <tr class="border-b border-gray-200 hover:bg-gray-100 transition">
+              <td class="py-2 px-4 text-center">${rank}</td>
+              <td class="py-2 px-4">${data.username || 'Anonymous'}</td>
+              <td class="py-2 px-4 text-center">${data.packsOpened || 0}</td>
+              <td class="py-2 px-4 text-center">${(data.cardValue || 0).toLocaleString()}</td>
+              <td class="py-2 px-4 text-center">${wins} Win${wins === 1 ? '' : 's'}</td>
+            </tr>`;
       }
       rank++;
     });

--- a/scripts/vault.js
+++ b/scripts/vault.js
@@ -43,14 +43,14 @@ function renderPack(data) {
     const rarity = (prize.rarity || 'common').toLowerCase().replace(/\s+/g,'');
     const color = rarityColors[rarity] || '#a1a1aa';
     return `
-      <div class="prize-card relative rounded-xl p-4 bg-gray-800 border-2 text-white text-center shadow-sm transition-transform duration-200 hover:scale-105" style="border-color:${color}">
-        <img src="${prize.image}" class="w-full h-[120px] object-contain mx-auto mb-3 bg-black/20 rounded-lg" />
+      <div class="prize-card relative rounded-xl p-4 bg-white border-2 text-gray-900 text-center shadow-sm transition-transform duration-200 hover:scale-105" style="border-color:${color}">
+        <img src="${prize.image}" class="w-full h-[120px] object-contain mx-auto mb-3 bg-gray-100 rounded-lg" />
         <div class="font-semibold text-sm clamp-2 mb-8">${prize.name}</div>
-        <div class="absolute bottom-2 left-2 flex items-center gap-1 text-yellow-300 font-medium text-xs">
+        <div class="absolute bottom-2 left-2 flex items-center gap-1 text-yellow-600 font-medium text-xs">
           <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4" />
           ${(prize.value || 0).toLocaleString()}
         </div>
-        <div class="absolute bottom-2 right-2 text-white/70 bg-black/40 px-2 py-[2px] text-xs rounded-full">
+        <div class="absolute bottom-2 right-2 text-gray-600 bg-gray-100 px-2 py-[2px] text-xs rounded-full">
           ${(prize.odds || 0).toFixed(1)}%
         </div>
       </div>

--- a/vault.html
+++ b/vault.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Packly.gg | Pickem</title>
+  <title>Packly.gg | Vault</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://js.stripe.com/v3/"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
@@ -19,17 +19,6 @@
       -webkit-line-clamp: 1;
       -webkit-box-orient: vertical;
       overflow: hidden;
-    }
-  </style>
-  <style>
-    #particle-canvas {
-      position: fixed;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      z-index: -1;
-      pointer-events: none;
     }
   </style>
   <style>
@@ -74,26 +63,25 @@
       .legendary-spark::after{--sx:30px;--sy:-30px;}
     </style>
   </head>
-  <body class="bg-gradient-to-br from-black via-gray-900 to-black text-white overflow-x-hidden">
+  <body class="min-h-screen bg-gray-50 text-gray-900 overflow-x-hidden">
 <script src="scripts/preloader.js"></script>
-  <canvas id="particle-canvas"></canvas>
   <header></header>
 
   <section id="pack-section" class="relative pt-32 pb-10 px-4">
     <div class="relative z-10 mb-6">
-      <div class="flex items-center justify-between px-4 py-2 bg-black/40 backdrop-blur-md rounded-full shadow-lg">
+      <div class="flex items-center justify-between px-4 py-2 bg-white rounded-full shadow border border-gray-200">
         <a id="back-btn" href="pickem.html" class="flex items-center justify-center w-10 h-10 rounded-full bg-gradient-to-br from-pink-500 to-purple-500 text-white hover:scale-110 transition-transform" aria-label="Back to packs">
           <i class="fas fa-arrow-left"></i>
         </a>
-        <h2 id="pack-name" class="flex-1 text-center text-xl sm:text-2xl font-bold mx-4 bg-gradient-to-r from-yellow-400 via-pink-500 to-purple-500 bg-clip-text text-transparent leading-none">Loading...</h2>
+        <h2 id="pack-name" class="flex-1 text-center text-xl sm:text-2xl font-bold mx-4 gradient-text leading-none">Loading...</h2>
       </div>
       <div id="case-spice" class="text-center text-xs mt-2"></div>
     </div>
 
     <div id="pack-display" class="flex flex-col items-center gap-4 mt-6">
       <div class="relative w-28 h-28 sm:w-40 sm:h-40">
-        <img id="top-card-1" class="hidden absolute z-0 -left-8 sm:-left-10 top-1/2 w-16 h-24 sm:w-20 sm:h-28 object-contain rounded-lg bg-black/40 border-2 shadow-lg transform -translate-y-1/2 -rotate-12" />
-        <img id="top-card-2" class="hidden absolute z-0 -right-8 sm:-right-10 top-1/2 w-16 h-24 sm:w-20 sm:h-28 object-contain rounded-lg bg-black/40 border-2 shadow-lg transform -translate-y-1/2 rotate-12" />
+        <img id="top-card-1" class="hidden absolute z-0 -left-8 sm:-left-10 top-1/2 w-16 h-24 sm:w-20 sm:h-28 object-contain rounded-lg bg-white border-2 shadow-lg transform -translate-y-1/2 -rotate-12" />
+        <img id="top-card-2" class="hidden absolute z-0 -right-8 sm:-right-10 top-1/2 w-16 h-24 sm:w-20 sm:h-28 object-contain rounded-lg bg-white border-2 shadow-lg transform -translate-y-1/2 rotate-12" />
         <img id="main-pack-image" class="relative z-10 w-full h-full object-contain" alt="Pack" />
       </div>
       <button id="open-pack" class="shining-button animate-pulse relative px-6 py-3 rounded-full bg-gradient-to-r from-yellow-400 via-pink-500 to-purple-500 text-white font-extrabold flex items-center justify-center gap-2 shadow-lg transition-transform hover:scale-105 focus:outline-none overflow-hidden">
@@ -104,8 +92,8 @@
         </span>
       </button>
       <div class="flex justify-center mt-2">
-        <button id="pf-info" class="flex items-center gap-2 text-sm font-semibold text-green-400 hover:text-green-300 transition cursor-pointer">
-          <i class="fa-solid fa-shield-halved text-green-400 text-base drop-shadow"></i>
+        <button id="pf-info" class="flex items-center gap-2 text-sm font-semibold text-green-600 hover:text-green-500 transition cursor-pointer">
+          <i class="fa-solid fa-shield-halved text-green-600 text-base drop-shadow"></i>
           <span>Provably Fair</span>
         </button>
       </div>
@@ -113,7 +101,7 @@
 
     <div id="card-container" class="hidden flex flex-wrap justify-center gap-2 sm:gap-4 mt-10"></div>
 
-    <div class="bg-black/30 backdrop-blur-md rounded-2xl shadow-md border border-white/10 p-6 hover:shadow-purple-500/20 transition-all duration-300 mt-10 relative">
+    <div class="bg-white rounded-2xl shadow-md border border-gray-200 p-6 transition-all duration-300 mt-10 relative">
       <img class="case-pack-image absolute -top-10 left-0 -translate-x-1/2 w-64 opacity-20 z-0 pointer-events-none -rotate-12" alt="Pack Art" />
       <img class="case-pack-image absolute -top-10 right-0 translate-x-1/2 w-64 opacity-20 z-0 pointer-events-none rotate-12" alt="Pack Art" />
       <div class="relative z-10">
@@ -122,7 +110,7 @@
             <img src="https://cdn-icons-png.flaticon.com/128/5172/5172637.png" alt="Rewards Icon" class="w-5 h-5" />
             <span class="text-sm font-bold uppercase tracking-wider text-white">Rewards Table</span>
           </div>
-          <p class="mt-2 text-sm text-gray-300">Each pack contains a mix of prizes with different rarities and values.</p>
+          <p class="mt-2 text-sm text-gray-600">Each pack contains a mix of prizes with different rarities and values.</p>
         </div>
         <div id="prizes-grid" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-5 gap-4 sm:gap-6 text-sm"></div>
       </div>
@@ -130,13 +118,13 @@
   </section>
 
   <div id="win-popup" class="fixed inset-0 bg-black/80 backdrop-blur-sm hidden flex items-center justify-center z-50">
-    <div id="popup-card" class="premium-popup popup-box border-2 rounded-2xl p-6 w-full max-w-sm text-center relative text-white">
-      <button id="close-popup" class="absolute top-2 right-3 text-gray-400 hover:text-white text-xl">&times;</button>
+    <div id="popup-card" class="premium-popup popup-box border rounded-2xl p-6 w-full max-w-sm text-center relative bg-white text-gray-900">
+      <button id="close-popup" class="absolute top-2 right-3 text-gray-500 hover:text-gray-700 text-xl">&times;</button>
       <img id="popup-image" src="" alt="Prize" class="w-48 h-48 object-contain mx-auto mb-4 rounded-lg premium-glow" />
       <h3 id="popup-name" class="text-lg font-semibold mb-1"></h3>
       <div id="popup-rarity" class="text-xs uppercase tracking-wider mb-1"></div>
-      <div class="text-yellow-300 font-bold mb-1"><span id="popup-value"></span> coins</div>
-      <div class="text-gray-400 text-xs mb-4"><span id="popup-odds"></span> chance</div>
+      <div class="text-yellow-600 font-bold mb-1"><span id="popup-value"></span> coins</div>
+      <div class="text-gray-600 text-xs mb-4"><span id="popup-odds"></span> chance</div>
       <div class="flex justify-center gap-4">
         <button id="keep-btn" class="px-4 py-2 rounded-xl premium-button text-sm">Keep</button>
         <button id="sell-btn" class="px-4 py-2 rounded-xl bg-red-600 hover:bg-red-700 text-white text-sm font-bold">Sell for <span id="sell-value"></span></button>
@@ -146,20 +134,20 @@
 
   <!-- Provably Fair Modal -->
   <div id="provably-fair-modal" class="hidden fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-50">
-    <div class="bg-gray-900 p-4 rounded-xl w-full max-w-sm text-white relative border border-white/10">
-      <button onclick="document.getElementById('provably-fair-modal').classList.add('hidden')" class="absolute top-2 right-3 text-white text-xl">&times;</button>
+    <div class="bg-white p-4 rounded-xl w-full max-w-sm text-gray-900 relative border border-gray-200">
+      <button onclick="document.getElementById('provably-fair-modal').classList.add('hidden')" class="absolute top-2 right-3 text-gray-500 text-xl">&times;</button>
       <h3 class="text-lg font-bold mb-3">Provably Fair</h3>
-      <p class="text-xs text-gray-300 mb-4">All outcomes are generated using your client seed, our server seed, and a nonce. The resulting roll is compared against the case odds to decide the prize, ensuring every spin is fair and verifiable.</p>
-      <div class="text-left text-xs space-y-2 font-mono text-gray-100 break-words">
+      <p class="text-xs text-gray-600 mb-4">All outcomes are generated using your client seed, our server seed, and a nonce. The resulting roll is compared against the case odds to decide the prize, ensuring every spin is fair and verifiable.</p>
+      <div class="text-left text-xs space-y-2 font-mono text-gray-800 break-words">
         <div><strong>Server Seed:</strong> <span id="pf-server-seed">...</span></div>
         <div><strong>Client Seed:</strong> <span id="pf-client-seed">...</span></div>
         <div><strong>Nonce:</strong> <span id="pf-nonce">...</span></div>
       </div>
       <div class="mt-4 space-y-2 text-xs">
-        <input id="client-seed-input" type="text" placeholder="New client seed" class="w-full px-2 py-1 rounded bg-gray-800 text-white" />
+        <input id="client-seed-input" type="text" placeholder="New client seed" class="w-full px-2 py-1 rounded bg-gray-100 text-gray-900" />
         <button id="update-client-seed" class="w-full bg-green-600 hover:bg-green-500 rounded py-2 text-white">Update Client Seed</button>
         <button id="new-server-seed" class="w-full bg-purple-600 hover:bg-purple-500 rounded py-2 text-white">New Server Seed</button>
-        <a href="verify.html" class="block text-center text-blue-400 hover:underline mt-2">Verify a roll</a>
+        <a href="verify.html" class="block text-center text-blue-600 hover:underline mt-2">Verify a roll</a>
       </div>
     </div>
   </div>
@@ -171,50 +159,6 @@
   <script src="scripts/navbar.js"></script>
   <script src="scripts/topup.js"></script>
   <script src="scripts/vault.js"></script>
-
-  <script>
-document.addEventListener('DOMContentLoaded', () => {
-  const canvas = document.getElementById('particle-canvas');
-  const ctx = canvas.getContext('2d');
-  const particles = [];
-  const count = 50;
-
-  function resize() {
-    canvas.width = window.innerWidth;
-    canvas.height = window.innerHeight;
-  }
-  window.addEventListener('resize', resize);
-  resize();
-
-  for (let i = 0; i < count; i++) {
-    particles.push({
-      x: Math.random() * canvas.width,
-      y: Math.random() * canvas.height,
-      r: Math.random() * 3 + 1,
-      dx: (Math.random() - 0.5) * 0.3,
-      dy: (Math.random() - 0.5) * 0.3
-    });
-  }
-
-  function draw() {
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    for (const p of particles) {
-      ctx.beginPath();
-      ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
-      ctx.fillStyle = 'rgba(255,255,255,0.5)';
-      ctx.fill();
-      p.x += p.dx;
-      p.y += p.dy;
-      if (p.x < 0) p.x = canvas.width;
-      if (p.x > canvas.width) p.x = 0;
-      if (p.y < 0) p.y = canvas.height;
-      if (p.y > canvas.height) p.y = 0;
-    }
-    requestAnimationFrame(draw);
-  }
-  draw();
-});
-  </script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- apply site-wide styles to profile page
- switch profile content to light containers and gray text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a42e0441a08320bf03d08f32dd0165