### PR TITLE
Add dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,15 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Packly.gg | Virtual Packs, Real Cards</title>
+    <script>
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme === 'dark') {
+            document.documentElement.classList.add('dark');
+        }
+        tailwind.config = {
+            darkMode: 'class'
+        };
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
@@ -43,11 +52,6 @@
         
         .coin-icon {
             filter: drop-shadow(0 0 2px rgba(245, 158, 11, 0.7));
-        }
-        
-        .navbar {
-            backdrop-filter: blur(10px);
-            background-color: rgba(255, 255, 255, 0.8);
         }
         
         @keyframes float {
@@ -180,7 +184,7 @@
         }
     </style>
 </head>
-<body class="bg-gray-50">
+<body class="bg-gray-50 dark:bg-gray-900 dark:text-gray-100">
   <script src="scripts/preloader.js"></script>
   <header></header>
 
@@ -238,7 +242,7 @@
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="lg:text-center">
                 <h2 class="text-base text-indigo-600 font-semibold tracking-wide uppercase">Recent Drops</h2>
-                <p class="mt-2 text-3xl leading-8 font-extrabold tracking-tight text-gray-900 sm:text-4xl">
+                <p class="mt-2 text-3xl leading-8 font-extrabold tracking-tight text-black dark:text-white sm:text-4xl">
                     Hot cards from recent packs
                 </p>
             </div>

--- a/scripts/darkmode.js
+++ b/scripts/darkmode.js
@@ -1,0 +1,32 @@
+// Handles dark mode toggle and persistence
+
+function initThemeToggles() {
+  const root = document.documentElement;
+  const toggles = document.querySelectorAll('#theme-toggle, #theme-toggle-mobile');
+
+  const setTheme = (isDark) => {
+    root.classList.toggle('dark', isDark);
+    toggles.forEach(btn => {
+      btn.innerHTML = isDark ? '<i class="fas fa-sun"></i>' : '<i class="fas fa-moon"></i>';
+    });
+  };
+
+  const stored = localStorage.getItem('theme');
+  if (stored === 'dark') {
+    setTheme(true);
+  }
+
+  toggles.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const isDark = !root.classList.contains('dark');
+      setTheme(isDark);
+      localStorage.setItem('theme', isDark ? 'dark' : 'light');
+    });
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initThemeToggles);
+} else {
+  initThemeToggles();
+}

--- a/scripts/header.js
+++ b/scripts/header.js
@@ -10,7 +10,7 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   header.innerHTML = `
-    <nav class="navbar fixed top-0 left-0 right-0 z-50 border-b border-gray-200 backdrop-blur bg-white/80">
+    <nav class="navbar fixed top-0 left-0 right-0 z-50 border-b border-gray-200 backdrop-blur bg-white dark:bg-gray-800 dark:border-gray-700">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex justify-between h-16">
           <div class="flex items-center">
@@ -19,12 +19,15 @@ document.addEventListener("DOMContentLoaded", () => {
             </a>
             <div class="hidden md:ml-6 md:flex md:space-x-8">
               <a href="index.html" class="border-indigo-500 text-gray-900 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Open Packs</a>
-              <a href="pickem.html" class="border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Pickem <span id="pickem-nav-timer-desktop" class="ml-1 bg-indigo-100 text-indigo-800 text-xs font-medium px-2 py-0.5 rounded-full">--:--</span></a>
-              <a href="leaderboard.html" class="border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Leaderboard</a>
-              <a href="marketplace.html" class="border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Marketplace</a>
+              <a href="pickem.html" class="border-transparent text-gray-900 dark:text-gray-300 hover:border-gray-300 hover:text-gray-700 dark:hover:text-gray-100 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Pickem <span id="pickem-nav-timer-desktop" class="ml-1 bg-indigo-100 text-indigo-800 text-xs font-medium px-2 py-0.5 rounded-full">--:--</span></a>
+              <a href="leaderboard.html" class="border-transparent text-gray-900 dark:text-gray-300 hover:border-gray-300 hover:text-gray-700 dark:hover:text-gray-100 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Leaderboard</a>
+              <a href="marketplace.html" class="border-transparent text-gray-900 dark:text-gray-300 hover:border-gray-300 hover:text-gray-700 dark:hover:text-gray-100 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Marketplace</a>
             </div>
           </div>
           <div class="hidden md:ml-6 md:flex md:items-center">
+            <button id="theme-toggle" class="p-2 rounded-md text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700">
+              <i class="fas fa-moon"></i>
+            </button>
             <div id="auth-buttons" class="flex items-center space-x-4">
               <a href="auth.html" class="text-sm font-medium text-gray-700 hover:text-gray-900">Sign In</a>
               <a href="auth.html#register" class="text-sm font-medium text-indigo-600 hover:text-indigo-800">Register</a>
@@ -54,6 +57,10 @@ document.addEventListener("DOMContentLoaded", () => {
             </div>
           </div>
           <div class="-mr-2 flex items-center md:hidden">
+            <button id="theme-toggle-mobile" type="button" class="p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700 focus:outline-none mr-2">
+              <span class="sr-only">Toggle theme</span>
+              <i class="fas fa-moon"></i>
+            </button>
             <div id="user-balance-mobile-header" class="hidden flex items-center mr-3">
               <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="h-5 w-5 coin-icon mr-1" alt="Coins">
               <span id="balance-amount-mobile" class="font-medium text-gray-700">0</span>
@@ -71,9 +78,9 @@ document.addEventListener("DOMContentLoaded", () => {
       <div id="mobile-dropdown" class="md:hidden hidden">
         <div class="pt-2 pb-3 space-y-1">
           <a href="index.html" class="block pl-3 pr-4 py-2 border-l-4 border-indigo-500 text-base font-medium text-indigo-700 bg-indigo-50">Open Packs</a>
-          <a href="pickem.html" class="block pl-3 pr-4 py-2 border-l-4 border-transparent text-base font-medium text-gray-600 hover:bg-gray-50 hover:border-gray-300">Pickem <span id="pickem-nav-timer" class="ml-1 bg-indigo-100 text-indigo-800 text-xs font-medium px-2 py-0.5 rounded-full">--:--</span></a>
-          <a href="leaderboard.html" class="block pl-3 pr-4 py-2 border-l-4 border-transparent text-base font-medium text-gray-600 hover:bg-gray-50 hover:border-gray-300">Leaderboard</a>
-          <a href="marketplace.html" class="block pl-3 pr-4 py-2 border-l-4 border-transparent text-base font-medium text-gray-600 hover:bg-gray-50 hover:border-gray-300">Marketplace</a>
+          <a href="pickem.html" class="block pl-3 pr-4 py-2 border-l-4 border-transparent text-base font-medium text-gray-900 dark:text-gray-300 hover:bg-gray-50 hover:border-gray-300 dark:hover:bg-gray-700">Pickem <span id="pickem-nav-timer" class="ml-1 bg-indigo-100 text-indigo-800 text-xs font-medium px-2 py-0.5 rounded-full">--:--</span></a>
+          <a href="leaderboard.html" class="block pl-3 pr-4 py-2 border-l-4 border-transparent text-base font-medium text-gray-900 dark:text-gray-300 hover:bg-gray-50 hover:border-gray-300 dark:hover:bg-gray-700">Leaderboard</a>
+          <a href="marketplace.html" class="block pl-3 pr-4 py-2 border-l-4 border-transparent text-base font-medium text-gray-900 dark:text-gray-300 hover:bg-gray-50 hover:border-gray-300 dark:hover:bg-gray-700">Marketplace</a>
         </div>
         <div class="pt-4 pb-3 border-t border-gray-200">
           <div class="flex items-center px-4 mb-3">
@@ -81,14 +88,22 @@ document.addEventListener("DOMContentLoaded", () => {
             <span id="balance-amount-mobile-dropdown" class="font-medium text-gray-700">0</span>
           </div>
           <div class="space-y-1">
-            <a href="inventory.html" class="block px-4 py-2 text-base font-medium text-gray-500 hover:bg-gray-100">Inventory</a>
-            <a href="profile.html" class="block px-4 py-2 text-base font-medium text-gray-500 hover:bg-gray-100">Profile</a>
-            <a href="how-it-works.html" class="block px-4 py-2 text-base font-medium text-gray-500 hover:bg-gray-100">How It Works</a>
-            <a id="mobile-auth-button" href="auth.html" class="block px-4 py-2 text-base font-medium text-gray-500 hover:bg-gray-100">Sign In</a>
-            <a id="mobile-register-button" href="auth.html#register" class="block px-4 py-2 text-base font-medium text-gray-500 hover:bg-gray-100">Register</a>
+            <a href="inventory.html" class="block px-4 py-2 text-base font-medium text-gray-900 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">Inventory</a>
+            <a href="profile.html" class="block px-4 py-2 text-base font-medium text-gray-900 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">Profile</a>
+            <a href="how-it-works.html" class="block px-4 py-2 text-base font-medium text-gray-900 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">How It Works</a>
+            <a id="mobile-auth-button" href="auth.html" class="block px-4 py-2 text-base font-medium text-gray-900 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">Sign In</a>
+            <a id="mobile-register-button" href="auth.html#register" class="block px-4 py-2 text-base font-medium text-gray-900 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">Register</a>
           </div>
         </div>
       </div>
     </nav>
   `;
+
+  const headerScript = document.querySelector('script[src*="header.js"]');
+  if (headerScript && !document.querySelector('script[src*="darkmode.js"]')) {
+    const basePath = headerScript.getAttribute('src').split('header.js')[0];
+    const darkScript = document.createElement('script');
+    darkScript.src = basePath + 'darkmode.js';
+    document.body.appendChild(darkScript);
+  }
 });

--- a/scripts/hot-cards.js
+++ b/scripts/hot-cards.js
@@ -39,10 +39,10 @@ document.addEventListener('DOMContentLoaded', () => {
       cardEl.innerHTML = `
         <img class="w-full h-48 object-contain p-4" src="${card.image}" alt="${card.name}">
         <div class="p-4">
-          <p class="text-sm font-semibold text-center truncate mb-2" title="${displayName}">${truncatedName}</p>
+          <p class="text-sm font-semibold text-center truncate mb-2 text-black dark:text-white" title="${displayName}">${truncatedName}</p>
           <div class="flex items-center justify-center gap-1">
             <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="h-5 w-5 coin-icon" alt="Coins">
-            <span class="text-gray-900 font-medium">${price}</span>
+            <span class="font-medium text-black dark:text-white">${price}</span>
           </div>
         </div>`;
       container.appendChild(cardEl);

--- a/scripts/packs.js
+++ b/scripts/packs.js
@@ -87,7 +87,7 @@ function renderCases(caseList, reset = true) {
           <img src="${packImg}" id="${imgIdDesktop}" class="case-card-img w-full h-64 object-contain p-6 transition-all duration-300">
         </div>
         <div class="p-4">
-          <h3 class="text-lg font-medium text-gray-900">${c.name}</h3>
+          <h3 class="text-lg font-medium text-black dark:text-white">${c.name}</h3>
           <div class="mt-4">
             <a href="${openLink}" class="open-button glow-button text-sm whitespace-nowrap">
               Open for ${priceLabel} ${priceIcon}
@@ -104,7 +104,7 @@ function renderCases(caseList, reset = true) {
             <img src="${packImg}" id="${imgIdMobile}" class="case-card-img w-full h-64 object-contain p-6 transition-all duration-300">
           </div>
           <div class="p-4">
-            <h3 class="text-lg font-medium text-gray-900">${c.name}</h3>
+            <h3 class="text-lg font-medium text-black dark:text-white">${c.name}</h3>
             <div class="mt-4">
               <a href="${openLink}" class="open-button glow-button text-sm whitespace-nowrap">
                 Open for ${priceLabel} ${priceIcon}

--- a/styles/main.css
+++ b/styles/main.css
@@ -6,6 +6,11 @@ body {
   color: #1f2937;
 }
 
+.navbar {
+  backdrop-filter: blur(10px);
+  background-color: #ffffff;
+}
+
 .case-card-img {
   height: 256px;
   width: 100%;
@@ -1008,5 +1013,80 @@ html {
   font-size: 0.625rem;
   line-height: 1;
   pointer-events: none;
+}
+
+/* Dark mode styles */
+.dark body {
+  background-color: #1f2937;
+  color: #f8fafc;
+}
+
+.dark .navbar {
+  background-color: #1f2937;
+  border-color: #374151;
+}
+
+.dark .navbar a {
+  color: #f8fafc;
+}
+
+.dark #user-dropdown,
+.dark #mobile-dropdown {
+  background-color: #1f2937;
+  color: #f8fafc;
+}
+
+.dark #user-dropdown a,
+.dark #mobile-dropdown a {
+  color: #f8fafc;
+}
+
+/* Generic dark mode overrides for common utility classes */
+.dark .bg-white,
+.dark .bg-gray-50,
+.dark .bg-gray-100 {
+  background-color: #1f2937;
+}
+
+.dark .text-gray-900,
+.dark .text-gray-800,
+.dark .text-gray-700,
+.dark .text-gray-600 {
+  color: #f8fafc;
+}
+
+.dark .text-gray-500 {
+  color: #d1d5db;
+}
+
+.dark .text-gray-400 {
+  color: #9ca3af;
+}
+
+.dark .border-gray-200,
+.dark .border-gray-300 {
+  border-color: #4b5563;
+}
+
+.dark .bg-indigo-100 {
+  background-color: #3730a3;
+}
+
+.dark .text-indigo-700,
+.dark .text-indigo-800 {
+  color: #c7d2fe;
+}
+
+.dark .bg-gray-300 {
+  background-color: #4b5563;
+}
+
+.dark .hover\:bg-gray-50:hover,
+.dark .hover\:bg-gray-100:hover {
+  background-color: #374151;
+}
+
+.dark .hover\:text-gray-500:hover {
+  color: #d1d5db;
 }
 


### PR DESCRIPTION
## Summary
- centralize light-mode header styling in main stylesheet so nav stays bright
- update navigation links to render dark text in light mode and fade appropriately in dark mode
- ensure "Recent Drops" heading and card names use black text in light mode and white in dark mode
- render pack titles in black for light mode and white for dark mode
- ensure card prices use dark text in light mode and white text in dark mode
- set navigation bar background to solid white in light mode and dark gray in dark mode

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a48d6edd10832087405d3c2336cf94