### PR TITLE
Match spinner win border color to rarity and highlight case rewards

### DIFF
--- a/case.html
+++ b/case.html
@@ -63,7 +63,7 @@
     }
     .tile img { width: 150px; height: 210px; object-fit: cover; border-radius: 8px; }
     .tile:hover { transform: translateY(-4px); box-shadow: 0 4px 8px rgba(0,0,0,0.6); }
-    .tile.win { box-shadow: 0 0 0 3px #FFD36E; animation: flash 0.6s; }
+    .tile.win { box-shadow: 0 0 0 3px var(--win-color,#FFD36E); border-color: var(--win-color,#FFD36E); animation: flash 0.6s; }
     @keyframes flash {0%,100%{filter:brightness(1);}50%{filter:brightness(1.8);}}
     .tile.skeleton { position:relative; overflow:hidden; }
     .tile.skeleton::after { content:""; position:absolute; top:0; left:-100%; width:100%; height:100%; background:linear-gradient(90deg,transparent,rgba(255,255,255,0.1),transparent); animation:shimmer 1.5s infinite; }
@@ -506,7 +506,7 @@ if (repeatedBestDrops.length) {
   <div class="prize-card relative rounded-xl p-4 bg-white border-2 text-gray-900 text-center shadow-sm cursor-pointer transition-transform duration-200 hover:scale-105" data-rarity="${rarity}" style="border-color:${color}">
     <img src="${prize.image}" class="w-full h-[120px] object-contain mx-auto mb-3 bg-gray-50 rounded-lg" />
     <div class="prize-name font-semibold text-sm clamp-2 mb-8">${prize.name}</div>
-    <div class="absolute bottom-2 left-2 flex items-center gap-1 text-yellow-300 font-medium text-xs">
+    <div class="absolute bottom-2 left-2 inline-flex items-center gap-1 px-2 py-[2px] rounded-full bg-yellow-400/40 text-yellow-300 font-medium text-xs">
       <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4" />
       ${formatCoins(prize.value || 0)}
     </div>


### PR DESCRIPTION
## Summary
- synchronize spinner win visuals with item rarity
- highlight coin values in case reward grid with pill-style badges
- revert quest reward pill styling
- darken coin value pill for better visibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ec0644c08320a99d13a06e9f6db4