### PR TITLE
Match spinner win border color to rarity

### DIFF
--- a/case.html
+++ b/case.html
@@ -63,7 +63,7 @@
     }
     .tile img { width: 150px; height: 210px; object-fit: cover; border-radius: 8px; }
     .tile:hover { transform: translateY(-4px); box-shadow: 0 4px 8px rgba(0,0,0,0.6); }
-    .tile.win { box-shadow: 0 0 0 3px #FFD36E; animation: flash 0.6s; }
+    .tile.win { box-shadow: 0 0 0 3px var(--win-color,#FFD36E); border-color: var(--win-color,#FFD36E); animation: flash 0.6s; }
     @keyframes flash {0%,100%{filter:brightness(1);}50%{filter:brightness(1.8);}}
     .tile.skeleton { position:relative; overflow:hidden; }
     .tile.skeleton::after { content:""; position:absolute; top:0; left:-100%; width:100%; height:100%; background:linear-gradient(90deg,transparent,rgba(255,255,255,0.1),transparent); animation:shimmer 1.5s infinite; }


### PR DESCRIPTION
## Summary
- synchronize spinner win visuals with item rarity
- style winning tiles using CSS variable for border and glow

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ec0644c08320a99d13a06e9f6db4