### PR TITLE
Center and polish hero spinner cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,6 @@
             padding: 1rem 0;
             display: flex;
             align-items: center;
-            justify-content: center;
         }
 
         .reel {
@@ -82,7 +81,6 @@
             will-change: transform;
             padding: 0;
             align-items: center;
-            justify-content: center;
         }
 
         .tile {

--- a/index.html
+++ b/index.html
@@ -72,13 +72,17 @@
             border-radius: 12px;
             background: linear-gradient(180deg,#1e2333,#151820);
             padding: 1rem 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
         }
 
         .reel {
             display: flex;
             will-change: transform;
-            padding: 1rem 0;
+            padding: 0;
             align-items: center;
+            justify-content: center;
         }
 
         .tile {
@@ -123,6 +127,12 @@
             border-bottom-left-radius: 12px;
             border-bottom-right-radius: 12px;
             text-align: center;
+        }
+
+        .tile-info .name {
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
 
         .tile-info .price {

--- a/pack-opener/spinner.js
+++ b/pack-opener/spinner.js
@@ -47,7 +47,7 @@
         tile.dataset.id = item.id;
         const priceHtml =
           item.value !== undefined
-            ? `<div class="price">${item.value}<img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" alt="coin"/></div>`
+            ? `<div class="price">${Number(item.value).toLocaleString()}<img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" alt="coin"/></div>`
             : "";
         tile.innerHTML = `<img src="${item.image}" alt="${item.name}"/><div class="tile-info"><div class="name">${item.name}</div>${priceHtml}</div>`;
         tile.style.borderColor = rarityColors[item.rarity] || "#3a4050";
@@ -168,7 +168,7 @@
         clone.className = "tile";
         const priceHtml =
           it.value !== undefined
-            ? `<div class="price">${it.value}<img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" alt="coin"/></div>`
+            ? `<div class="price">${Number(it.value).toLocaleString()}<img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" alt="coin"/></div>`
             : "";
         clone.innerHTML = `<img src="${it.image}" alt="${it.name}"/><div class="tile-info"><div class="name">${it.name}</div>${priceHtml}</div>`;
         tiles[midStart + index + (dir === 1 ? -1 : 1)].replaceWith(clone);
@@ -177,7 +177,7 @@
     }
 
     const container = state.root.parentElement;
-    const containerWidth = container.clientWidth;
+    const containerWidth = container.getBoundingClientRect().width;
     const centerOffset = containerWidth / 2 - state.tileWidth / 2;
 
     const targetIndex = state.items.length * 2 + index;


### PR DESCRIPTION
## Summary
- Center hero spinner cards within their container for proper alignment
- Display card values with thousands separators
- Clamp spinner card titles to a single line

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a68ef9f80c83208c9c392b52391e73