### PR TITLE
style: revamp topup popup with gradients

### DIFF
--- a/components/topup.html
+++ b/components/topup.html
@@ -1,49 +1,49 @@
 <!-- components/topup.html -->
 <div id="topup-popup" class="fixed inset-0 z-[200] hidden flex items-center justify-center bg-black/70 backdrop-blur-sm p-4">
-  <div class="relative w-full max-w-xl max-h-[90vh] overflow-y-auto rounded-xl bg-gray-900 p-4 text-white sm:p-6">
+  <div class="relative w-full max-w-xl max-h-[90vh] overflow-y-auto rounded-xl bg-gradient-to-br from-gray-900 to-gray-800 p-4 text-white shadow-xl sm:p-6">
     <button id="close-topup" class="absolute top-4 right-4 text-2xl text-white/60 hover:text-white">&times;</button>
     <h2 class="mb-2 text-center text-3xl font-bold">Add Coins</h2>
     <p class="mb-6 text-center text-sm text-gray-400">Choose a package</p>
     <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-      <form data-price-id="price_1RTtr3I76TkBIa1xiGafiRfX" class="rounded-lg border border-gray-700 bg-gray-800 p-4 text-center transition hover:border-pink-500">
+      <form data-price-id="price_1RTtr3I76TkBIa1xiGafiRfX" class="rounded-xl border border-gray-700 bg-gradient-to-br from-gray-800 to-gray-700 p-4 text-center transition transform hover:scale-105 hover:shadow-lg">
         <div class="mb-1 flex items-center justify-center gap-1 text-xl font-semibold">
           <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="h-5 w-5" alt="coin" />
           2,000
         </div>
         <div class="text-sm text-gray-400">$20.00</div>
-        <button type="submit" class="mt-3 w-full rounded-md bg-pink-600 py-2 text-sm font-medium text-white hover:bg-pink-500">Select</button>
+        <button type="submit" class="mt-3 w-full rounded-md bg-gradient-to-r from-pink-600 to-purple-600 py-2 text-sm font-medium text-white hover:from-pink-500 hover:to-purple-500">Select</button>
       </form>
-      <form data-price-id="price_1RTtwSI76TkBIa1xmcHFALFX" class="rounded-lg border border-gray-700 bg-gray-800 p-4 text-center transition hover:border-pink-500">
+      <form data-price-id="price_1RTtwSI76TkBIa1xmcHFALFX" class="rounded-xl border border-gray-700 bg-gradient-to-br from-gray-800 to-gray-700 p-4 text-center transition transform hover:scale-105 hover:shadow-lg">
         <div class="mb-1 flex items-center justify-center gap-1 text-xl font-semibold">
           <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="h-5 w-5" alt="coin" />
           3,000
         </div>
         <div class="text-sm text-gray-400">$30.00</div>
-        <button type="submit" class="mt-3 w-full rounded-md bg-pink-600 py-2 text-sm font-medium text-white hover:bg-pink-500">Select</button>
+        <button type="submit" class="mt-3 w-full rounded-md bg-gradient-to-r from-pink-600 to-purple-600 py-2 text-sm font-medium text-white hover:from-pink-500 hover:to-purple-500">Select</button>
       </form>
-      <form data-price-id="price_1RTu1cI76TkBIa1xGbcbubuY" class="rounded-lg border border-gray-700 bg-gray-800 p-4 text-center transition hover:border-pink-500">
+      <form data-price-id="price_1RTu1cI76TkBIa1xGbcbubuY" class="rounded-xl border border-gray-700 bg-gradient-to-br from-gray-800 to-gray-700 p-4 text-center transition transform hover:scale-105 hover:shadow-lg">
         <div class="mb-1 flex items-center justify-center gap-1 text-xl font-semibold">
           <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="h-5 w-5" alt="coin" />
           5,000
         </div>
         <div class="text-sm text-gray-400">$50.00</div>
-        <button type="submit" class="mt-3 w-full rounded-md bg-pink-600 py-2 text-sm font-medium text-white hover:bg-pink-500">Select</button>
+        <button type="submit" class="mt-3 w-full rounded-md bg-gradient-to-r from-pink-600 to-purple-600 py-2 text-sm font-medium text-white hover:from-pink-500 hover:to-purple-500">Select</button>
       </form>
-      <form data-price-id="price_1RTu5pI76TkBIa1xqsVfedwB" class="rounded-lg border border-gray-700 bg-gray-800 p-4 text-center transition hover:border-pink-500">
+      <form data-price-id="price_1RTu5pI76TkBIa1xqsVfedwB" class="rounded-xl border border-purple-500 bg-gradient-to-br from-purple-800 via-pink-700 to-red-700 p-4 text-center text-white transition transform hover:scale-105 hover:shadow-xl">
         <div class="mb-1 flex items-center justify-center gap-1 text-xl font-semibold">
           <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="h-5 w-5" alt="coin" />
           10,000
         </div>
-        <div class="text-sm text-gray-400">$100.00</div>
-        <button type="submit" class="mt-3 w-full rounded-md bg-pink-600 py-2 text-sm font-medium text-white hover:bg-pink-500">Select</button>
+        <div class="text-sm text-gray-200">$100.00</div>
+        <button type="submit" class="mt-3 w-full rounded-md bg-gradient-to-r from-purple-600 to-pink-600 py-2 text-sm font-medium text-white hover:from-purple-500 hover:to-pink-500">Select</button>
       </form>
-      <form data-price-id="price_1RTuAMI76TkBIa1x1mEVXL2M" class="rounded-lg border border-pink-500 bg-gray-800 p-4 text-center sm:col-span-2">
+      <form data-price-id="price_1RTuAMI76TkBIa1x1mEVXL2M" class="rounded-xl border-2 border-yellow-400 bg-gradient-to-r from-pink-600 via-yellow-500 to-purple-600 p-4 text-center sm:col-span-2 premium-glow transition transform hover:scale-105 hover:shadow-2xl">
         <div class="mb-1 flex items-center justify-center gap-1 text-xl font-semibold">
           <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="h-5 w-5" alt="coin" />
           15,000 <span class="ml-1 text-xs font-bold text-pink-300">+1,500 Bonus</span>
         </div>
-        <div class="text-sm text-gray-400">$150.00</div>
-        <button type="submit" class="mt-3 w-full rounded-md bg-pink-600 py-2 text-sm font-medium text-white hover:bg-pink-500">Select</button>
+        <div class="text-sm text-yellow-100">$150.00</div>
+        <button type="submit" class="mt-3 w-full rounded-md bg-gradient-to-r from-yellow-400 via-pink-500 to-purple-600 py-2 text-sm font-semibold text-white hover:from-yellow-300 hover:via-pink-400 hover:to-purple-500">Select</button>
       </form>
     </div>
     <div class="mt-6 flex flex-col items-center gap-1 text-xs text-gray-500">

--- a/components/topup.html
+++ b/components/topup.html
@@ -1,49 +1,53 @@
 <!-- components/topup.html -->
-<div id="topup-popup" class="fixed inset-0 z-[200] hidden flex items-center justify-center bg-black/70 backdrop-blur-sm p-4">
-  <div class="relative w-full max-w-xl max-h-[90vh] overflow-y-auto rounded-xl bg-gradient-to-br from-gray-900 to-gray-800 p-4 text-white shadow-xl sm:p-6">
-    <button id="close-topup" class="absolute top-4 right-4 text-2xl text-white/60 hover:text-white">&times;</button>
+<div id="topup-popup" class="fixed inset-0 z-[200] hidden flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
+  <div class="relative w-full max-w-xl max-h-[90vh] overflow-y-auto rounded-xl bg-white p-4 text-gray-900 shadow-xl sm:p-6">
+    <button id="close-topup" class="absolute top-4 right-4 text-2xl text-gray-500 hover:text-gray-700">&times;</button>
     <h2 class="mb-2 text-center text-3xl font-bold">Add Coins</h2>
-    <p class="mb-6 text-center text-sm text-gray-400">Choose a package</p>
+    <p class="mb-6 text-center text-sm text-gray-500">Choose a package</p>
     <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-      <form data-price-id="price_1RTtr3I76TkBIa1xiGafiRfX" class="rounded-xl border border-gray-700 bg-gradient-to-br from-gray-800 to-gray-700 p-4 text-center transition transform hover:scale-105 hover:shadow-lg">
+      <form data-price-id="price_1RTtr3I76TkBIa1xiGafiRfX" class="rounded-xl border border-gray-200 bg-white p-4 text-center transition transform hover:scale-105 hover:shadow-lg">
         <div class="mb-1 flex items-center justify-center gap-1 text-xl font-semibold">
           <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="h-5 w-5" alt="coin" />
           2,000
         </div>
-        <div class="text-sm text-gray-400">$20.00</div>
-        <button type="submit" class="mt-3 w-full rounded-md bg-gradient-to-r from-pink-600 to-purple-600 py-2 text-sm font-medium text-white hover:from-pink-500 hover:to-purple-500">Select</button>
+        <div class="text-sm text-gray-500">$20.00</div>
+        <button type="submit" class="mt-3 w-full rounded-md bg-gradient-to-r from-blue-500 to-purple-500 py-2 text-sm font-medium text-white hover:from-blue-400 hover:to-purple-400">Select</button>
       </form>
-      <form data-price-id="price_1RTtwSI76TkBIa1xmcHFALFX" class="rounded-xl border border-gray-700 bg-gradient-to-br from-gray-800 to-gray-700 p-4 text-center transition transform hover:scale-105 hover:shadow-lg">
+      <form data-price-id="price_1RTtwSI76TkBIa1xmcHFALFX" class="rounded-xl border border-gray-200 bg-white p-4 text-center transition transform hover:scale-105 hover:shadow-lg">
         <div class="mb-1 flex items-center justify-center gap-1 text-xl font-semibold">
           <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="h-5 w-5" alt="coin" />
           3,000
         </div>
-        <div class="text-sm text-gray-400">$30.00</div>
-        <button type="submit" class="mt-3 w-full rounded-md bg-gradient-to-r from-pink-600 to-purple-600 py-2 text-sm font-medium text-white hover:from-pink-500 hover:to-purple-500">Select</button>
+        <div class="text-sm text-gray-500">$30.00</div>
+        <button type="submit" class="mt-3 w-full rounded-md bg-gradient-to-r from-blue-500 to-purple-500 py-2 text-sm font-medium text-white hover:from-blue-400 hover:to-purple-400">Select</button>
       </form>
-      <form data-price-id="price_1RTu1cI76TkBIa1xGbcbubuY" class="rounded-xl border border-gray-700 bg-gradient-to-br from-gray-800 to-gray-700 p-4 text-center transition transform hover:scale-105 hover:shadow-lg">
+      <form data-price-id="price_1RTu1cI76TkBIa1xGbcbubuY" class="rounded-xl border border-gray-200 bg-white p-4 text-center transition transform hover:scale-105 hover:shadow-lg">
         <div class="mb-1 flex items-center justify-center gap-1 text-xl font-semibold">
           <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="h-5 w-5" alt="coin" />
           5,000
         </div>
-        <div class="text-sm text-gray-400">$50.00</div>
-        <button type="submit" class="mt-3 w-full rounded-md bg-gradient-to-r from-pink-600 to-purple-600 py-2 text-sm font-medium text-white hover:from-pink-500 hover:to-purple-500">Select</button>
+        <div class="text-sm text-gray-500">$50.00</div>
+        <button type="submit" class="mt-3 w-full rounded-md bg-gradient-to-r from-blue-500 to-purple-500 py-2 text-sm font-medium text-white hover:from-blue-400 hover:to-purple-400">Select</button>
       </form>
-      <form data-price-id="price_1RTu5pI76TkBIa1xqsVfedwB" class="rounded-xl border border-purple-500 bg-gradient-to-br from-purple-800 via-pink-700 to-red-700 p-4 text-center text-white transition transform hover:scale-105 hover:shadow-xl">
-        <div class="mb-1 flex items-center justify-center gap-1 text-xl font-semibold">
-          <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="h-5 w-5" alt="coin" />
-          10,000
+      <form data-price-id="price_1RTu5pI76TkBIa1xqsVfedwB" class="rounded-xl p-[1px] bg-gradient-to-r from-blue-500 to-purple-500 transition transform hover:scale-105 hover:shadow-xl">
+        <div class="rounded-xl bg-white p-4 text-center">
+          <div class="mb-1 flex items-center justify-center gap-1 text-xl font-semibold">
+            <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="h-5 w-5" alt="coin" />
+            10,000
+          </div>
+          <div class="text-sm text-gray-500">$100.00</div>
+          <button type="submit" class="mt-3 w-full rounded-md bg-gradient-to-r from-blue-500 to-purple-500 py-2 text-sm font-medium text-white hover:from-blue-400 hover:to-purple-400">Select</button>
         </div>
-        <div class="text-sm text-gray-200">$100.00</div>
-        <button type="submit" class="mt-3 w-full rounded-md bg-gradient-to-r from-purple-600 to-pink-600 py-2 text-sm font-medium text-white hover:from-purple-500 hover:to-pink-500">Select</button>
       </form>
-      <form data-price-id="price_1RTuAMI76TkBIa1x1mEVXL2M" class="rounded-xl border-2 border-yellow-400 bg-gradient-to-r from-pink-600 via-yellow-500 to-purple-600 p-4 text-center sm:col-span-2 premium-glow transition transform hover:scale-105 hover:shadow-2xl">
-        <div class="mb-1 flex items-center justify-center gap-1 text-xl font-semibold">
-          <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="h-5 w-5" alt="coin" />
-          15,000 <span class="ml-1 text-xs font-bold text-pink-300">+1,500 Bonus</span>
+      <form data-price-id="price_1RTuAMI76TkBIa1x1mEVXL2M" class="rounded-xl p-[1px] bg-gradient-to-r from-yellow-400 via-pink-500 to-purple-600 sm:col-span-2 premium-glow transition transform hover:scale-105 hover:shadow-2xl">
+        <div class="rounded-xl bg-white p-4 text-center">
+          <div class="mb-1 flex items-center justify-center gap-1 text-xl font-semibold">
+            <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="h-5 w-5" alt="coin" />
+            15,000 <span class="ml-1 text-xs font-bold text-pink-600">+1,500 Bonus</span>
+          </div>
+          <div class="text-sm text-gray-500">$150.00</div>
+          <button type="submit" class="mt-3 w-full rounded-md bg-gradient-to-r from-yellow-400 via-pink-500 to-purple-600 py-2 text-sm font-semibold text-white hover:from-yellow-300 hover:via-pink-400 hover:to-purple-500">Select</button>
         </div>
-        <div class="text-sm text-yellow-100">$150.00</div>
-        <button type="submit" class="mt-3 w-full rounded-md bg-gradient-to-r from-yellow-400 via-pink-500 to-purple-600 py-2 text-sm font-semibold text-white hover:from-yellow-300 hover:via-pink-400 hover:to-purple-500">Select</button>
       </form>
     </div>
     <div class="mt-6 flex flex-col items-center gap-1 text-xs text-gray-500">


### PR DESCRIPTION
## Summary
- restyle top-up popup with gradient background
- add gradient buttons and highlight higher tier packages with flares

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a69befd49c832098a3d00fef8b0229