### PR TITLE
Use dark gray pill for coin value in case rewards table

### DIFF
--- a/case.html
+++ b/case.html
@@ -506,7 +506,7 @@ if (repeatedBestDrops.length) {
   <div class="prize-card relative rounded-xl p-4 bg-white border-2 text-gray-900 text-center shadow-sm cursor-pointer transition-transform duration-200 hover:scale-105" data-rarity="${rarity}" style="border-color:${color}">
     <img src="${prize.image}" class="w-full h-[120px] object-contain mx-auto mb-3 bg-gray-50 rounded-lg" />
     <div class="prize-name font-semibold text-sm clamp-2 mb-8">${prize.name}</div>
-    <div class="absolute bottom-2 left-2 inline-flex items-center gap-1 px-2 py-[2px] rounded-full bg-yellow-400/40 text-yellow-300 font-medium text-xs">
+    <div class="absolute bottom-2 left-2 inline-flex items-center gap-1 px-2 py-[2px] rounded-full bg-gray-800 text-yellow-300 font-medium text-xs">
       <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4" />
       ${formatCoins(prize.value || 0)}
     </div>


### PR DESCRIPTION
## Summary
- restyle reward coin pill in case.html to use a dark gray background

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f1bc58b48320adb75ec002fa46e0