### PR TITLE
Add Box Battles page with Firebase and spinner integration

### DIFF
--- a/box-battles.html
+++ b/box-battles.html
@@ -1,0 +1,591 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Box Battles | Packly.gg</title>
+
+  <!-- Tailwind (CDN) -->
+  <script src="https://cdn.tailwindcss.com"></script>
+
+  <!-- Firebase compat (assumes app is initialized elsewhere on the page/app) -->
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
+  <script src="scripts/firebase-config.js"></script>
+
+  <!-- Site global UI loaders (adjust paths if needed) -->
+  <script defer src="scripts/header.js"></script>
+  <script defer src="scripts/navbar.js"></script>
+  <script defer src="scripts/footer.js"></script>
+
+  <!-- Spinner logic from case.html (adjust path if needed) -->
+  <script defer src="pack-opener/spinner.js"></script>
+
+  <style>
+    /* Minimal reel host styles; rest via Tailwind */
+    .reel-host { position: relative; overflow: hidden; }
+    .center-marker::after{
+      content:""; position:absolute; top:0; bottom:0; left:50%; width:2px; transform:translateX(-50%);
+      background: linear-gradient(to bottom, transparent, rgba(255,255,255,.6), transparent);
+    }
+    .pill{border-radius:9999px;padding:.25rem .6rem;border:1px solid rgba(255,255,255,.1);font-size:.75rem}
+    .pill.live{border-color:#22c55e;box-shadow:0 0 0 2px rgba(34,197,94,.2) inset}
+    dialog[open]{animation:fadeIn .12s ease-out}
+    @keyframes fadeIn{from{opacity:.0;transform:scale(.98)}to{opacity:1;transform:scale(1)}}
+  </style>
+</head>
+<body class="min-h-screen bg-[#0b0e19] text-white selection:bg-indigo-500/40">
+  <!-- Header / Nav injected -->
+  <div id="header"></div>
+  <div id="navbar"></div>
+
+  <main class="mx-auto max-w-6xl px-4 py-8 space-y-8">
+    <!-- Hero -->
+    <section class="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
+      <div>
+        <h1 class="text-3xl md:text-4xl font-extrabold tracking-tight">Box Battles</h1>
+        <p class="text-white/70 mt-1">Winner takes all. Spin across N rounds — highest total wins the pot.</p>
+        <p id="stage-status" class="text-indigo-300/80 mt-1"></p>
+      </div>
+      <div class="flex items-center gap-3">
+        <button id="create-battle-btn" class="px-5 py-2 rounded-xl bg-gradient-to-r from-indigo-500 to-blue-500 hover:from-indigo-400 hover:to-blue-400 shadow-lg shadow-indigo-500/20">
+          + Create Battle
+        </button>
+        <a href="#previous-battles" class="text-white/75 hover:text-white underline underline-offset-4">Previous Battles</a>
+      </div>
+    </section>
+
+    <!-- Two-column lists -->
+    <section class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+      <!-- Open Battles -->
+      <div class="lg:col-span-2 bg-[#0f1220] border border-white/10 rounded-2xl p-4">
+        <header class="flex items-center justify-between mb-3">
+          <h2 class="text-lg font-semibold">Open Battles</h2>
+          <form id="filters-form" class="hidden md:flex items-center gap-2 text-sm">
+            <input class="bg-white/5 rounded-lg px-3 py-1.5 placeholder-white/40" placeholder="Min value"/>
+            <select class="bg-white/5 rounded-lg px-3 py-1.5">
+              <option>Any seats</option><option>2</option><option>3</option><option>4</option>
+            </select>
+          </form>
+        </header>
+        <div id="battle-list" class="space-y-3"></div>
+      </div>
+
+      <!-- My Battles -->
+      <aside class="bg-[#0f1220] border border-white/10 rounded-2xl p-4">
+        <header class="flex items-center justify-between mb-3">
+          <h2 class="text-lg font-semibold">My Battles</h2>
+          <span id="my-battles-count" class="text-sm text-white/60"></span>
+        </header>
+        <div id="my-battles" class="space-y-3"></div>
+      </aside>
+    </section>
+
+    <!-- Battle Stage (appears when joined/created) -->
+    <section id="battle-stage" class="hidden bg-[#0f1220] border border-white/10 rounded-2xl p-4">
+      <div class="flex flex-col lg:flex-row gap-6">
+        <!-- Reel -->
+        <div class="reel-host relative grow rounded-xl border border-white/10 bg-black/20 p-3">
+          <div id="stage-reel" class="reel h-40 md:h-48 flex items-center"></div>
+          <div class="center-marker pointer-events-none absolute inset-0"></div>
+        </div>
+
+        <!-- Scoreboard -->
+        <div class="w-full lg:w-80">
+          <h3 class="text-base font-semibold mb-2">Scoreboard</h3>
+          <div id="stage-scoreboard" class="space-y-2"></div>
+          <aside id="join-aside" class="mt-4"></aside>
+        </div>
+      </div>
+    </section>
+
+    <!-- Previous Battles -->
+    <section id="previous-battles" class="bg-[#0f1220] border border-white/10 rounded-2xl p-4">
+      <header class="flex items-center justify-between mb-3">
+        <h2 class="text-lg font-semibold">Previous Battles</h2>
+        <span class="text-sm text-white/60">Latest 20</span>
+      </header>
+      <div id="previous-battles-list" class="space-y-3"></div>
+    </section>
+  </main>
+
+  <!-- Footer injected -->
+  <div id="footer"></div>
+
+  <!-- Create Battle Modal -->
+  <dialog id="battle-form" class="bg-[#0f1220] text-white border border-white/10 rounded-2xl p-0 w-[min(720px,calc(100vw-2rem))]">
+    <form method="dialog" class="p-5">
+      <header class="flex items-center justify-between mb-4">
+        <h3 class="text-xl font-semibold">Create Battle</h3>
+        <button class="px-2 py-1 text-white/70 hover:text-white" value="cancel">✕</button>
+      </header>
+
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div class="md:col-span-2">
+          <label class="text-sm text-white/70">Choose Packs</label>
+          <div id="pack-grid" class="mt-2 grid grid-cols-2 sm:grid-cols-3 gap-3 overflow-y-auto max-h-72"></div>
+        </div>
+        <div class="space-y-3">
+          <div>
+            <label class="text-sm text-white/70">Rounds (spins)</label>
+            <input id="spin-count" type="number" min="1" max="20" value="10"
+                   class="mt-1 w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2"/>
+          </div>
+          <div>
+            <label class="text-sm text-white/70">Players</label>
+            <select id="player-count" class="mt-1 w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2">
+              <option value="2">2</option><option value="3">3</option><option value="4" selected>4</option>
+            </select>
+          </div>
+          <button id="create-lobby" class="w-full mt-2 px-4 py-2 rounded-xl bg-gradient-to-r from-indigo-500 to-blue-500 hover:from-indigo-400 hover:to-blue-400">
+            Create Lobby
+          </button>
+        </div>
+      </div>
+    </form>
+  </dialog>
+
+  <!-- Rewatch Modal -->
+  <dialog id="rewatch-modal" class="bg-[#0f1220] text-white border border-white/10 rounded-2xl p-0 w-[min(840px,calc(100vw-2rem))]">
+    <form method="dialog" class="p-5">
+      <header class="flex items-center justify-between mb-4">
+        <h3 class="text-xl font-semibold">Rewatch Battle</h3>
+        <button class="px-2 py-1 text-white/70 hover:text-white" value="cancel">✕</button>
+      </header>
+      <div id="rewatch-stage" class="reel-host rounded-xl border border-white/10 bg-black/20 p-3">
+        <div id="rewatch-reel" class="reel h-40 md:h-48 flex items-center"></div>
+        <div class="center-marker pointer-events-none absolute inset-0"></div>
+      </div>
+      <div class="mt-4 flex items-center gap-3">
+        <button id="rewatch-play" class="px-4 py-1.5 rounded-lg bg-white/10 hover:bg-white/15">Play</button>
+        <input id="rewatch-progress" type="range" min="0" value="0" class="w-full"/>
+      </div>
+    </form>
+  </dialog>
+
+  <!-- Page logic -->
+  <script>
+    /***** DESCRIPTION FOR CODEX *****
+     - Build a Winner-Takes-All Box Battles page that:
+       1) Lists open battles (#battle-list) and my battles (#my-battles).
+       2) Lets user create a lobby via #battle-form (choose packs, spinCount, playerCount).
+       3) On join, if seats < max at countdown end, fill with bots.
+       4) Run N rounds turn-by-turn using existing PackOpener spinner:
+          - For each turn: set items to current pack prizes, compute deterministic index,
+            call PackOpener.spinToIndex(index, {durationMs: 1600, nearMiss: true, onReveal}),
+            update player's total and store pull to Firestore.
+       5) After last round, highest total wins the pot. Persist winner + pulls.
+       6) Previous Battles list shows last 20 finished; Rewatch modal replays stored indexes quickly.
+     - Keep Firebase compat. Assume firebase.initializeApp(...) already exists globally.
+     - DO NOT rename these hook IDs: 
+       #create-battle-btn #battle-form #pack-grid #spin-count #player-count
+       #battle-list #my-battles #previous-battles #rewatch-modal #rewatch-stage
+       #battle-stage #stage-reel #stage-scoreboard #stage-status #join-aside #filters-form
+     *********************************/
+
+    // --- Shortcuts
+    const db = firebase.firestore();
+    const battlesRef = db.collection('battles');
+
+    // TODO: Wire to your real auth.
+    function currentUser(){
+      const u = firebase.auth().currentUser;
+      if (u) return { uid: u.uid, displayName: u.displayName || (u.email||'User').split('@')[0], avatarUrl: u.photoURL || '' };
+      // Fallback guest (dev only)
+      return { uid: 'guest-' + Math.random().toString(36).slice(2,8), displayName: 'Guest', avatarUrl: '' };
+    }
+
+    // TODO: Wire to your real packs API / Firestore. Must return: [{id,name,image,price,prizes:[{id,name,image,value,rarity}]}]
+    async function fetchAvailablePacks(){
+      return [
+        { id:'p1', name:'Starter', image:'https://via.placeholder.com/80x96?text=P1', price:100, prizes: demoPrizes('P1') },
+        { id:'p2', name:'Epic',    image:'https://via.placeholder.com/80x96?text=P2', price:250, prizes: demoPrizes('P2') },
+        { id:'p3', name:'Mythic',  image:'https://via.placeholder.com/80x96?text=P3', price:500, prizes: demoPrizes('P3') },
+      ];
+    }
+    function demoPrizes(tag){
+      return [
+        {id:tag+'-c1',name:'Common A',image:'https://via.placeholder.com/100x140?text='+tag+'-C',value:120,rarity:'common'},
+        {id:tag+'-u1',name:'Uncommon A',image:'https://via.placeholder.com/100x140?text='+tag+'-U',value:260,rarity:'uncommon'},
+        {id:tag+'-r1',name:'Rare A',image:'https://via.placeholder.com/100x140?text='+tag+'-R',value:540,rarity:'rare'},
+        {id:tag+'-ur',name:'Ultra A',image:'https://via.placeholder.com/100x140?text='+tag+'-UR',value:980,rarity:'ultra'},
+        {id:tag+'-l1',name:'Legendary',image:'https://via.placeholder.com/100x140?text='+tag+'-L',value:1500,rarity:'legendary'},
+      ];
+    }
+
+    // TODO: Replace with your provably fair index generator.
+    function getWinningIndex(pack, serverSeed, clientSeed, nonce){
+      // Deterministic placeholder: use a simple seeded hash
+      const str = [serverSeed, clientSeed, nonce, pack.id].join('|');
+      let h = 2166136261;
+      for (let i=0;i<str.length;i++){ h ^= str.charCodeAt(i); h += (h<<1)+(h<<4)+(h<<7)+(h<<8)+(h<<24); }
+      const x = (h>>>0) / 2**32;
+      return Math.floor(x * pack.prizes.length);
+    }
+
+    // Utilities
+    const $ = (s, r=document) => r.querySelector(s);
+    const $$ = (s, r=document) => Array.from(r.querySelectorAll(s));
+    const sleep = (ms) => new Promise(r=>setTimeout(r, ms));
+
+    // Render helpers
+    function pill(text, extra=''){ return `<span class="pill bg-white/5 ${extra}">${text}</span>`; }
+    function avatar(name){
+      const init = (name||'U')[0]?.toUpperCase() || 'U';
+      return `<div class="w-8 h-8 rounded-full bg-white/10 grid place-items-center text-sm font-semibold">${init}</div>`;
+    }
+    function rowCard(inner){ return `<div class="rounded-xl border border-white/10 bg-white/5 p-3">${inner}</div>`; }
+
+    // --- Pack chooser UI
+    async function populatePackGrid(){
+      const packs = await fetchAvailablePacks();
+      const grid = $('#pack-grid'); grid.innerHTML = '';
+      packs.forEach(p=>{
+        const el = document.createElement('button');
+        el.type = 'button';
+        el.className = 'group relative rounded-xl border border-white/10 bg-white/5 hover:bg-white/10 p-2 text-left';
+        el.dataset.id = p.id;
+        el.innerHTML = `
+          <img src="${p.image}" class="w-16 h-20 object-cover rounded-md mx-auto"/>
+          <div class="mt-2 text-xs flex items-center justify-between">
+            <span class="truncate">${p.name}</span>
+            <span class="text-white/60">${p.price}</span>
+          </div>
+          <span class="absolute top-2 right-2 hidden group-[.selected]:inline-flex pill bg-indigo-500/20 border-indigo-400/30">Selected</span>
+        `;
+        el.addEventListener('click', ()=>{
+          el.classList.toggle('selected');
+          el.classList.contains('selected') ? el.classList.add('ring-2','ring-indigo-500/50') : el.classList.remove('ring-2','ring-indigo-500/50');
+        });
+        grid.appendChild(el);
+      });
+    }
+
+    // --- Open/My/Previous lists
+    function renderBattleRow(b){
+      const live = b.status === 'spinning' ? pill('LIVE','live') : '';
+      const packs = (b.packs||[]).map(p=>`<img src="${p.image}" class="w-10 h-12 object-cover rounded-md border border-white/10"/>`).join('');
+      const players = (b.players||[]).map(p=>`<div class="flex items-center gap-1">${avatar(p.displayName)}<span class="hidden md:inline text-sm">${p.displayName||'Player'}</span></div>`).join('');
+      const canJoin = (b.status==='lobby' || b.status==='countdown') && (b.players?.length||0) < b.maxPlayers;
+
+      return rowCard(`
+        <div class="flex items-center justify-between gap-3">
+          <div class="flex items-center gap-3">
+            <div class="w-10 h-10 rounded-full grid place-items-center bg-white/5">${b.spinCount}</div>
+            <div class="flex items-center gap-2">${packs}</div>
+          </div>
+          <div class="flex items-center gap-3">
+            ${live}
+            <div class="text-sm text-white/80">Pot: <span class="font-semibold">${b.potValue||0}</span></div>
+            <div class="flex items-center gap-2">${players}</div>
+            <div class="flex items-center gap-2">
+              ${canJoin ? `<button class="join-btn px-3 py-1.5 rounded-lg bg-indigo-500/80 hover:bg-indigo-500" data-id="${b.id}">Join</button>` : ''}
+              <button class="watch-btn px-3 py-1.5 rounded-lg bg-white/10 hover:bg-white/15" data-id="${b.id}">Watch</button>
+            </div>
+          </div>
+        </div>
+      `);
+    }
+
+    function renderPreviousRow(b){
+      const winner = b.winner?.displayName || '—';
+      const packs = (b.packs||[]).slice(0,6).map(p=>`<img src="${p.image}" class="w-8 h-10 object-cover rounded-md border border-white/10"/>`).join('');
+      return rowCard(`
+        <div class="flex items-center justify-between gap-3">
+          <div class="flex items-center gap-3">${packs}</div>
+          <div class="text-sm text-white/70">Rounds: ${b.spinCount} • Players: ${b.maxPlayers}</div>
+          <div class="text-sm">Winner: <span class="font-semibold">${winner}</span></div>
+          <div class="text-sm text-white/80">Pot: ${b.potValue||0}</div>
+          <button class="rewatch-btn px-3 py-1.5 rounded-lg bg-white/10 hover:bg-white/15" data-id="${b.id}">Rewatch</button>
+        </div>
+      `);
+    }
+
+    // --- Stage (spinner + scoreboard)
+    function ensureStage(){
+      const host = $('#stage-reel');
+      if (!host._packlySpinnerReady){
+        PackOpener.init({ root: host, items: [] });
+        host._packlySpinnerReady = true;
+      }
+    }
+    function setStageItems(prizes){ ensureStage(); PackOpener.setItems(prizes); }
+    function highlightTurn(idx){
+      $$('#stage-scoreboard .player').forEach((el,i)=> el.classList.toggle('ring-2', i===idx));
+    }
+    function renderScoreboard(players){
+      const html = players.map(p=>`
+        <div class="player rounded-xl border border-white/10 bg-white/5 p-3 flex items-center justify-between">
+          <div class="flex items-center gap-2">${avatar(p.displayName)}<div>
+            <div class="font-semibold">${p.displayName}${p.isBot? ' (Bot)':''}</div>
+            <div class="text-xs text-white/60">Total: ${p.total||0}</div>
+          </div></div>
+          <div class="text-xs text-white/60">${p.pulls?.length||0} pulls</div>
+        </div>
+      `).join('');
+      $('#stage-scoreboard').innerHTML = html;
+    }
+
+    // --- Live listeners
+    function subscribeLists(){
+      battlesRef.orderBy('createdAt','desc').limit(50).onSnapshot(snap=>{
+        const me = currentUser();
+        const open = []; const mine = []; const finished = [];
+        snap.forEach(doc=>{
+          const b = {id:doc.id, ...doc.data()};
+          if (b.status==='finished') finished.push(b);
+          else open.push(b);
+          if ((b.players||[]).some(p=>p.uid===me.uid)) mine.push(b);
+        });
+
+        $('#battle-list').innerHTML = open.map(renderBattleRow).join('') || '<div class="text-white/60">No open battles right now.</div>';
+        $('#my-battles').innerHTML = mine.map(renderBattleRow).join('') || '<div class="text-white/60">You are not in any battles.</div>';
+        $('#my-battles-count').textContent = mine.length ? `${mine.length}` : '';
+
+        // Buttons
+        $$('.join-btn').forEach(btn=> btn.onclick = ()=> joinBattle(btn.dataset.id));
+        $$('.watch-btn').forEach(btn=> btn.onclick = ()=> showBattle(btn.dataset.id));
+      });
+
+      battlesRef.where('status','==','finished').orderBy('createdAt','desc').limit(20).onSnapshot(snap=>{
+        const arr = snap.docs.map(d=>({id:d.id, ...d.data()}));
+        $('#previous-battles-list').innerHTML = arr.map(renderPreviousRow).join('') || '<div class="text-white/60">Nothing yet — be the first!</div>';
+        $$('.rewatch-btn').forEach(btn=> btn.onclick = ()=> openRewatch(btn.dataset.id));
+      });
+    }
+
+    // --- Create / Join / Watch
+    async function openCreateModal(){
+      await populatePackGrid();
+      $('#battle-form').showModal();
+    }
+
+    async function createLobby(){
+      const me = currentUser();
+      const spinCount = Math.max(1, Math.min(20, parseInt($('#spin-count').value||10)));
+      const maxPlayers = parseInt($('#player-count').value||4);
+      const selected = $$('#pack-grid .selected').map(el=> el.dataset.id);
+      if (!selected.length){ alert('Pick at least one pack'); return; }
+      const all = await fetchAvailablePacks();
+      const packs = all.filter(p=> selected.includes(p.id));
+
+      // Compute pot (players * rounds * pack price average)
+      const avgPrice = Math.round(packs.reduce((s,p)=>s+p.price,0) / packs.length);
+      const potValue = avgPrice * spinCount * maxPlayers;
+
+      const b = {
+        createdAt: firebase.firestore.FieldValue.serverTimestamp(),
+        createdBy: me,
+        packs: packs.map(p=>({id:p.id, name:p.name, image:p.image, price:p.price})),
+        spinCount, maxPlayers, mode:'winner_takes_all',
+        players: [{...me, total:0, pulls:[]}],
+        potValue, status:'lobby'
+      };
+
+      const docRef = await battlesRef.add(b);
+      $('#battle-form').close();
+      showBattle(docRef.id);
+    }
+
+    async function joinBattle(battleId){
+      const me = currentUser();
+      const docRef = battlesRef.doc(battleId);
+      await db.runTransaction(async (tx)=>{
+        const snap = await tx.get(docRef);
+        if (!snap.exists) throw new Error('Battle missing');
+        const b = snap.data();
+        if (b.status!=='lobby' && b.status!=='countdown') return;
+        const exists = (b.players||[]).some(p=>p.uid===me.uid);
+        if (!exists && (b.players?.length||0) < b.maxPlayers){
+          b.players.push({...me, total:0, pulls:[]});
+        }
+        // If full -> start countdown in 5s
+        if (b.players.length === b.maxPlayers){
+          b.status='countdown';
+          b.countdownEndsAt = firebase.firestore.Timestamp.fromDate(new Date(Date.now()+5000));
+        }
+        tx.set(docRef, b, {merge:true});
+      });
+      showBattle(battleId);
+    }
+
+    function showBattle(battleId){
+      $('#battle-stage').classList.remove('hidden');
+      ensureStage();
+
+      // live subscribe to this battle
+      battlesRef.doc(battleId).onSnapshot(async snap=>{
+        if (!snap.exists) return;
+        const b = {id:snap.id, ...snap.data()};
+        $('#stage-status').textContent = renderStatus(b);
+
+        renderScoreboard(b.players||[]);
+
+        if (b.status==='lobby'){
+          $('#join-aside').innerHTML = `<div class="text-white/70 text-sm">Waiting for players… ${b.players?.length||0}/${b.maxPlayers}</div>`;
+        }
+
+        if (b.status==='countdown'){
+          const secs = Math.max(0, Math.ceil((b.countdownEndsAt?.toDate() - new Date())/1000));
+          $('#join-aside').innerHTML = `<div class="text-sm">Starting in <span class="font-semibold">${secs}</span>s</div>`;
+          if (secs<=0) await maybeFillBotsAndStart(b);
+        }
+
+        if (b.status==='spinning' && !window._battleLoopActive){
+          window._battleLoopActive = true;
+          await runBattleLoop(b.id); // runs until finished
+          window._battleLoopActive = false;
+        }
+      });
+    }
+
+    function renderStatus(b){
+      if (b.status==='lobby') return 'Waiting for players…';
+      if (b.status==='countdown') return 'Countdown to start…';
+      if (b.status==='spinning'){
+        const totalPulls = (b.players||[]).reduce((s,p)=> s+(p.pulls?.length||0), 0);
+        const roundsDone = Math.floor(totalPulls / (b.players?.length||1));
+        return `Round ${Math.min(roundsDone+1, b.spinCount)} of ${b.spinCount}`;
+      }
+      if (b.status==='finished') return `Winner: ${b.winner?.displayName || '—'}`;
+      return '';
+    }
+
+    async function maybeFillBotsAndStart(b){
+      const docRef = battlesRef.doc(b.id);
+      await db.runTransaction(async (tx)=>{
+        const snap = await tx.get(docRef);
+        const data = snap.data();
+        if (data.status!=='countdown') return;
+
+        // Fill with bots if needed
+        while ((data.players?.length||0) < data.maxPlayers){
+          data.players.push({ uid:'bot-'+Math.random().toString(36).slice(2,8), displayName:'Bot', isBot:true, total:0, pulls:[] });
+        }
+        data.status='spinning';
+        data.roundIndex = 0; data.turnIndex = 0; // progress markers
+        tx.set(docRef, data, {merge:true});
+      });
+    }
+
+    // --- Main loop: spin through N rounds, players 0..max-1
+    async function runBattleLoop(battleId){
+      const docRef = battlesRef.doc(battleId);
+
+      for(;;){
+        const snap = await docRef.get();
+        if (!snap.exists) return;
+        const b = {id:snap.id, ...snap.data()};
+        if (b.status!=='spinning') break;
+
+        const round = b.roundIndex || 0;
+        const turn = b.turnIndex || 0;
+        const players = b.players||[];
+        const packs = b.packs||[];
+        const player = players[turn];
+
+        // Choose pack for this round (cycle through selected)
+        const pack = packs[(round) % packs.length];
+
+        // Load full prize list for spinner (from cached demo or TODO: real data)
+        const all = await fetchAvailablePacks();
+        const full = all.find(x=>x.id===pack.id) || pack;
+        setStageItems(full.prizes);
+
+        // Deterministic index (replace with your server/client seed values)
+        const index = getWinningIndex(full, 'serverSeed', player.uid, round+'-'+turn);
+
+        highlightTurn(turn);
+
+        // Spin
+        await new Promise(resolve=>{
+          PackOpener.spinToIndex(index, {
+            durationMs: 1600,
+            nearMiss: true,
+            onReveal: ()=> resolve()
+          });
+        });
+
+        // Update Firestore with the pull + totals + advance turn
+        await db.runTransaction(async (tx)=>{
+          const s = await tx.get(docRef);
+          const d = s.data(); if (!d || d.status!=='spinning') return;
+
+          const P = d.players[turn];
+          const prize = full.prizes[index];
+          const pull = { round, packId: full.id, prizeId: prize.id, value: prize.value, index, at: firebase.firestore.FieldValue.serverTimestamp() };
+          P.pulls = (P.pulls||[]).concat([pull]);
+          P.total = (P.total||0) + (prize.value||0);
+          d.players[turn] = P;
+
+          // Advance turn/round
+          let nextTurn = (turn + 1) % d.players.length;
+          let nextRound = round;
+          if (nextTurn === 0) nextRound++;
+
+          if (nextRound >= d.spinCount){
+            // Finish: compute winner
+            const byTotal = [...d.players].sort((a,b)=> (b.total||0)-(a.total||0));
+            const top = byTotal[0]; // TODO tie-breaker by highest pull then earliest join
+            d.winner = { uid: top.uid, displayName: top.displayName, total: top.total };
+            d.status = 'finished';
+            d.finishedAt = firebase.firestore.FieldValue.serverTimestamp();
+          }else{
+            d.roundIndex = nextRound;
+            d.turnIndex = nextTurn;
+          }
+          tx.set(docRef, d, {merge:true});
+        });
+
+        await sleep(200); // tiny pacing between turns
+      }
+    }
+
+    // --- Rewatch
+    async function openRewatch(id){
+      const snap = await battlesRef.doc(id).get();
+      if (!snap.exists) return;
+      const b = {id:snap.id, ...snap.data()};
+      const all = await fetchAvailablePacks();
+      const reel = $('#rewatch-reel');
+      if (!reel._ready){ PackOpener.init({ root: reel, items: [] }); reel._ready = true; }
+
+      $('#rewatch-modal').showModal();
+      const pulls = (b.players||[]).flatMap(p=> p.pulls||[]).sort((a,b)=> (a.round??0)-(b.round??0));
+
+      // build a quick sequence of {pack, index}
+      const seq = pulls.map(pl=>{
+        const pack = all.find(x=>x.id===pl.packId);
+        return { pack, index: pl.index };
+      });
+
+      let i = 0;
+      $('#rewatch-play').onclick = async (e)=> {
+        e.preventDefault();
+        for (; i<seq.length; i++){
+          const step = seq[i];
+          PackOpener.setItems(step.pack.prizes);
+          await new Promise(r=> PackOpener.spinToIndex(step.index, {durationMs: 900, nearMiss:false, onReveal:r}));
+          $('#rewatch-progress').value = i+1;
+          await sleep(150);
+        }
+      };
+      $('#rewatch-progress').max = seq.length;
+      $('#rewatch-progress').value = 0;
+    }
+
+    // --- Wire up UI
+    window.addEventListener('DOMContentLoaded', ()=>{
+      subscribeLists();
+      $('#create-battle-btn').onclick = openCreateModal;
+      $('#create-lobby').onclick = (e)=>{ e.preventDefault(); createLobby(); };
+      // Clicking outside dialog to close (optional)
+      ['battle-form','rewatch-modal'].forEach(id=>{
+        const d = document.getElementById(id);
+        d?.addEventListener('click',(e)=>{ if(e.target===d) d.close(); });
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Box Battles page using Firebase compat SDK and PackOpener spinner
- allow creating lobbies, filling with bots, spinning rounds, and rewatching past battles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5210bfc888320abe320de7eec3194