### PR TITLE
Revamp pack filters and standardize coin icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,48 +260,51 @@
     <!-- Available Packs Section -->
     <div id="available-packs" class="py-12 bg-white">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="flex justify-between items-center mb-8">
-          <div>
-            <h2 class="text-2xl font-bold text-gray-900">Available Packs</h2>
-            <p class="mt-2 text-gray-600">Rip, collect, and uncover what's inside 🔥</p>
-          </div>
-          <div class="flex space-x-3">
-            <button id="filter-toggle" class="inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none"><i class="fas fa-filter mr-2"></i><span>Show Filters</span></button>
-            <button id="clear-filters" class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none"><i class="fas fa-undo mr-2"></i>Clear Filters</button>
-          </div>
-        </div>
+        
+<div class="flex flex-col sm:flex-row sm:justify-between sm:items-center mb-8">
+  <div>
+    <h2 class="text-2xl font-bold text-gray-900">Available Packs</h2>
+    <p class="mt-2 text-gray-600">Rip, collect, and uncover what's inside 🔥</p>
+  </div>
+  <div class="mt-4 sm:mt-0 flex gap-2 w-full sm:w-auto">
+    <button id="filter-toggle" class="flex-1 sm:flex-none flex items-center justify-center gap-2 px-3 py-2 rounded-md text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700"><i class="fas fa-filter"></i><span>Filters</span></button>
+    <button id="clear-filters" class="flex-1 sm:flex-none flex items-center justify-center gap-2 px-3 py-2 rounded-md text-sm font-medium text-gray-700 bg-gray-200 hover:bg-gray-300"><i class="fas fa-undo"></i><span>Clear</span></button>
+  </div>
+</div>
 
         <!-- Filter Panel -->
-        <div id="filter-panel" class="hidden sm:flex flex-wrap gap-4 mb-6 items-center bg-gray-100 p-4 rounded-lg">
-          <input id="search-box" type="text" placeholder="Search packs" class="px-3 py-2 rounded bg-gray-100 text-gray-900 placeholder-gray-500 border border-gray-300 w-48" />
-          <input id="min-price" type="number" placeholder="Min" class="px-3 py-2 rounded bg-gray-100 text-gray-900 placeholder-gray-500 border border-gray-300 w-24" />
-          <input id="max-price" type="number" placeholder="Max" class="px-3 py-2 rounded bg-gray-100 text-gray-900 placeholder-gray-500 border border-gray-300 w-24" />
-          <div class="flex items-center gap-3 px-3 py-2 rounded bg-gray-100 border border-gray-300">
-            <label for="affordable-only" class="flex items-center cursor-pointer select-none">
-              <div class="relative">
-                <input type="checkbox" id="affordable-only" class="sr-only peer">
-                <div class="w-11 h-6 bg-gray-300 rounded-full peer-checked:bg-indigo-600 transition-all duration-300"></div>
-                <div class="absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full peer-checked:translate-x-full transform transition-transform duration-300"></div>
-              </div>
-              <span class="ml-3 text-sm text-gray-700">Enough coins to buy</span>
-            </label>
-          </div>
-          <select id="sort-select" class="px-3 py-2 rounded bg-gray-100 text-gray-900 border border-gray-300">
-            <option value="default">Sorting</option>
-            <option value="asc">Ascending</option>
-            <option value="desc">Descending</option>
-            <option value="rarity">Rarity</option>
-          </select>
-        </div>
+
+<div id="filter-panel" class="hidden flex-col sm:flex sm:flex-wrap gap-4 mb-6 bg-gray-50 p-4 rounded-lg">
+  <input id="search-box" type="text" placeholder="Search packs" class="w-full sm:w-48 px-3 py-2 rounded-md border border-gray-300 text-gray-900 placeholder-gray-500" />
+  <input id="min-price" type="number" placeholder="Min" class="w-full sm:w-24 px-3 py-2 rounded-md border border-gray-300 text-gray-900 placeholder-gray-500" />
+  <input id="max-price" type="number" placeholder="Max" class="w-full sm:w-24 px-3 py-2 rounded-md border border-gray-300 text-gray-900 placeholder-gray-500" />
+  <div class="flex items-center gap-3 px-3 py-2 rounded-md border border-gray-300 bg-white w-full sm:w-auto">
+    <label for="affordable-only" class="flex items-center cursor-pointer select-none">
+      <div class="relative">
+        <input type="checkbox" id="affordable-only" class="sr-only peer">
+        <div class="w-11 h-6 bg-gray-300 rounded-full peer-checked:bg-indigo-600 transition-all duration-300"></div>
+        <div class="absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full peer-checked:translate-x-full transform transition-transform duration-300"></div>
+      </div>
+      <span class="ml-3 text-sm text-gray-700">Enough coins to buy</span>
+    </label>
+  </div>
+  <select id="sort-select" class="w-full sm:w-auto px-3 py-2 rounded-md border border-gray-300 text-gray-900">
+    <option value="default">Sorting</option>
+    <option value="asc">Ascending</option>
+    <option value="desc">Descending</option>
+    <option value="rarity">Rarity</option>
+  </select>
+</div>
 
         <!-- Category Tabs -->
-        <div id="category-tabs" class="flex flex-wrap justify-center gap-2 mb-6">
-          <button data-category="all" class="category-tab active inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-indigo-100 text-indigo-800"><i class="fas fa-layer-group mr-1"></i>All</button>
-          <button data-category="new" class="category-tab inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-800"><i class="fas fa-star mr-1"></i>New</button>
-          <button data-category="featured" class="category-tab inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-800"><i class="fas fa-fire mr-1"></i>Featured</button>
-          <button data-category="starter" class="category-tab inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-800"><i class="fas fa-seedling mr-1"></i>Starter</button>
-          <button data-category="other" class="category-tab inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-800"><i class="fas fa-ellipsis-h mr-1"></i>Other</button>
-        </div>
+
+<div id="category-tabs" class="flex overflow-x-auto sm:flex-wrap gap-2 mb-6">
+  <button data-category="all" class="category-tab active"><i class="fas fa-layer-group"></i><span class="tab-label">All</span></button>
+  <button data-category="new" class="category-tab"><i class="fas fa-star"></i><span class="tab-label">New</span></button>
+  <button data-category="featured" class="category-tab"><i class="fas fa-fire"></i><span class="tab-label">Featured</span></button>
+  <button data-category="starter" class="category-tab"><i class="fas fa-seedling"></i><span class="tab-label">Starter</span></button>
+  <button data-category="other" class="category-tab"><i class="fas fa-ellipsis-h"></i><span class="tab-label">Other</span></button>
+</div>
 
         <!-- Cases Containers -->
         <div id="cases-carousel" class="flex space-x-4 overflow-x-auto sm:hidden pb-4"></div>

--- a/scripts/filters.js
+++ b/scripts/filters.js
@@ -13,9 +13,9 @@ export function setupFilters(cases, renderFn, getUserBalanceFn) {
   const inputs = [searchInput, minInput, maxInput, sortSelect];
   inputs.forEach(input => {
     if (!input) return;
-    input.style.border = "1px solid #4b5563";
-    input.style.backgroundColor = "#1f2937";
-    input.style.color = "#ffffff";
+    input.style.border = "1px solid #d1d5db";
+    input.style.backgroundColor = "#ffffff";
+    input.style.color = "#374151";
     input.style.padding = "0.5rem";
     input.style.borderRadius = "0.5rem";
     input.style.transition = "all 0.3s ease";
@@ -31,25 +31,18 @@ export function setupFilters(cases, renderFn, getUserBalanceFn) {
   });
 
   if (clearButton) {
-    clearButton.style.color = "#f87171";
-    clearButton.style.fontWeight = "bold";
-    clearButton.style.transition = "color 0.3s ease";
+    clearButton.style.backgroundColor = "#e5e7eb";
+    clearButton.style.color = "#374151";
+    clearButton.style.fontWeight = "500";
+    clearButton.style.border = "1px solid #d1d5db";
+    clearButton.style.borderRadius = "0.375rem";
+    clearButton.style.transition = "background-color 0.3s ease";
     clearButton.addEventListener("mouseenter", () => {
-      clearButton.style.color = "#fecaca";
+      clearButton.style.backgroundColor = "#d1d5db";
     });
     clearButton.addEventListener("mouseleave", () => {
-      clearButton.style.color = "#f87171";
+      clearButton.style.backgroundColor = "#e5e7eb";
     });
-  }
-
-  // Make filter container responsive
-  const filterContainer = searchInput?.closest(".flex.flex-wrap");
-  if (filterContainer) {
-    filterContainer.style.display = "flex";
-    filterContainer.style.flexWrap = "wrap";
-    filterContainer.style.gap = "0.75rem";
-    filterContainer.style.alignItems = "center";
-    filterContainer.style.justifyContent = "flex-start";
   }
 
   function getRarityValue(rarity) {

--- a/scripts/header.js
+++ b/scripts/header.js
@@ -39,7 +39,7 @@ document.addEventListener("DOMContentLoaded", () => {
             <div id="user-area" class="hidden md:flex md:items-center">
               <div id="user-balance" class="hidden coin-box text-sm mr-4">
                 <div class="balance">
-                  <img src="https://cdn-icons-png.flaticon.com/128/1490/1490837.png" class="w-4 h-4 object-contain" alt="Coins">
+                  <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" alt="Coins">
                   <span id="balance-amount" class="font-medium">0</span>
                 </div>
                 <button id="topup-button" class="hidden topup-btn">REFILL</button>
@@ -65,7 +65,7 @@ document.addEventListener("DOMContentLoaded", () => {
           <div class="-mr-2 flex items-center md:hidden">
             <div id="user-balance-mobile-header" class="hidden coin-box text-sm mr-3">
               <div class="balance">
-                <img src="https://cdn-icons-png.flaticon.com/128/1490/1490837.png" class="w-4 h-4 object-contain" alt="Coins">
+                <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" alt="Coins">
                 <span id="balance-amount-mobile" class="font-medium">0</span>
               </div>
               <button id="topup-button-mobile-header" class="hidden topup-btn">REFILL</button>
@@ -89,7 +89,7 @@ document.addEventListener("DOMContentLoaded", () => {
         <div class="pt-4 pb-3 border-t border-gray-200">
           <div id="user-balance-mobile-drawer" class="hidden coin-box text-sm mx-4 mb-3">
             <div class="balance">
-              <img src="https://cdn-icons-png.flaticon.com/128/1490/1490837.png" class="w-4 h-4 object-contain" alt="Coins">
+              <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" alt="Coins">
               <span id="balance-amount-mobile-dropdown" class="font-medium">0</span>
             </div>
             <button id="topup-button-mobile-drawer" class="hidden topup-btn">REFILL</button>

--- a/styles/main.css
+++ b/styles/main.css
@@ -993,32 +993,29 @@ html {
 }
 
 /* Category tabs */
+
 .category-tab {
-  background-color: #1f2937;
-  color: #ffffff;
-  border: 1px solid #374151;
-  padding: 0.5rem 0.25rem;
-  border-radius: 0.5rem;
-  font-size: 1rem;
-  width: 3.5rem;
-  height: 3.5rem;
-  display: flex;
-  flex-direction: column;
+  background-color: #e5e7eb;
+  color: #374151;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  gap: 0.125rem;
+  gap: 0.25rem;
+  white-space: nowrap;
   cursor: pointer;
   transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 .category-tab:hover {
-  background-color: #374151;
+  background-color: #d1d5db;
 }
 
 .category-tab.active {
-  background-color: #facc15;
-  border-color: #facc15;
-  color: #000;
+  background-color: #4f46e5;
+  color: #ffffff;
 }
 
 .category-tab i {
@@ -1026,8 +1023,7 @@ html {
 }
 
 .category-tab .tab-label {
-  font-size: 0.625rem;
-  line-height: 1;
   pointer-events: none;
 }
+
 


### PR DESCRIPTION
## Summary
- Replace header balance coin icon with site-wide coin graphic
- Redesign Available Packs filter and category buttons for a cleaner, mobile-friendly layout
- Update filter script and styles to match light theme

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7ca8f33c8320a3267bd998e714bb