### PR TITLE
feat: unify wallet balance display and top-up

### DIFF
--- a/box-battles.html
+++ b/box-battles.html
@@ -1001,5 +1001,6 @@
       });
     });
   </script>
+  <script src="scripts/topup.js"></script>
 </body>
 </html>

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -52,6 +52,7 @@
   <script src="scripts/header.js"></script>
   <script src="scripts/navbar.js"></script>
   <script src="scripts/footer.js"></script>
+  <script src="scripts/topup.js"></script>
   <script src="scripts/leaderboard.js"></script>
 </body>
 </html>

--- a/rewards.html
+++ b/rewards.html
@@ -163,5 +163,6 @@
   <script src="scripts/header.js"></script>
   <script src="scripts/navbar.js"></script>
   <script src="scripts/footer.js"></script>
+  <script src="scripts/topup.js"></script>
 </body>
 </html>

--- a/scripts/header.js
+++ b/scripts/header.js
@@ -20,8 +20,8 @@ document.addEventListener("DOMContentLoaded", () => {
             <div class="hidden md:ml-6 md:flex md:space-x-8">
               <a href="index.html" class="border-indigo-500 text-gray-900 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"><i class="fas fa-box-open mr-1"></i>Open Packs</a>
               <a href="box-battles.html" class="border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"><i class="fas fa-sword mr-1"></i><i class="fas fa-shield-alt mr-2"></i> Battles</a>
-              <a href="leaderboard.html" class="border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Leaderboard</a>
-              <a href="marketplace.html" class="border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Marketplace</a>
+              <a href="leaderboard.html" class="border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"><i class="fas fa-trophy mr-1"></i>Leaderboard</a>
+              <a href="marketplace.html" class="border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"><i class="fas fa-store mr-1"></i>Marketplace</a>
             </div>
           </div>
           <div class="hidden md:ml-6 md:flex md:items-center">
@@ -30,10 +30,11 @@ document.addEventListener("DOMContentLoaded", () => {
               <a href="auth.html#register" class="text-sm font-medium text-indigo-600 hover:text-indigo-800">Register</a>
             </div>
             <div id="user-area" class="hidden md:flex md:items-center">
-              <div id="user-balance" class="hidden flex items-center mr-4">
-                <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="h-5 w-5 coin-icon mr-1" alt="Coins">
-                <span id="balance-amount" class="font-medium text-gray-700">0</span>
-                <button id="topup-button" class="ml-2 text-sm text-indigo-600 hover:text-indigo-800 hidden"><i class="fas fa-wallet"></i></button>
+              <div id="user-balance" class="hidden items-center gap-1 bg-gray-800 text-white px-3 py-1 rounded-full text-sm mr-4">
+                <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" alt="Coins">
+                <span id="balance-amount">0</span>
+                <span>coins</span>
+                <button id="topup-button" class="text-green-400 font-bold ml-1 hidden"><i class="fas fa-plus"></i></button>
               </div>
               <div class="ml-4 relative flex-shrink-0">
                 <button id="dropdown-toggle" class="inline-flex justify-center w-full px-4 py-2 text-sm font-medium text-gray-700 bg-white rounded-md hover:bg-gray-50 focus:outline-none">
@@ -54,10 +55,11 @@ document.addEventListener("DOMContentLoaded", () => {
             </div>
           </div>
           <div class="-mr-2 flex items-center md:hidden">
-            <div id="user-balance-mobile-header" class="hidden flex items-center mr-3">
-              <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="h-5 w-5 coin-icon mr-1" alt="Coins">
-              <span id="balance-amount-mobile" class="font-medium text-gray-700">0</span>
-              <button id="topup-button-mobile" class="ml-2 text-sm text-indigo-600 hover:text-indigo-800 hidden"><i class="fas fa-wallet"></i></button>
+            <div id="user-balance-mobile-header" class="hidden items-center gap-1 bg-gray-800 text-white px-3 py-1 rounded-full text-sm mr-3">
+              <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" alt="Coins">
+              <span id="balance-amount-mobile">0</span>
+              <span>coins</span>
+              <button id="topup-button-mobile-header" class="text-green-400 font-bold ml-1 hidden"><i class="fas fa-plus"></i></button>
             </div>
             <button id="menu-toggle" type="button" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none" aria-expanded="false">
               <span class="sr-only">Open main menu</span>
@@ -72,13 +74,17 @@ document.addEventListener("DOMContentLoaded", () => {
         <div class="pt-2 pb-3 space-y-1">
           <a href="index.html" class="block pl-3 pr-4 py-2 border-l-4 border-indigo-500 text-base font-medium text-indigo-700 bg-indigo-50"><i class="fas fa-box-open mr-2"></i>Open Packs</a>
           <a href="box-battles.html" class="block pl-3 pr-4 py-2 border-l-4 border-transparent text-base font-medium text-gray-600 hover:bg-gray-50 hover:border-gray-300"><i class="fas fa-sword mr-1"></i><i class="fas fa-shield-alt mr-2"></i> Battles</a>
-          <a href="leaderboard.html" class="block pl-3 pr-4 py-2 border-l-4 border-transparent text-base font-medium text-gray-600 hover:bg-gray-50 hover:border-gray-300">Leaderboard</a>
-          <a href="marketplace.html" class="block pl-3 pr-4 py-2 border-l-4 border-transparent text-base font-medium text-gray-600 hover:bg-gray-50 hover:border-gray-300">Marketplace</a>
+          <a href="leaderboard.html" class="block pl-3 pr-4 py-2 border-l-4 border-transparent text-base font-medium text-gray-600 hover:bg-gray-50 hover:border-gray-300"><i class="fas fa-trophy mr-2"></i>Leaderboard</a>
+          <a href="marketplace.html" class="block pl-3 pr-4 py-2 border-l-4 border-transparent text-base font-medium text-gray-600 hover:bg-gray-50 hover:border-gray-300"><i class="fas fa-store mr-2"></i>Marketplace</a>
         </div>
         <div class="pt-4 pb-3 border-t border-gray-200">
-          <div class="flex items-center px-4 mb-3">
-            <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="h-5 w-5 coin-icon mr-1" alt="Coins">
-            <span id="balance-amount-mobile-dropdown" class="font-medium text-gray-700">0</span>
+          <div id="user-balance-mobile-drawer" class="hidden flex items-center justify-between px-4 mb-3">
+            <div class="flex items-center gap-1">
+              <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" alt="Coins">
+              <span id="balance-amount-mobile-dropdown">0</span>
+              <span>coins</span>
+            </div>
+            <button id="topup-button-mobile-drawer" class="text-green-400 font-bold hidden"><i class="fas fa-plus"></i></button>
           </div>
           <div class="space-y-1">
             <a href="inventory.html" class="block px-4 py-2 text-base font-medium text-gray-500 hover:bg-gray-100">Inventory</a>
@@ -92,3 +98,4 @@ document.addEventListener("DOMContentLoaded", () => {
     </nav>
   `;
 });
+

--- a/scripts/navbar.js
+++ b/scripts/navbar.js
@@ -26,8 +26,10 @@ document.addEventListener("DOMContentLoaded", () => {
     const userArea = document.getElementById("user-area");
     const balanceContainer = document.getElementById("user-balance");
     const balanceMobileHeader = document.getElementById("user-balance-mobile-header");
+    const balanceMobileDrawer = document.getElementById("user-balance-mobile-drawer");
     const topupBtn = document.getElementById("topup-button");
-    const topupMobile = document.getElementById("topup-button-mobile");
+    const topupMobileHeader = document.getElementById("topup-button-mobile-header");
+    const topupMobileDrawer = document.getElementById("topup-button-mobile-drawer");
 
     if (!usernameEl || !balanceEl) return;
 
@@ -55,8 +57,10 @@ document.addEventListener("DOMContentLoaded", () => {
         if (userArea) userArea.classList.remove("hidden");
         if (balanceContainer) balanceContainer.classList.remove("hidden");
         if (balanceMobileHeader) balanceMobileHeader.classList.remove("hidden");
+        if (balanceMobileDrawer) balanceMobileDrawer.classList.remove("hidden");
         if (topupBtn) topupBtn.classList.remove("hidden");
-        if (topupMobile) topupMobile.classList.remove("hidden");
+        if (topupMobileHeader) topupMobileHeader.classList.remove("hidden");
+        if (topupMobileDrawer) topupMobileDrawer.classList.remove("hidden");
         if (mobileRegisterBtn) mobileRegisterBtn.classList.add("hidden");
 
         if (logoutBtn) {
@@ -92,8 +96,10 @@ document.addEventListener("DOMContentLoaded", () => {
         if (userArea) userArea.classList.add("hidden");
         if (balanceContainer) balanceContainer.classList.add("hidden");
         if (balanceMobileHeader) balanceMobileHeader.classList.add("hidden");
+        if (balanceMobileDrawer) balanceMobileDrawer.classList.add("hidden");
         if (topupBtn) topupBtn.classList.add("hidden");
-        if (topupMobile) topupMobile.classList.add("hidden");
+        if (topupMobileHeader) topupMobileHeader.classList.add("hidden");
+        if (topupMobileDrawer) topupMobileDrawer.classList.add("hidden");
         if (mobileRegisterBtn) mobileRegisterBtn.classList.remove("hidden");
 
         if (logoutBtn) logoutBtn.style.display = "none";
@@ -112,14 +118,16 @@ waitForElement("#topup-button", () => {
   waitForElement("#topup-popup", () => {
     const topupPopup = document.getElementById("topup-popup");
     const topupDesktop = document.getElementById("topup-button");
-    const topupMobile = document.getElementById("topup-button-mobile");
+    const topupMobileHeader = document.getElementById("topup-button-mobile-header");
+    const topupMobileDrawer = document.getElementById("topup-button-mobile-drawer");
 
     const openTopup = () => {
       topupPopup.classList.remove("hidden");
     };
 
     if (topupDesktop) topupDesktop.addEventListener("click", openTopup);
-    if (topupMobile) topupMobile.addEventListener("click", openTopup);
+    if (topupMobileHeader) topupMobileHeader.addEventListener("click", openTopup);
+    if (topupMobileDrawer) topupMobileDrawer.addEventListener("click", openTopup);
   });
 });
   // Dropdown toggle


### PR DESCRIPTION
## Summary
- style wallet balance as a unified pill with coin, amount and top-up button in header and mobile menus
- add nav icons for leaderboard and marketplace and support mobile/desktop top-up triggers
- load top-up script on battles, leaderboard and rewards pages for site-wide functionality

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a69bb0932c83209825e1fda643e0ac