### PR TITLE
Add Box Battles page with Firebase and spinner integration

### DIFF
--- a/box-battles.html
+++ b/box-battles.html
@@ -677,6 +677,7 @@
     // --- Round-robin engine
     async function runBattleLoop(battleId) {
       const docRef = battlesRef.doc(battleId);
+      const packCache = await fetchAvailablePacks();
 
       for (;;) {
         const snap = await docRef.get();
@@ -692,8 +693,7 @@
 
         // Choose pack for this round
         const packMeta = packs[round];
-        const all = await fetchAvailablePacks();
-        const full = all.find(x => x.id === packMeta.id) || packMeta;
+        const full = packCache.find(x => x.id === packMeta.id) || packMeta;
 
         // Prepare reel for this turn
         setStageItems(full.prizes);
@@ -708,6 +708,8 @@
         });
 
         // Commit pull + advance pointers (transaction)
+        let grantUid = null;
+        let winnerPlayer = null;
         await firestore.runTransaction(async tx => {
           const s = await tx.get(docRef);
           const d = s.data(); if (!d || d.status !== 'spinning') return;
@@ -745,6 +747,11 @@
             d.winner = { uid: top.uid, displayName: top.displayName, total: top.total };
             d.status = 'finished';
             d.finishedAt = firebase.firestore.FieldValue.serverTimestamp();
+            if (!top.isBot && !d.inventoryGranted) {
+              d.inventoryGranted = true;
+              grantUid = top.uid;
+              winnerPlayer = top;
+            }
           } else {
             d.turnIndex = nextTurn;
             d.roundIndex = nextRound;
@@ -752,6 +759,24 @@
 
           tx.set(docRef, d, { merge: true });
         });
+
+        if (grantUid && winnerPlayer) {
+          const pulls = winnerPlayer.pulls || [];
+          for (const pl of pulls) {
+            const pack = packCache.find(p => p.id === pl.packId);
+            const prize = pack?.prizes?.find(pr => pr.id === pl.prizeId);
+            if (prize) {
+              await firebase.database().ref(`users/${grantUid}/inventory`).push({
+                name: prize.name,
+                image: prize.image,
+                rarity: prize.rarity,
+                value: prize.value,
+                timestamp: Date.now(),
+                sold: false
+              });
+            }
+          }
+        }
 
         await sleep(150); // small pacing
       }


### PR DESCRIPTION
## Summary
- add Box Battles page using Firebase compat SDK and PackOpener spinner
- drive one shared reel per battle with round-robin turns and countdown/bot timers
- cache pack metadata and support rewatch playback on a second spinner
- expose PackOpener globally via UMD script
- record pull timestamps with `Timestamp.now()` to satisfy Firestore array constraints
- hide other sections once a battle is shown so the spinner and scoreboard are the only visible elements
- style stage and rewatch reels with center marker arrows and line to match case page
- trigger a server battle runner so matches resolve even if no players stay on the page
- require users to sign in and pay the combined pack cost to create or join battles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5210bfc888320abe320de7eec3194