### PR TITLE
Add Box Battles page with Firebase and spinner integration

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -8,6 +8,7 @@
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-database-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
   <script>
     const firebaseConfig = {
       apiKey: "AIzaSyCyRm6dWH-fAmfWy83zLTrPFVi9Ny8gyxE",
@@ -19,6 +20,7 @@
       appId: "1:22502548396:web:aac335672c21f07524d009"
     };
     firebase.initializeApp(firebaseConfig);
+    const firestore = firebase.firestore();
     const allowedAdmins = [
       "jhuxf12@outlook.com" // Add more admin emails as needed
     ];
@@ -59,6 +61,7 @@
   </nav>
 
   <main id="admin-panel" class="p-6" style="display: none;">
+    <button id="clear-battles" class="mb-6 px-4 py-2 rounded bg-red-600 hover:bg-red-500">Clear Stuck Battles</button>
     <!-- Cases Section -->
     <section id="cases-section">
       <h1 class="text-3xl font-bold mb-6">Manage Cases</h1>
@@ -941,6 +944,16 @@ document.getElementById('milestone-config-form').addEventListener('submit', e =>
     if (!isNaN(threshold)) levels.push({ threshold, reward });
   });
   firebase.database().ref('milestoneConfig').set({ badges, levels }).then(() => showToast('✅ Milestone config saved'));
+});
+
+document.getElementById('clear-battles').addEventListener('click', () => {
+  firestore.collection('battles').get().then(snap => {
+    const batch = firestore.batch();
+    snap.forEach(doc => {
+      if ((doc.data().status || '') !== 'finished') batch.delete(doc.ref);
+    });
+    return batch.commit();
+  }).then(() => showToast('✅ Battles cleared'));
 });
 
   </script>

--- a/api/run-battle.js
+++ b/api/run-battle.js
@@ -1,0 +1,171 @@
+const admin = require('firebase-admin');
+if (!admin.apps.length) admin.initializeApp();
+const db = admin.firestore();
+
+module.exports = async (req, res) => {
+  const battleId = req.query.battleId;
+  if (!battleId) {
+    res.statusCode = 400;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ error: 'battleId required' }));
+    return;
+  }
+
+  // Progress the battle to completion in the background. We don't await the
+  // runner so the HTTP request can return immediately; the event loop stays
+  // alive via the pending async work.
+  processBattle(battleId).catch(err => console.error('run-battle error', err));
+
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/json');
+  res.end(JSON.stringify({ ok: true }));
+};
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+// Progress a battle until it finishes, waiting out lobby/countdown timers and
+// spinning all rounds without requiring additional HTTP pings.
+async function processBattle(id) {
+  const ref = db.collection('battles').doc(id);
+
+  for (;;) {
+    const snap = await ref.get();
+    if (!snap.exists) return;
+    const b = snap.data();
+    const now = new Date();
+
+    if (b.status === 'lobby') {
+      const wait = b.botFillAt ? b.botFillAt.toDate() - now : 0;
+      if (wait > 0) await sleep(wait);
+      const players = b.players || [];
+      while (players.length < b.maxPlayers) {
+        players.push({ uid: 'bot-' + Math.random().toString(36).slice(2,8), displayName: 'Bot', isBot: true, total: 0, pulls: [] });
+      }
+      const countdownEndsAt = admin.firestore.Timestamp.fromDate(new Date(Date.now() + 5000));
+      await ref.set({ players, status: 'countdown', countdownEndsAt }, { merge: true });
+      continue;
+    }
+
+    if (b.status === 'countdown') {
+      const wait = b.countdownEndsAt ? b.countdownEndsAt.toDate() - now : 0;
+      if (wait > 0) await sleep(wait);
+      const players = b.players || [];
+      while (players.length < b.maxPlayers) {
+        players.push({ uid: 'bot-' + Math.random().toString(36).slice(2,8), displayName: 'Bot', isBot: true, total: 0, pulls: [] });
+      }
+      await ref.set({ players, status: 'spinning', roundIndex: 0, turnIndex: 0 }, { merge: true });
+      continue;
+    }
+
+    if (b.status === 'spinning') {
+      await runLoop(ref);
+      return;
+    }
+
+    // Finished or unknown state
+    return;
+  }
+}
+
+async function runLoop(ref) {
+  const packCache = new Map();
+  for (;;) {
+    const snap = await ref.get();
+    const data = snap.data();
+    if (!data || data.status !== 'spinning') return;
+
+    const round = data.roundIndex || 0;
+    const turn = data.turnIndex || 0;
+    const players = data.players || [];
+    const packs = data.packs || [];
+    const player = players[turn];
+    const packMeta = packs[round % packs.length];
+
+    let full = packCache.get(packMeta.id);
+    if (!full) {
+      const packDoc = await db.collection('packs').doc(packMeta.id).get();
+      full = { id: packMeta.id, prizes: packDoc.get('prizes') || [] };
+      packCache.set(packMeta.id, full);
+    }
+
+    const index = getWinningIndex(full, 'serverSeed', player.uid, `${round}-${turn}`);
+
+    let grantUid = null;
+    let allPulls = [];
+    await db.runTransaction(async tx => {
+      const s = await tx.get(ref);
+      const d = s.data();
+      if (!d || d.status !== 'spinning') return;
+
+      const P = d.players[turn];
+      const prize = full.prizes[index];
+      const pull = { round, packId: full.id, prizeId: prize.id, value: prize.value, index, at: admin.firestore.Timestamp.now() };
+      P.pulls = (P.pulls || []).concat([pull]);
+      P.total = (P.total || 0) + (prize.value || 0);
+      d.players[turn] = P;
+
+      let nextTurn = (turn + 1) % d.players.length;
+      let nextRound = round;
+      if (nextTurn === 0) nextRound++;
+
+      if (nextRound >= d.spinCount) {
+        const ranked = d.players.map((p, i) => ({
+          ...p,
+          highestPull: Math.max(0, ...(p.pulls || []).map(x => x.value || 0)),
+          joinOrder: i
+        })).sort((a, b) =>
+          (b.total || 0) - (a.total || 0) ||
+          (b.highestPull || 0) - (a.highestPull || 0) ||
+          (a.joinOrder || 0) - (b.joinOrder || 0)
+        );
+        const top = ranked[0];
+        d.winner = { uid: top.uid, displayName: top.displayName, total: top.total };
+        d.status = 'finished';
+        d.finishedAt = admin.firestore.FieldValue.serverTimestamp();
+        if (!top.isBot && !d.inventoryGranted) {
+          d.inventoryGranted = true;
+          grantUid = top.uid;
+          allPulls = (d.players || []).flatMap(pl => pl.pulls || []);
+        }
+      } else {
+        d.turnIndex = nextTurn;
+        d.roundIndex = nextRound;
+      }
+
+      tx.set(ref, d, { merge: true });
+    });
+
+    if (grantUid && allPulls.length) {
+      for (const pl of allPulls) {
+        let pack = packCache.get(pl.packId);
+        if (!pack) {
+          const doc = await db.collection('packs').doc(pl.packId).get();
+          pack = { id: pl.packId, prizes: doc.get('prizes') || [] };
+          packCache.set(pl.packId, pack);
+        }
+        const prize = pack.prizes.find(pr => pr.id === pl.prizeId);
+        if (prize) {
+          await admin.database().ref(`users/${grantUid}/inventory`).push({
+            name: prize.name,
+            image: prize.image,
+            rarity: prize.rarity,
+            value: prize.value,
+            timestamp: Date.now(),
+            sold: false
+          });
+        }
+      }
+    }
+  }
+}
+
+function getWinningIndex(pack, serverSeed, clientSeed, nonce) {
+  const str = [serverSeed, clientSeed, nonce, pack.id].join('|');
+  let h = 2166136261;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  const x = (h >>> 0) / 2 ** 32;
+  return Math.floor(x * pack.prizes.length);
+}

--- a/api/run-battle.js
+++ b/api/run-battle.js
@@ -167,5 +167,13 @@ function getWinningIndex(pack, serverSeed, clientSeed, nonce) {
     h = Math.imul(h, 16777619);
   }
   const x = (h >>> 0) / 2 ** 32;
-  return Math.floor(x * pack.prizes.length);
+  const prizes = pack.prizes || [];
+  const total = prizes.reduce((sum, p) => sum + (p.odds || 1), 0);
+  let accum = 0;
+  const target = x * total;
+  for (let i = 0; i < prizes.length; i++) {
+    accum += prizes[i].odds || 1;
+    if (target < accum) return i;
+  }
+  return prizes.length ? prizes.length - 1 : 0;
 }

--- a/box-battles.html
+++ b/box-battles.html
@@ -390,7 +390,7 @@
 
     // --- Open/My/Previous lists
     function renderBattleRow(b){
-      const live = b.status === 'spinning' ? pill('LIVE','live') : '';
+      const live = (b.status==='lobby' || b.status==='countdown') ? pill('LIVE','live') : '';
       const packs = (b.packs||[]).map(p=>`<img src="${p.image}" class="w-10 h-12 object-cover rounded-md border border-white/10"/>`).join('');
       const players = (b.players||[]).map(p=>`<div class="flex items-center gap-1">${avatar(p.displayName)}<span class="hidden md:inline text-sm">${p.displayName||'Player'}</span></div>`).join('');
       const canJoin = (b.status==='lobby' || b.status==='countdown') && (b.players?.length||0) < b.maxPlayers;
@@ -493,15 +493,15 @@
     function subscribeLists(){
       battlesRef.orderBy('createdAt','desc').limit(20).onSnapshot(snap=>{
         const me = currentUser();
-        const open = []; const mine = []; const finished = [];
+        const all = []; const mine = []; const finished = [];
         snap.forEach(doc=>{
           const b = {id:doc.id, ...doc.data()};
+          all.push(b);
           if (b.status==='finished') finished.push(b);
-          else open.push(b);
           if (me && (b.players||[]).some(p=>p.uid===me.uid)) mine.push(b);
         });
 
-        $('#battle-list').innerHTML = open.slice(0,5).map(renderBattleRow).join('') || '<div class="text-white/60">No open battles right now.</div>';
+        $('#battle-list').innerHTML = all.slice(0,5).map(renderBattleRow).join('') || '<div class="text-white/60">No battles yet.</div>';
         $('#my-battles').innerHTML = mine.slice(0,5).map(renderBattleRow).join('') || '<div class="text-white/60">You are not in any battles.</div>';
         $('#my-battles-count').textContent = me ? (mine.length ? `${mine.length}` : '') : '';
         $('#previous-battles-list').innerHTML = finished.slice(0,5).map(renderPreviousRow).join('') || '<div class="text-white/60">Nothing yet — be the first!</div>';

--- a/box-battles.html
+++ b/box-battles.html
@@ -54,14 +54,14 @@
     .pill.live{border-color:#22c55e;box-shadow:0 0 0 2px rgba(34,197,94,.2) inset}
     dialog[open]{animation:fadeIn .12s ease-out}
     @keyframes fadeIn{from{opacity:.0;transform:scale(.98)}to{opacity:1;transform:scale(1)}}
-    /* Spinner item sizing */
-    .reel-host .reel{display:flex;will-change:transform}
-    .reel-host .reel .tile{flex:0 0 132px;margin:0 6px;position:relative;background:#1f2937;border:1px solid #334155;border-radius:8px;padding:4px;color:#f1f5f9}
-    .reel-host .reel .tile img{width:96px;height:128px;object-fit:cover;border-radius:4px}
-    .reel-host .reel .tile-info{position:absolute;left:0;right:0;bottom:0;background:rgba(0,0,0,.6);font-size:.625rem;padding:2px 4px;border-bottom-left-radius:8px;border-bottom-right-radius:8px;text-align:center}
-    .reel-host .reel .tile-info .name{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;font-size:.625rem}
+    /* Spinner styling – match case.html */
+    .reel-host .reel{display:flex;will-change:transform;padding:1rem 0}
+    .reel-host .reel .tile{flex:0 0 170px;margin:0 10px;position:relative;background:#2a2f3a;border:1px solid #3a4050;border-radius:12px;padding:8px;box-shadow:0 2px 4px rgba(0,0,0,0.5);color:#f1f5f9;transition:transform .2s,box-shadow .2s}
+    .reel-host .reel .tile img{width:150px;height:210px;object-fit:cover;border-radius:8px}
+    .reel-host .reel .tile-info{position:absolute;left:0;right:0;bottom:0;background:rgba(0,0,0,.6);font-size:.75rem;padding:2px 4px;border-bottom-left-radius:12px;border-bottom-right-radius:12px}
+    .reel-host .reel .tile-info .name{white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
     .reel-host .reel .tile-info .price{margin-top:2px;display:flex;align-items:center;justify-content:center;gap:2px;color:#fbbf24}
-    .reel-host .reel .tile-info .price img{width:.5rem;height:.5rem}
+    .reel-host .reel .tile-info .price img{width:.6rem;height:.6rem}
   </style>
 </head>
 <body class="min-h-screen bg-[#0b0e19] text-white selection:bg-indigo-500/40">
@@ -74,7 +74,7 @@
     <section id="battle-stage" class="hidden bg-[#0f1220] border border-white/10 rounded-2xl p-4">
       <div class="flex flex-col lg:flex-row gap-6">
         <!-- Reel -->
-        <div class="reel-host relative grow rounded-xl border border-white/10 bg-black/20 p-3 overflow-x-auto">
+        <div class="reel-host relative grow rounded-xl border border-white/10 bg-black/20 p-3">
           <div id="stage-reel" class="reel h-40 md:h-48"></div>
           <div class="center-marker z-10">
             <span class="marker-arrow top"></span>

--- a/box-battles.html
+++ b/box-battles.html
@@ -82,14 +82,15 @@
       <div class="flex flex-col lg:flex-row gap-6">
         <!-- Reel -->
         <div class="reel-host relative grow rounded-xl border border-white/10 bg-black/20 p-3">
-          <div id="stage-reel" class="reel h-40 md:h-48 flex items-center"></div>
-          <div class="center-marker z-10">
+          <div id="stage-reel" class="reel h-40 md:h-48 flex items-center z-0"></div>
+          <div id="pack-preview" class="absolute inset-0 flex items-center justify-center gap-2 z-10 transition-opacity duration-500"></div>
+          <div class="center-marker z-20">
             <span class="marker-arrow top"></span>
             <span class="marker-line"></span>
             <span class="marker-arrow bottom"></span>
           </div>
         </div>
-
+        
         <!-- Scoreboard -->
         <div class="w-full lg:w-80">
           <h3 class="text-base font-semibold mb-2">Scoreboard</h3>
@@ -466,6 +467,18 @@
       $('#stage-scoreboard').innerHTML = html;
     }
 
+    function renderPackPreview(packs) {
+      const overlay = $('#pack-preview');
+      overlay.innerHTML = packs.map(p => `<img src="${p.image}" alt="${p.name}" class="w-16 h-20 object-cover rounded-md border border-white/10"/>`).join('');
+      overlay.classList.remove('opacity-0','pointer-events-none');
+    }
+
+    function hidePackPreview() {
+      const overlay = $('#pack-preview');
+      overlay.classList.add('opacity-0','pointer-events-none');
+      setTimeout(() => { overlay.innerHTML = ''; }, 500);
+    }
+
     function startCountdownTimer(b) {
       clearInterval(countdownInterval);
       function tick() {
@@ -629,9 +642,20 @@
 
         renderScoreboard(b.players || [], b.winner?.uid);
 
-        if (b.status === 'lobby') startBotTimer(b);
-        else if (b.status === 'countdown') startCountdownTimer(b);
-        else { clearInterval(botInterval); clearInterval(countdownInterval); $('#join-aside').innerHTML = ''; }
+        if (b.status === 'lobby') {
+          renderPackPreview(b.packs || []);
+          startBotTimer(b);
+        }
+        else if (b.status === 'countdown') {
+          renderPackPreview(b.packs || []);
+          startCountdownTimer(b);
+        }
+        else {
+          hidePackPreview();
+          clearInterval(botInterval);
+          clearInterval(countdownInterval);
+          $('#join-aside').innerHTML = '';
+        }
 
         if (b.status === 'spinning' && !window._battleLoopActive) {
           window._battleLoopActive = true;

--- a/box-battles.html
+++ b/box-battles.html
@@ -783,7 +783,7 @@
           }
         }
 
-        await sleep(500); // small pacing
+        await sleep(1000); // expanded pacing between spins
       }
     }
 

--- a/box-battles.html
+++ b/box-battles.html
@@ -448,9 +448,9 @@
         el.classList.toggle('ring-indigo-500/50', i === idx);
       });
     }
-    function renderScoreboard(players) {
+    function renderScoreboard(players, winnerUid) {
       const html = players.map(p => `
-        <div class="player rounded-xl border border-white/10 bg-white/5 p-3 flex items-center justify-between">
+        <div class="player rounded-xl border border-white/10 bg-white/5 p-3 flex items-center justify-between ${p.uid===winnerUid ? 'ring-2 ring-yellow-400/80' : ''}">
           <div class="flex items-center gap-2">
             <div class="w-8 h-8 rounded-full bg-white/10 grid place-items-center text-sm font-semibold">
               ${(p.displayName||'U').slice(0,1).toUpperCase()}
@@ -627,7 +627,7 @@
         if (b.status === 'finished') activeBattleId = null;
         $('#stage-status').textContent = renderStatus(b);
 
-        renderScoreboard(b.players || []);
+        renderScoreboard(b.players || [], b.winner?.uid);
 
         if (b.status === 'lobby') startBotTimer(b);
         else if (b.status === 'countdown') startCountdownTimer(b);
@@ -647,7 +647,7 @@
       if (b.status==='spinning'){
         return `Round ${(b.roundIndex||0)+1} of ${b.spinCount}`;
       }
-      if (b.status==='finished') return `Winner: ${b.winner?.displayName || '—'}`;
+      if (b.status==='finished') return `${b.winner?.displayName || ''}`;
       return '';
     }
 

--- a/box-battles.html
+++ b/box-battles.html
@@ -54,14 +54,21 @@
     .pill.live{border-color:#22c55e;box-shadow:0 0 0 2px rgba(34,197,94,.2) inset}
     dialog[open]{animation:fadeIn .12s ease-out}
     @keyframes fadeIn{from{opacity:.0;transform:scale(.98)}to{opacity:1;transform:scale(1)}}
-    /* Spinner styling – match case.html */
+    /* Spinner styling – scaled down for Box Battles */
     .reel-host .reel{display:flex;will-change:transform;padding:1rem 0}
-    .reel-host .reel .tile{flex:0 0 170px;margin:0 10px;position:relative;background:#2a2f3a;border:1px solid #3a4050;border-radius:12px;padding:8px;box-shadow:0 2px 4px rgba(0,0,0,0.5);color:#f1f5f9;transition:transform .2s,box-shadow .2s}
-    .reel-host .reel .tile img{width:150px;height:210px;object-fit:cover;border-radius:8px}
-    .reel-host .reel .tile-info{position:absolute;left:0;right:0;bottom:0;background:rgba(0,0,0,.6);font-size:.75rem;padding:2px 4px;border-bottom-left-radius:12px;border-bottom-right-radius:12px}
+    .reel-host .reel .tile{flex:0 0 110px;margin:0 6px;position:relative;background:#2a2f3a;border:1px solid #3a4050;border-radius:12px;padding:4px;box-shadow:0 2px 4px rgba(0,0,0,0.5);color:#f1f5f9;transition:transform .2s,box-shadow .2s}
+    .reel-host .reel .tile img{width:100px;height:140px;object-fit:cover;border-radius:8px}
+    .reel-host .reel .tile-info{position:absolute;left:0;right:0;bottom:0;background:rgba(0,0,0,.6);font-size:.7rem;padding:2px 4px;border-bottom-left-radius:12px;border-bottom-right-radius:12px}
     .reel-host .reel .tile-info .name{white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
     .reel-host .reel .tile-info .price{margin-top:2px;display:flex;align-items:center;justify-content:center;gap:2px;color:#fbbf24}
-    .reel-host .reel .tile-info .price img{width:.6rem;height:.6rem}
+    .reel-host .reel .tile-info .price img{width:.55rem;height:.55rem}
+    .reel-host .reel .tile.win{box-shadow:0 0 0 3px var(--win-color,#FFD36E);border-color:var(--win-color,#FFD36E);animation:flash .6s}
+    @keyframes flash{0%,100%{filter:brightness(1)}50%{filter:brightness(1.8)}}
+    .reel-host .reel .tile.rarity-common{border-color:#b6bdc9}
+    .reel-host .reel .tile.rarity-uncommon{border-color:#8FE3C9}
+    .reel-host .reel .tile.rarity-rare{border-color:#A6C8FF}
+    .reel-host .reel .tile.rarity-ultra,.reel-host .reel .tile.rarity-ultrarare{border-color:#C9A7FF}
+    .reel-host .reel .tile.rarity-legendary{border-color:#FFD36E}
   </style>
 </head>
 <body class="min-h-screen bg-[#0b0e19] text-white selection:bg-indigo-500/40">
@@ -75,7 +82,7 @@
       <div class="flex flex-col lg:flex-row gap-6">
         <!-- Reel -->
         <div class="reel-host relative grow rounded-xl border border-white/10 bg-black/20 p-3">
-          <div id="stage-reel" class="reel h-40 md:h-48"></div>
+          <div id="stage-reel" class="reel h-40 md:h-48 flex items-center"></div>
           <div class="center-marker z-10">
             <span class="marker-arrow top"></span>
             <span class="marker-line"></span>
@@ -184,7 +191,7 @@
         <button class="px-2 py-1 text-white/70 hover:text-white" value="cancel">✕</button>
       </header>
       <div id="rewatch-stage" class="reel-host rounded-xl border border-white/10 bg-black/20 p-3">
-        <div id="rewatch-reel" class="reel h-40 md:h-48"></div>
+        <div id="rewatch-reel" class="reel h-40 md:h-48 flex items-center"></div>
         <div class="center-marker z-10">
           <span class="marker-arrow top"></span>
           <span class="marker-line"></span>
@@ -776,7 +783,7 @@
           }
         }
 
-        await sleep(150); // small pacing
+        await sleep(500); // small pacing
       }
     }
 

--- a/box-battles.html
+++ b/box-battles.html
@@ -279,7 +279,8 @@
               name: pv.name,
               image: pv.image,
               value: pv.value,
-              rarity: pv.rarity || pv.tier || ''
+              rarity: pv.rarity || pv.tier || '',
+              odds: pv.odds || pv.chance || pv.weight || 0
             }))
           }));
         }
@@ -305,7 +306,15 @@
         h = Math.imul(h, 16777619);
       }
       const x = (h>>>0) / 2**32;
-      return Math.floor(x * pack.prizes.length);
+      const prizes = pack.prizes || [];
+      const total = prizes.reduce((s,p)=> s + (p.odds || 1), 0);
+      let accum = 0;
+      const target = x * total;
+      for (let i=0;i<prizes.length;i++){
+        accum += prizes[i].odds || 1;
+        if (target < accum) return i;
+      }
+      return prizes.length ? prizes.length - 1 : 0;
     };
     const getWinningIndex = window.getWinningIndex;
 

--- a/box-battles.html
+++ b/box-battles.html
@@ -1,0 +1,835 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Box Battles | Packly.gg</title>
+
+  <!-- Tailwind (CDN) -->
+  <script src="https://cdn.tailwindcss.com"></script>
+
+  <!-- Firebase compat (assumes app is initialized elsewhere on the page/app) -->
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-database-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
+  <script src="scripts/firebase-config.js"></script>
+
+  <!-- Site global UI loaders (adjust paths if needed) -->
+  <script defer src="scripts/header.js"></script>
+  <script defer src="scripts/navbar.js"></script>
+  <script defer src="scripts/footer.js"></script>
+  <!-- PackOpener spinner library -->
+  <script defer src="pack-opener/spinner.js"></script>
+
+  <style>
+    /* Minimal reel host styles; rest via Tailwind */
+    .reel-host { position: relative; overflow: hidden; }
+    .center-marker {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 50%;
+      transform: translateX(-50%);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      pointer-events: none;
+    }
+    .center-marker .marker-line {
+      flex: 1;
+      width: 2px;
+      background: linear-gradient(#8b5cf6,#3b82f6);
+      box-shadow: 0 0 6px #8b5cf6;
+    }
+    .center-marker .marker-arrow {
+      width: 0;
+      height: 0;
+      border-left: 12px solid transparent;
+      border-right: 12px solid transparent;
+    }
+    .center-marker .marker-arrow.top { border-top: 12px solid #cbd5e1; }
+    .center-marker .marker-arrow.bottom { border-bottom: 12px solid #cbd5e1; }
+    .pill{border-radius:9999px;padding:.25rem .6rem;border:1px solid rgba(255,255,255,.1);font-size:.75rem}
+    .pill.live{border-color:#22c55e;box-shadow:0 0 0 2px rgba(34,197,94,.2) inset}
+    dialog[open]{animation:fadeIn .12s ease-out}
+    @keyframes fadeIn{from{opacity:.0;transform:scale(.98)}to{opacity:1;transform:scale(1)}}
+    /* Spinner item sizing */
+    .reel-host .reel{display:flex;will-change:transform}
+    .reel-host .reel .tile{flex:0 0 132px;margin:0 6px;position:relative;background:#1f2937;border:1px solid #334155;border-radius:8px;padding:4px;color:#f1f5f9}
+    .reel-host .reel .tile img{width:96px;height:128px;object-fit:cover;border-radius:4px}
+    .reel-host .reel .tile-info{position:absolute;left:0;right:0;bottom:0;background:rgba(0,0,0,.6);font-size:.625rem;padding:2px 4px;border-bottom-left-radius:8px;border-bottom-right-radius:8px;text-align:center}
+    .reel-host .reel .tile-info .name{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;font-size:.625rem}
+    .reel-host .reel .tile-info .price{margin-top:2px;display:flex;align-items:center;justify-content:center;gap:2px;color:#fbbf24}
+    .reel-host .reel .tile-info .price img{width:.5rem;height:.5rem}
+  </style>
+</head>
+<body class="min-h-screen bg-[#0b0e19] text-white selection:bg-indigo-500/40">
+  <!-- Header / Nav injected -->
+  <div id="header"></div>
+  <div id="navbar"></div>
+
+  <main class="mt-24 mx-auto max-w-6xl px-4 py-8 space-y-8">
+    <!-- Battle Stage (appears when joined/created) -->
+    <section id="battle-stage" class="hidden bg-[#0f1220] border border-white/10 rounded-2xl p-4">
+      <div class="flex flex-col lg:flex-row gap-6">
+        <!-- Reel -->
+        <div class="reel-host relative grow rounded-xl border border-white/10 bg-black/20 p-3 overflow-x-auto">
+          <div id="stage-reel" class="reel h-40 md:h-48"></div>
+          <div class="center-marker z-10">
+            <span class="marker-arrow top"></span>
+            <span class="marker-line"></span>
+            <span class="marker-arrow bottom"></span>
+          </div>
+        </div>
+
+        <!-- Scoreboard -->
+        <div class="w-full lg:w-80">
+          <h3 class="text-base font-semibold mb-2">Scoreboard</h3>
+          <div id="stage-scoreboard" class="space-y-2"></div>
+          <aside id="join-aside" class="mt-4"></aside>
+        </div>
+      </div>
+    </section>
+
+    <!-- Hero -->
+    <section class="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
+      <div>
+        <h1 class="text-3xl md:text-4xl font-extrabold tracking-tight">Box Battles</h1>
+        <p class="text-white/70 mt-1">Winner takes all. Spin across N rounds — highest total wins the cost.</p>
+        <p id="stage-status" class="text-indigo-300/80 mt-1" aria-live="polite"></p>
+      </div>
+      <div class="flex items-center gap-3">
+        <button id="create-battle-btn" class="px-5 py-2 rounded-xl bg-gradient-to-r from-indigo-500 to-blue-500 hover:from-indigo-400 hover:to-blue-400 shadow-lg shadow-indigo-500/20">
+          + Create Battle
+        </button>
+        <a href="#previous-battles" class="text-white/75 hover:text-white underline underline-offset-4">Previous Battles</a>
+      </div>
+    </section>
+
+    <!-- Two-column lists -->
+    <section class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+      <!-- Open Battles -->
+      <div class="lg:col-span-2 bg-[#0f1220] border border-white/10 rounded-2xl p-4">
+        <header class="flex items-center justify-between mb-3">
+          <h2 class="text-lg font-semibold">Open Battles</h2>
+          <form id="filters-form" class="hidden md:flex items-center gap-2 text-sm">
+            <input class="bg-white/5 rounded-lg px-3 py-1.5 placeholder-white/40" placeholder="Min value"/>
+            <select class="bg-white/5 rounded-lg px-3 py-1.5">
+              <option>Any seats</option><option>2</option><option>3</option><option>4</option>
+            </select>
+          </form>
+        </header>
+        <div id="battle-list" class="space-y-3"></div>
+      </div>
+
+      <!-- My Battles -->
+      <aside class="bg-[#0f1220] border border-white/10 rounded-2xl p-4">
+        <header class="flex items-center justify-between mb-3">
+          <h2 class="text-lg font-semibold">My Battles</h2>
+          <span id="my-battles-count" class="text-sm text-white/60"></span>
+        </header>
+        <div id="my-battles" class="space-y-3"></div>
+      </aside>
+    </section>
+
+    <!-- Previous Battles -->
+    <section id="previous-battles" class="bg-[#0f1220] border border-white/10 rounded-2xl p-4">
+      <header class="flex items-center justify-between mb-3">
+        <h2 class="text-lg font-semibold">Previous Battles</h2>
+        <span class="text-sm text-white/60">Latest 5</span>
+      </header>
+      <div id="previous-battles-list" class="space-y-3"></div>
+    </section>
+  </main>
+
+  <!-- Footer injected -->
+  <div id="footer"></div>
+
+  <!-- Create Battle Modal -->
+  <dialog id="battle-form" class="bg-[#0f1220] text-white border border-white/10 rounded-2xl p-0 w-[min(720px,calc(100vw-2rem))]">
+    <form method="dialog" class="p-5">
+      <header class="flex items-center justify-between mb-4">
+        <h3 class="text-xl font-semibold">Create Battle</h3>
+        <button class="px-2 py-1 text-white/70 hover:text-white" value="cancel">✕</button>
+      </header>
+
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div class="md:col-span-2">
+          <label class="text-sm text-white/70">Choose Packs</label>
+          <div id="pack-grid" class="mt-2 grid grid-cols-2 sm:grid-cols-3 gap-3 overflow-y-auto max-h-72"></div>
+        </div>
+        <div class="space-y-3">
+          <input id="spin-count" type="hidden" value="0"/>
+          <div>
+            <label class="text-sm text-white/70">Players</label>
+            <select id="player-count" class="mt-1 w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2">
+              <option value="2">2</option><option value="3">3</option><option value="4" selected>4</option>
+            </select>
+          </div>
+          <div id="selection-summary" class="text-sm text-white/70">0 boxes selected — Cost: 0</div>
+          <button id="create-lobby" class="w-full mt-2 px-4 py-2 rounded-xl bg-gradient-to-r from-indigo-500 to-blue-500 hover:from-indigo-400 hover:to-blue-400">
+            Create Lobby
+          </button>
+        </div>
+      </div>
+    </form>
+  </dialog>
+
+  <!-- Rewatch Modal -->
+  <dialog id="rewatch-modal" class="bg-[#0f1220] text-white border border-white/10 rounded-2xl p-0 w-[min(840px,calc(100vw-2rem))]">
+    <form method="dialog" class="p-5">
+      <header class="flex items-center justify-between mb-4">
+        <h3 class="text-xl font-semibold">Rewatch Battle</h3>
+        <button class="px-2 py-1 text-white/70 hover:text-white" value="cancel">✕</button>
+      </header>
+      <div id="rewatch-stage" class="reel-host rounded-xl border border-white/10 bg-black/20 p-3">
+        <div id="rewatch-reel" class="reel h-40 md:h-48"></div>
+        <div class="center-marker z-10">
+          <span class="marker-arrow top"></span>
+          <span class="marker-line"></span>
+          <span class="marker-arrow bottom"></span>
+        </div>
+      </div>
+      <div class="mt-4 flex items-center gap-3">
+        <button id="rewatch-play" class="px-4 py-1.5 rounded-lg bg-white/10 hover:bg-white/15">Play</button>
+        <input id="rewatch-progress" type="range" min="0" value="0" class="w-full"/>
+      </div>
+    </form>
+  </dialog>
+
+  <!-- Page logic -->
+  <script>
+    /***** DESCRIPTION FOR CODEX *****
+     - Build a Winner-Takes-All Box Battles page that:
+       1) Lists open battles (#battle-list) and my battles (#my-battles).
+       2) Lets user create a lobby via #battle-form (choose packs; spinCount equals number selected; choose playerCount).
+       3) On join, if seats < max at countdown end, fill with bots.
+       4) Run N rounds turn-by-turn using existing PackOpener spinner:
+          - For each turn: set items to current pack prizes, compute deterministic index,
+            call PackOpener.spinToIndex(index, {durationMs: 1600, nearMiss: true, onReveal}),
+            update player's total and store pull to Firestore.
+       5) After last round, highest total wins the cost. Persist winner + pulls.
+       6) Previous Battles list shows last 20 finished; Rewatch modal replays stored indexes quickly.
+     - Keep Firebase compat. Assume firebase.initializeApp(...) already exists globally.
+     - DO NOT rename these hook IDs: 
+       #create-battle-btn #battle-form #pack-grid #spin-count #player-count
+       #battle-list #my-battles #previous-battles #rewatch-modal #rewatch-stage
+       #battle-stage #stage-reel #stage-scoreboard #stage-status #join-aside #filters-form
+     *********************************/
+
+    // --- Shortcuts
+    const firestore = firebase.firestore();
+    const battlesRef = firestore.collection('battles');
+
+    // Resolve the current user via Firebase Auth (fallback guest during development).
+    function currentUser(){
+      const u = firebase.auth().currentUser;
+      if (!u) return null;
+      return { uid: u.uid, displayName: u.displayName || (u.email||'User').split('@')[0], avatarUrl: u.photoURL || '' };
+    }
+
+    // Fetch available packs + prizes from Firestore with a Realtime Database fallback.
+    let _packsCache;
+    async function fetchAvailablePacks(){
+      if (_packsCache) return _packsCache;
+      try {
+        let packs = [];
+
+        // Primary: Firestore "packs" collection (or legacy "cases" collection)
+        let snap = await firestore.collection('packs').get();
+        let docs = snap.docs;
+        if (docs.length === 0){
+          snap = await firestore.collection('cases').get();
+          docs = snap.docs;
+        }
+        if (docs.length){
+          packs = await Promise.all(docs.map(async doc => {
+            const data = doc.data() || {};
+            const pack = { id: doc.id, name: data.name, image: data.image, price: data.price, prizes: [] };
+            if (Array.isArray(data.prizes) && data.prizes.length){
+              pack.prizes = data.prizes;
+            }else{
+              const prizesSnap = await doc.ref.collection('prizes').get();
+              pack.prizes = prizesSnap.docs.map(p=> ({ id: p.id, ...p.data() }));
+            }
+            return pack;
+          }));
+        }
+
+        // Fallback: Realtime Database "cases" node (mirrors packs.js)
+        if (!packs.length){
+          const snapRT = await firebase.database().ref('cases').once('value');
+          const data = snapRT.val() || {};
+          packs = Object.entries(data).map(([id, val]) => ({
+            id,
+            name: val.name,
+            image: val.image,
+            price: val.price,
+            prizes: Object.entries(val.prizes || {}).map(([pid, pv]) => ({
+              id: pid,
+              name: pv.name,
+              image: pv.image,
+              value: pv.value,
+              rarity: pv.rarity || pv.tier || ''
+            }))
+          }));
+        }
+
+        _packsCache = packs;
+        return packs;
+      } catch(err){
+        console.error('fetchAvailablePacks failed', err);
+        return [];
+      }
+    }
+
+    // Deterministic index helper (provably fair or fallback hash).
+    const _legacyIndexHelper = window.provablyFairIndex || window.getWinningIndex;
+    window.getWinningIndex = function(pack, serverSeed, clientSeed, nonce){
+      if (typeof _legacyIndexHelper === 'function'){
+        return _legacyIndexHelper(pack, serverSeed, clientSeed, nonce);
+      }
+      const str = [serverSeed, clientSeed, nonce, pack.id].join('|');
+      let h = 2166136261;
+      for (let i=0; i<str.length; i++){
+        h ^= str.charCodeAt(i);
+        h = Math.imul(h, 16777619);
+      }
+      const x = (h>>>0) / 2**32;
+      return Math.floor(x * pack.prizes.length);
+    };
+    const getWinningIndex = window.getWinningIndex;
+
+    // Utilities
+    const $ = (s, r=document) => r.querySelector(s);
+    const $$ = (s, r=document) => Array.from(r.querySelectorAll(s));
+    const sleep = (ms) => new Promise(r=>setTimeout(r, ms));
+    function triggerBattleRunner(id, beacon=false){
+      const url = `/api/run-battle?battleId=${encodeURIComponent(id)}`;
+      if (beacon && navigator.sendBeacon){
+        navigator.sendBeacon(url);
+      } else {
+        fetch(url).catch(()=>{});
+      }
+    }
+    let activeBattleId = null;
+    function pingRunner(){
+      if (activeBattleId) triggerBattleRunner(activeBattleId, true);
+    }
+    window.addEventListener('pagehide', pingRunner);
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'hidden') pingRunner();
+    });
+
+    // Render helpers
+    function pill(text, extra=''){ return `<span class="pill bg-white/5 ${extra}">${text}</span>`; }
+    function avatar(name){
+      const init = (name||'U')[0]?.toUpperCase() || 'U';
+      return `<div class="w-8 h-8 rounded-full bg-white/10 grid place-items-center text-sm font-semibold">${init}</div>`;
+    }
+    function rowCard(inner){ return `<div class="rounded-xl border border-white/10 bg-white/5 p-3">${inner}</div>`; }
+
+    // --- Pack chooser UI
+    async function populatePackGrid(){
+      const packs = await fetchAvailablePacks();
+      const grid = $('#pack-grid'); grid.innerHTML = '';
+      packs.forEach(p=>{
+        const card = document.createElement('div');
+        card.className = 'pack-card rounded-xl border border-white/10 bg-white/5 p-2 text-center';
+        card.dataset.id = p.id;
+        card.dataset.name = p.name;
+        card.dataset.image = p.image;
+        card.dataset.price = p.price;
+        card.innerHTML = `
+          <img src="${p.image}" class="w-16 h-20 object-cover rounded-md mx-auto"/>
+          <div class="mt-2 text-xs flex items-center justify-between">
+            <span class="truncate">${p.name}</span>
+            <span class="text-white/60">${p.price}</span>
+          </div>
+          <div class="mt-2 flex items-center justify-center gap-2">
+            <button type="button" class="dec w-6 h-6 rounded bg-white/10">-</button>
+            <input type="number" min="0" value="0" class="qty w-8 bg-transparent text-center"/>
+            <button type="button" class="inc w-6 h-6 rounded bg-white/10">+</button>
+          </div>
+        `;
+        const qty = card.querySelector('.qty');
+        card.querySelector('.inc').onclick = ()=>{ qty.value = Number(qty.value||0)+1; updatePackSummary(); };
+        card.querySelector('.dec').onclick = ()=>{ qty.value = Math.max(0, Number(qty.value||0)-1); updatePackSummary(); };
+        qty.oninput = updatePackSummary;
+        grid.appendChild(card);
+      });
+      updatePackSummary();
+    }
+
+    function gatherSelectedPacks(){
+      const out = [];
+      $$('#pack-grid .pack-card').forEach(card=>{
+        const qty = Number(card.querySelector('.qty').value||0);
+        if (qty>0){
+          const meta = { id:card.dataset.id, name:card.dataset.name, image:card.dataset.image, price:Number(card.dataset.price) };
+          for(let i=0;i<qty;i++) out.push(meta);
+        }
+      });
+      return out;
+    }
+
+    function updatePackSummary(){
+      const packs = gatherSelectedPacks();
+      const total = packs.reduce((s,p)=>s+p.price,0);
+      $('#selection-summary').textContent = `${packs.length} boxes selected — Cost: ${total}`;
+      $('#spin-count').value = packs.length;
+    }
+
+    // --- Open/My/Previous lists
+    function renderBattleRow(b){
+      const live = b.status === 'spinning' ? pill('LIVE','live') : '';
+      const packs = (b.packs||[]).map(p=>`<img src="${p.image}" class="w-10 h-12 object-cover rounded-md border border-white/10"/>`).join('');
+      const players = (b.players||[]).map(p=>`<div class="flex items-center gap-1">${avatar(p.displayName)}<span class="hidden md:inline text-sm">${p.displayName||'Player'}</span></div>`).join('');
+      const canJoin = (b.status==='lobby' || b.status==='countdown') && (b.players?.length||0) < b.maxPlayers;
+
+      return rowCard(`
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <div class="flex items-center gap-3">
+            <div class="w-10 h-10 rounded-full grid place-items-center bg-white/5">${b.spinCount}</div>
+            <div class="flex items-center gap-2">${packs}</div>
+          </div>
+          <div class="flex flex-wrap items-center gap-3">
+            ${live}
+            <div class="text-sm text-white/80">Cost: <span class="font-semibold">${b.cost||0}</span></div>
+            <div class="flex items-center gap-2">${players}</div>
+            <div class="flex items-center gap-2">
+              ${canJoin ? `<button class="join-btn px-3 py-1.5 rounded-lg bg-indigo-500/80 hover:bg-indigo-500" data-id="${b.id}">Join</button>` : ''}
+              <button class="watch-btn px-3 py-1.5 rounded-lg bg-white/10 hover:bg-white/15" data-id="${b.id}">Watch</button>
+            </div>
+          </div>
+        </div>
+      `);
+    }
+
+    function renderPreviousRow(b){
+      const winner = b.winner?.displayName || '—';
+      const packs = (b.packs||[]).slice(0,6).map(p=>`<img src="${p.image}" class="w-8 h-10 object-cover rounded-md border border-white/10"/>`).join('');
+      return rowCard(`
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <div class="flex items-center gap-3">${packs}</div>
+          <div class="text-sm text-white/70">Rounds: ${b.spinCount} • Players: ${b.maxPlayers}</div>
+          <div class="text-sm">Winner: <span class="font-semibold">${winner}</span></div>
+          <div class="text-sm text-white/80">Cost: ${b.cost||0}</div>
+          <button class="rewatch-btn px-3 py-1.5 rounded-lg bg-white/10 hover:bg-white/15" data-id="${b.id}">Rewatch</button>
+        </div>
+      `);
+    }
+
+    // --- Stage (spinner + scoreboard) — SINGLE shared spinner for live battle
+    let countdownInterval, botInterval;
+
+    function ensureStage() {
+      const host = $('#stage-reel');
+      if (!host._spinnerReady) {
+        PackOpener.init({ root: host, items: [] });
+        host._spinnerReady = true;
+      }
+    }
+    function setStageItems(prizes) {
+      ensureStage();
+      PackOpener.setItems(prizes);
+    }
+    function highlightTurn(idx) {
+      $$('#stage-scoreboard .player').forEach((el, i) => {
+        el.classList.toggle('ring-2', i === idx);
+        el.classList.toggle('ring-indigo-500/50', i === idx);
+      });
+    }
+    function renderScoreboard(players) {
+      const html = players.map(p => `
+        <div class="player rounded-xl border border-white/10 bg-white/5 p-3 flex items-center justify-between">
+          <div class="flex items-center gap-2">
+            <div class="w-8 h-8 rounded-full bg-white/10 grid place-items-center text-sm font-semibold">
+              ${(p.displayName||'U').slice(0,1).toUpperCase()}
+            </div>
+            <div>
+              <div class="font-semibold">${p.displayName || 'Player'}${p.isBot ? ' (Bot)' : ''}</div>
+              <div class="text-xs text-white/60">Total: ${p.total || 0}</div>
+            </div>
+          </div>
+          <div class="text-xs text-white/60">${(p.pulls||[]).length} pulls</div>
+        </div>
+      `).join('');
+      $('#stage-scoreboard').innerHTML = html;
+    }
+
+    function startCountdownTimer(b) {
+      clearInterval(countdownInterval);
+      function tick() {
+        const secs = Math.max(0, Math.ceil((b.countdownEndsAt?.toDate() - new Date()) / 1000));
+        $('#join-aside').innerHTML = `<div class="text-sm">Starting in <span class="font-semibold">${secs}</span>s</div>`;
+        $('#stage-status').textContent = `Starting in ${secs}s`;
+        if (secs <= 0) { clearInterval(countdownInterval); maybeFillBotsAndStart(b); }
+      }
+      tick();
+      countdownInterval = setInterval(tick, 1000);
+    }
+    function startBotTimer(b) {
+      clearInterval(botInterval);
+      if (!b.botFillAt) return;
+      function tick() {
+        const secs = Math.max(0, Math.ceil((b.botFillAt.toDate() - new Date()) / 1000));
+        $('#join-aside').innerHTML = `Waiting for players… Auto-filling in <span class="font-semibold">${secs}</span>s`;
+        if (secs <= 0) { clearInterval(botInterval); maybeFillBotsAndStart(b); }
+      }
+      tick();
+      botInterval = setInterval(tick, 1000);
+    }
+
+    // --- Live listeners
+    function subscribeLists(){
+      battlesRef.orderBy('createdAt','desc').limit(20).onSnapshot(snap=>{
+        const me = currentUser();
+        const open = []; const mine = []; const finished = [];
+        snap.forEach(doc=>{
+          const b = {id:doc.id, ...doc.data()};
+          if (b.status==='finished') finished.push(b);
+          else open.push(b);
+          if (me && (b.players||[]).some(p=>p.uid===me.uid)) mine.push(b);
+        });
+
+        $('#battle-list').innerHTML = open.slice(0,5).map(renderBattleRow).join('') || '<div class="text-white/60">No open battles right now.</div>';
+        $('#my-battles').innerHTML = mine.slice(0,5).map(renderBattleRow).join('') || '<div class="text-white/60">You are not in any battles.</div>';
+        $('#my-battles-count').textContent = me ? (mine.length ? `${mine.length}` : '') : '';
+        $('#previous-battles-list').innerHTML = finished.slice(0,5).map(renderPreviousRow).join('') || '<div class="text-white/60">Nothing yet — be the first!</div>';
+
+        // Buttons
+        $$('.join-btn').forEach(btn=> btn.onclick = ()=> joinBattle(btn.dataset.id));
+        $$('.watch-btn').forEach(btn=> btn.onclick = ()=> showBattle(btn.dataset.id));
+        $$('.rewatch-btn').forEach(btn=> btn.onclick = ()=> openRewatch(btn.dataset.id));
+      });
+    }
+
+    // --- Create / Join / Watch
+    async function openCreateModal(){
+      await populatePackGrid();
+      $('#battle-form').showModal();
+    }
+
+    async function createLobby(){
+      const me = currentUser();
+      if (!me) { alert('Please sign in to create a battle.'); return; }
+      const maxPlayers = parseInt($('#player-count').value||4);
+      const packs = gatherSelectedPacks();
+      if (!packs.length){ alert('Pick at least one pack'); return; }
+      const spinCount = packs.length;
+
+      const cost = packs.reduce((s,p)=> s + (p.price||0), 0);
+
+      // Deduct coins
+      const balanceRef = firebase.database().ref('users/' + me.uid + '/balance');
+      const { committed } = await balanceRef.transaction(bal => {
+        if ((bal||0) < cost) return; // abort
+        return (bal||0) - cost;
+      });
+      if (!committed){ alert('Insufficient balance'); return; }
+
+      const b = {
+        createdAt: firebase.firestore.FieldValue.serverTimestamp(),
+        createdBy: me,
+        packs: packs.map(p=>({id:p.id, name:p.name, image:p.image, price:p.price})),
+        spinCount, maxPlayers, mode:'winner_takes_all',
+        players: [{...me, total:0, pulls:[]}],
+        cost, status:'lobby',
+        botFillAt: firebase.firestore.Timestamp.fromDate(new Date(Date.now()+60000))
+      };
+
+      try {
+        const docRef = await battlesRef.add(b);
+        triggerBattleRunner(docRef.id);
+        $('#battle-form').close();
+        showBattle(docRef.id);
+      } catch(err){
+        await balanceRef.transaction(bal => (bal||0) + cost); // refund on failure
+        console.error(err);
+        alert('Failed to create battle');
+      }
+    }
+
+    async function joinBattle(battleId){
+      const me = currentUser();
+      if (!me) { alert('Please sign in to join battles.'); return; }
+      const docRef = battlesRef.doc(battleId);
+      const snap = await docRef.get();
+      if (!snap.exists){ alert('Battle missing'); return; }
+      const battleData = snap.data();
+      const cost = battleData.cost || (battleData.packs||[]).reduce((s,p)=> s + (p.price||0), 0);
+
+      // Deduct coins before attempting to join
+      const balanceRef = firebase.database().ref('users/' + me.uid + '/balance');
+      const { committed } = await balanceRef.transaction(bal => {
+        if ((bal||0) < cost) return; // abort
+        return (bal||0) - cost;
+      });
+      if (!committed){ alert('Insufficient balance'); return; }
+
+      let joined = false;
+      try {
+        await firestore.runTransaction(async (tx)=>{
+          const snap = await tx.get(docRef);
+          if (!snap.exists) return;
+          const b = snap.data();
+          if (b.status!=='lobby' && b.status!=='countdown') return;
+          const exists = (b.players||[]).some(p=>p.uid===me.uid);
+          if (!exists && (b.players?.length||0) < b.maxPlayers){
+            b.players.push({...me, total:0, pulls:[]});
+            joined = true;
+          }
+          if (b.players.length === b.maxPlayers){
+            b.status='countdown';
+            b.countdownEndsAt = firebase.firestore.Timestamp.fromDate(new Date(Date.now()+5000));
+            delete b.botFillAt;
+          }else{
+            b.botFillAt = firebase.firestore.Timestamp.fromDate(new Date(Date.now()+60000));
+          }
+          tx.set(docRef, b, {merge:true});
+        });
+      } catch(err){
+        await balanceRef.transaction(bal => (bal||0) + cost); // refund
+        console.error(err);
+        alert('Failed to join battle');
+        return;
+      }
+
+      if (!joined){
+        await balanceRef.transaction(bal => (bal||0) + cost); // refund
+        alert('Unable to join battle.');
+        return;
+      }
+
+      triggerBattleRunner(battleId);
+      showBattle(battleId);
+    }
+
+    function showBattle(battleId) {
+      activeBattleId = battleId;
+      $('#battle-stage').classList.remove('hidden');
+      ensureStage();
+      $('#stage-scoreboard').innerHTML = '';
+      $('#battle-stage').scrollIntoView({ behavior: 'smooth', block: 'start' });
+
+      battlesRef.doc(battleId).onSnapshot(async snap => {
+        if (!snap.exists) return;
+        const b = { id: snap.id, ...snap.data() };
+        if (b.status === 'finished') activeBattleId = null;
+        $('#stage-status').textContent = renderStatus(b);
+
+        renderScoreboard(b.players || []);
+
+        if (b.status === 'lobby') startBotTimer(b);
+        else if (b.status === 'countdown') startCountdownTimer(b);
+        else { clearInterval(botInterval); clearInterval(countdownInterval); $('#join-aside').innerHTML = ''; }
+
+        if (b.status === 'spinning' && !window._battleLoopActive) {
+          window._battleLoopActive = true;
+          await runBattleLoop(b.id);             // runs until finished
+          window._battleLoopActive = false;
+        }
+      });
+    }
+
+    function renderStatus(b){
+      if (b.status==='lobby') return 'Waiting for players…';
+      if (b.status==='countdown') return 'Countdown to start…';
+      if (b.status==='spinning'){
+        return `Round ${(b.roundIndex||0)+1} of ${b.spinCount}`;
+      }
+      if (b.status==='finished') return `Winner: ${b.winner?.displayName || '—'}`;
+      return '';
+    }
+
+      async function maybeFillBotsAndStart(b){
+        const docRef = battlesRef.doc(b.id);
+        let started = false;
+        await firestore.runTransaction(async (tx)=>{
+          const snap = await tx.get(docRef);
+          const data = snap.data();
+          if (!data) return;
+          const now = new Date();
+          if (data.status==='lobby' && data.botFillAt && data.botFillAt.toDate() <= now){
+            while ((data.players?.length||0) < data.maxPlayers){
+              data.players.push({ uid:'bot-'+Math.random().toString(36).slice(2,8), displayName:'Bot', isBot:true, total:0, pulls:[] });
+            }
+            data.status = 'countdown';
+            data.countdownEndsAt = firebase.firestore.Timestamp.fromDate(new Date(Date.now()+5000));
+          } else if (data.status==='countdown' && data.countdownEndsAt && data.countdownEndsAt.toDate() <= now){
+            while ((data.players?.length||0) < data.maxPlayers){
+              data.players.push({ uid:'bot-'+Math.random().toString(36).slice(2,8), displayName:'Bot', isBot:true, total:0, pulls:[] });
+            }
+            data.status='spinning';
+            data.roundIndex = 0;
+            started = true;
+          } else {
+            return;
+          }
+          tx.set(docRef, data, {merge:true});
+        });
+        if (started) triggerBattleRunner(b.id);
+      }
+
+    // --- Round-robin engine
+    async function runBattleLoop(battleId) {
+      const docRef = battlesRef.doc(battleId);
+      const packCache = await fetchAvailablePacks();
+
+      for (;;) {
+        const snap = await docRef.get();
+        if (!snap.exists) return;
+        const b = { id: snap.id, ...snap.data() };
+        if (b.status !== 'spinning') break;
+
+        const round = b.roundIndex || 0;
+        const turn = b.turnIndex || 0;
+        const players = b.players || [];
+        const packs = b.packs || [];
+        const player = players[turn];
+
+        // Choose pack for this round
+        const packMeta = packs[round];
+        const full = packCache.find(x => x.id === packMeta.id) || packMeta;
+
+        // Prepare reel for this turn
+        setStageItems(full.prizes);
+        highlightTurn(turn);
+
+        // Deterministic index (replace seeds with your real PF setup)
+        const index = getWinningIndex(full, 'serverSeed', player.uid, `${round}-${turn}`);
+
+        // Spin
+        await new Promise(resolve => {
+          PackOpener.spinToIndex(index, { durationMs: 1600, nearMiss: true, onReveal: resolve });
+        });
+
+        // Commit pull + advance pointers (transaction)
+        let grantUid = null;
+        let allPulls = [];
+        await firestore.runTransaction(async tx => {
+          const s = await tx.get(docRef);
+          const d = s.data(); if (!d || d.status !== 'spinning') return;
+
+          const P = d.players[turn];
+          const prize = full.prizes[index];
+          const pull = {
+            round,
+            packId: full.id,
+            prizeId: prize.id,
+            value: prize.value,
+            index,
+            at: firebase.firestore.Timestamp.now()
+          };
+          P.pulls = (P.pulls || []).concat([pull]);
+          P.total = (P.total || 0) + (prize.value || 0);
+          d.players[turn] = P;
+
+          let nextTurn = (turn + 1) % d.players.length;
+          let nextRound = round;
+          if (nextTurn === 0) nextRound++;
+
+          if (nextRound >= d.spinCount) {
+            // Winner: highest total, tie-break by highest single pull, then earliest join
+            const ranked = d.players.map((p, i) => ({
+              ...p,
+              highestPull: Math.max(0, ...(p.pulls || []).map(x => x.value || 0)),
+              joinOrder: i
+            })).sort((a, b) =>
+              (b.total || 0) - (a.total || 0) ||
+              (b.highestPull || 0) - (a.highestPull || 0) ||
+              (a.joinOrder || 0) - (b.joinOrder || 0)
+            );
+            const top = ranked[0];
+            d.winner = { uid: top.uid, displayName: top.displayName, total: top.total };
+            d.status = 'finished';
+            d.finishedAt = firebase.firestore.FieldValue.serverTimestamp();
+            if (!top.isBot && !d.inventoryGranted) {
+              d.inventoryGranted = true;
+              grantUid = top.uid;
+              allPulls = (d.players || []).flatMap(pl => pl.pulls || []);
+            }
+          } else {
+            d.turnIndex = nextTurn;
+            d.roundIndex = nextRound;
+          }
+
+          tx.set(docRef, d, { merge: true });
+        });
+
+        if (grantUid && allPulls.length) {
+          for (const pl of allPulls) {
+            const pack = packCache.find(p => p.id === pl.packId);
+            const prize = pack?.prizes?.find(pr => pr.id === pl.prizeId);
+            if (prize) {
+              await firebase.database().ref(`users/${grantUid}/inventory`).push({
+                name: prize.name,
+                image: prize.image,
+                rarity: prize.rarity,
+                value: prize.value,
+                timestamp: Date.now(),
+                sold: false
+              });
+            }
+          }
+        }
+
+        await sleep(150); // small pacing
+      }
+    }
+
+    // --- Rewatch
+    async function openRewatch(id) {
+      const snap = await battlesRef.doc(id).get();
+      if (!snap.exists) return;
+      const b = { id: snap.id, ...snap.data() };
+      const all = await fetchAvailablePacks();
+
+      const reel = $('#rewatch-reel');
+      if (!reel._spinnerReady) { PackOpener.init({ root: reel, items: [] }); reel._spinnerReady = true; }
+
+      $('#rewatch-modal').showModal();
+
+      // Chronological sequence by round then join order
+      const seq = [];
+      for (let r = 0; r < (b.spinCount || 0); r++) {
+        for (let t = 0; t < (b.players || []).length; t++) {
+          const pl = (b.players[t].pulls || []).find(p => p.round === r);
+          if (pl) {
+            const pack = all.find(x => x.id === pl.packId);
+            seq.push({ pack, index: pl.index });
+          }
+        }
+      }
+
+      let i = 0;
+      $('#rewatch-play').onclick = async (e) => {
+        e.preventDefault();
+        for (; i < seq.length; i++) {
+          const step = seq[i];
+          PackOpener.setItems(step.pack.prizes);
+          await new Promise(r => PackOpener.spinToIndex(step.index, { durationMs: 900, nearMiss: false, onReveal: r }));
+          $('#rewatch-progress').value = i + 1;
+          await sleep(120);
+        }
+      };
+      $('#rewatch-progress').max = seq.length;
+      $('#rewatch-progress').value = 0;
+    }
+
+    // --- Wire up UI
+    window.addEventListener('DOMContentLoaded', ()=>{
+      subscribeLists();
+      $('#create-battle-btn').onclick = openCreateModal;
+      $('#create-lobby').onclick = (e)=>{ e.preventDefault(); createLobby(); };
+      // Clicking outside dialog to close (optional)
+      ['battle-form','rewatch-modal'].forEach(id=>{
+        const d = document.getElementById(id);
+        d?.addEventListener('click',(e)=>{ if(e.target===d) d.close(); });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/pack-opener/spinner.js
+++ b/pack-opener/spinner.js
@@ -43,13 +43,14 @@
     for (let c = 0; c < copies; c++) {
       state.items.forEach((item) => {
         const tile = document.createElement("div");
-        tile.className = "tile";
+        tile.className = `tile rarity-${item.rarity || "common"}`;
         tile.dataset.id = item.id;
         const priceHtml =
           item.value !== undefined
             ? `<div class="price">${item.value}<img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" alt="coin"/></div>`
             : "";
         tile.innerHTML = `<img src="${item.image}" alt="${item.name}"/><div class="tile-info"><div class="name">${item.name}</div>${priceHtml}</div>`;
+        tile.style.borderColor = rarityColors[item.rarity] || "#3a4050";
         frag.appendChild(tile);
       });
     }


### PR DESCRIPTION
## Summary
- rename battle "pot" displays and fields to "cost" and adjust layout spacing
- add an admin utility to clear unfinished battles from Firestore
- move the battle stage to the top of the page and reveal it on demand without hiding lists

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5210bfc888320abe320de7eec3194