### PR TITLE
style: theme-aligned preloader

### DIFF
--- a/scripts/preloader.js
+++ b/scripts/preloader.js
@@ -8,8 +8,9 @@
       flex-direction: column;
       align-items: center;
       justify-content: center;
-      background-color: #111827;
-      color: #ffffff;
+      background-color: #f8fafc;
+      color: #1f2937;
+      font-family: 'Poppins', sans-serif;
       z-index: 9999;
       transition: opacity 0.5s ease;
     }
@@ -25,6 +26,10 @@
     #preloader-progress {
       font-size: 1.5rem;
       font-weight: 700;
+      background: linear-gradient(90deg, #3b82f6, #8b5cf6);
+      -webkit-background-clip: text;
+      background-clip: text;
+      color: transparent;
     }
     @keyframes bounce {
       0%, 100% {


### PR DESCRIPTION
## Summary
- restyle preloader with light theme colors and Poppins font
- add gradient progress text matching site accents

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a43a786cb4832087b32b2446551ad5