### PR TITLE
Revamp Best Drops section with carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -318,56 +318,38 @@
     </div>
 
     <!-- Best Drops Section -->
-    <div class="py-12 bg-gray-50">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="lg:text-center">
-                <h2 class="text-base text-indigo-600 font-semibold tracking-wide uppercase">Best Drops</h2>
-                <p class="mt-2 text-3xl leading-8 font-extrabold tracking-tight text-gray-900 sm:text-4xl">
+    <section class="relative py-16 bg-gray-900 overflow-hidden">
+        <div class="best-drops-bg"></div>
+        <div class="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="text-center">
+                <h2 class="text-base text-indigo-400 font-semibold tracking-wide uppercase">Best Drops</h2>
+                <p class="mt-2 text-3xl leading-8 font-extrabold tracking-tight text-white sm:text-4xl">
                     Legendary pulls from our community
                 </p>
             </div>
 
-            <div class="mt-10">
-                <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-                    <!-- Drop 1 -->
-                    <div class="bg-white rounded-lg overflow-hidden shadow-md card-hover">
-                        <div class="flex p-4 items-center">
-                            <img class="w-24 h-32 object-contain" src="https://tcgplayer-cdn.tcgplayer.com/product/284302_in_1000x1000.jpg" alt="Pikachu VMAX">
-                            <img class="w-32 h-44 object-contain ml-2" src="https://firebasestorage.googleapis.com/v0/b/cases-e5b4e.firebasestorage.app/o/Pack%20Images%2FUntitled%20design%20(27).png?alt=media&token=27661ed2-182e-49d5-a635-f07d19410001" alt="Pika Pika pack">
-                        </div>
-                        <div class="p-4 border-t border-gray-200">
-                            <h3 class="text-lg font-medium text-gray-900">Pikachu VMAX (Secret)</h3>
-                            <p class="mt-1 text-sm text-gray-500">From: Pika Pika</p>
-                        </div>
-                    </div>
-                    
-                    <!-- Drop 2 -->
-                    <div class="bg-white rounded-lg overflow-hidden shadow-md card-hover">
-                        <div class="flex p-4 items-center">
-                            <img class="w-24 h-32 object-contain" src="https://tcgplayer-cdn.tcgplayer.com/product/201352_in_1000x1000.jpg" alt="Pikachu">
-                            <img class="w-32 h-44 object-contain ml-2" src="https://firebasestorage.googleapis.com/v0/b/cases-e5b4e.firebasestorage.app/o/Pack%20Images%2FUntitled%20design%20(27).png?alt=media&token=27661ed2-182e-49d5-a635-f07d19410001" alt="Pika Pika pack">
-                        </div>
-                        <div class="p-4 border-t border-gray-200">
-                            <h3 class="text-lg font-medium text-gray-900">Pikachu (Secret) SM</h3>
-                            <p class="mt-1 text-sm text-gray-500">From: Pika Pika</p>
-                        </div>
-                    </div>
-                    
-                    <!-- Drop 3 -->
-                    <div class="bg-white rounded-lg overflow-hidden shadow-md card-hover">
-                        <div class="flex p-4 items-center">
-                            <img class="w-24 h-32 object-contain" src="https://boxed.gg/_next/image?url=https%3A%2F%2Fproduct-images.tcgplayer.com%2F623594.jpg&w=640&q=75" alt="N's Reshiram">
-                            <img class="w-32 h-44 object-contain ml-2" src="https://firebasestorage.googleapis.com/v0/b/cases-e5b4e.firebasestorage.app/o/Pack%20Images%2FChatGPT_Image_Aug_10__2025__11_20_09_PM-removebg-preview.png?alt=media&token=34a17fd5-2a05-4c2c-899c-c4ac0484a152" alt="Twin Dragons pack">
-                        </div>
-                        <div class="p-4 border-t border-gray-200">
-                            <h3 class="text-lg font-medium text-gray-900">N's Reshiram</h3>
-                            <p class="mt-1 text-sm text-gray-500">From: Twin Dragons</p>
-                        </div>
-                    </div>
-                </div>
+            <!-- Filter Tabs -->
+            <div class="mt-6 flex justify-center space-x-2 text-sm">
+                <button class="filter-tab active" data-filter="liked">Most Liked</button>
+                <button class="filter-tab" data-filter="new">Newest Drops</button>
+                <button class="filter-tab" data-filter="rare">Most Rare</button>
             </div>
+
+            <!-- Carousel -->
+            <div class="mt-10 relative">
+                <button id="drops-prev" class="carousel-btn prev hidden md:flex items-center justify-center">
+                    <i class="fas fa-chevron-left"></i>
+                </button>
+                <div class="overflow-hidden">
+                    <div id="drops-container" class="flex space-x-6 transition-transform duration-500"></div>
+                </div>
+                <button id="drops-next" class="carousel-btn next hidden md:flex items-center justify-center">
+                    <i class="fas fa-chevron-right"></i>
+                </button>
+            </div>
+
         </div>
-    </div>
+    </section>
 
     <!-- Features Section -->
     <div class="py-12 bg-white">
@@ -611,6 +593,7 @@
           });
         }
     </script>
+    <script src="scripts/best-drops.js"></script>
     <script type="module" src="scripts/hot-cards.js"></script>
     <script type="module" src="scripts/auth.js"></script>
     <script type="module" src="scripts/packs.js"></script>

--- a/scripts/best-drops.js
+++ b/scripts/best-drops.js
@@ -1,0 +1,192 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const ULTRA_RARITIES = ['ultra rare', 'secret rare', 'rainbow rare', 'legendary'];
+  const fs = firebase.firestore();
+
+  const dropsData = { liked: [], new: [], rare: [] };
+  const FALLBACK_DROPS = [
+    {
+      title: 'Signed Rookie Card',
+      pack: 'Legends Rising',
+      cardImg: 'https://picsum.photos/seed/card1/200/300',
+      packImg: 'https://picsum.photos/seed/pack1/200/300',
+      packLink: 'pack-opener/?pack=Legends%20Rising',
+    },
+    {
+      title: 'Holographic Dragon',
+      pack: 'Mystic Monsters',
+      cardImg: 'https://picsum.photos/seed/card2/200/300',
+      packImg: 'https://picsum.photos/seed/pack2/200/300',
+      packLink: 'pack-opener/?pack=Mystic%20Monsters',
+    },
+    {
+      title: 'Rare Gemstone',
+      pack: 'Treasure Trove',
+      cardImg: 'https://picsum.photos/seed/card3/200/300',
+      packImg: 'https://picsum.photos/seed/pack3/200/300',
+      packLink: 'pack-opener/?pack=Treasure%20Trove',
+    },
+    {
+      title: 'Prototype Sneaker',
+      pack: 'Street Heat',
+      cardImg: 'https://picsum.photos/seed/card4/200/300',
+      packImg: 'https://picsum.photos/seed/pack4/200/300',
+      packLink: 'pack-opener/?pack=Street%20Heat',
+    },
+    {
+      title: 'Limited Art Print',
+      pack: 'Gallery Picks',
+      cardImg: 'https://picsum.photos/seed/card5/200/300',
+      packImg: 'https://picsum.photos/seed/pack5/200/300',
+      packLink: 'pack-opener/?pack=Gallery%20Picks',
+    },
+    {
+      title: 'Autographed Jersey',
+      pack: 'Hall of Fame',
+      cardImg: 'https://picsum.photos/seed/card6/200/300',
+      packImg: 'https://picsum.photos/seed/pack6/200/300',
+      packLink: 'pack-opener/?pack=Hall%20of%20Fame',
+    },
+    {
+      title: 'Vintage Comic',
+      pack: 'Retro Classics',
+      cardImg: 'https://picsum.photos/seed/card7/200/300',
+      packImg: 'https://picsum.photos/seed/pack7/200/300',
+      packLink: 'pack-opener/?pack=Retro%20Classics',
+    },
+    {
+      title: 'Mythic Creature Figurine',
+      pack: 'Arcane Vault',
+      cardImg: 'https://picsum.photos/seed/card8/200/300',
+      packImg: 'https://picsum.photos/seed/pack8/200/300',
+      packLink: 'pack-opener/?pack=Arcane%20Vault',
+    },
+    {
+      title: 'Crystal Relic',
+      pack: 'Hidden Realms',
+      cardImg: 'https://picsum.photos/seed/card9/200/300',
+      packImg: 'https://picsum.photos/seed/pack9/200/300',
+      packLink: 'pack-opener/?pack=Hidden%20Realms',
+    },
+    {
+      title: 'Golden Ticket',
+      pack: 'Factory Floor',
+      cardImg: 'https://picsum.photos/seed/card10/200/300',
+      packImg: 'https://picsum.photos/seed/pack10/200/300',
+      packLink: 'pack-opener/?pack=Factory%20Floor',
+    },
+    {
+      title: 'Fossil Fragment',
+      pack: 'Jurassic Finds',
+      cardImg: 'https://picsum.photos/seed/card11/200/300',
+      packImg: 'https://picsum.photos/seed/pack11/200/300',
+      packLink: 'pack-opener/?pack=Jurassic%20Finds',
+    },
+    {
+      title: 'Celestial Map',
+      pack: 'Star Seekers',
+      cardImg: 'https://picsum.photos/seed/card12/200/300',
+      packImg: 'https://picsum.photos/seed/pack12/200/300',
+      packLink: 'pack-opener/?pack=Star%20Seekers',
+    },
+  ];
+
+  function useFallback() {
+    const shuffled = [...FALLBACK_DROPS].sort(() => Math.random() - 0.5);
+    const sample = shuffled.slice(0, 10);
+    dropsData.liked = sample;
+    dropsData.new = sample;
+    dropsData.rare = sample;
+    render();
+  }
+  const container = document.getElementById('drops-container');
+  const prevBtn = document.getElementById('drops-prev');
+  const nextBtn = document.getElementById('drops-next');
+  const tabs = document.querySelectorAll('.filter-tab');
+
+  let currentFilter = 'liked';
+
+  function render() {
+    const items = dropsData[currentFilter] || [];
+    const display = items.slice(0, 10);
+    if (!display.length) {
+      useFallback();
+      return;
+    }
+    container.innerHTML = display
+      .map(
+        (item) => `
+      <div class="drop-card bg-white rounded-lg overflow-hidden shadow-lg min-w-full sm:min-w-[300px]">
+        <div class="flex p-4 items-center">
+          <img class="w-24 h-32 object-contain" src="${item.cardImg}" alt="${item.title}">
+          <img class="w-32 h-44 object-contain ml-2" src="${item.packImg}" alt="${item.pack}">
+        </div>
+        <div class="p-4 border-t border-gray-200">
+          <h3 class="text-lg font-medium text-gray-900">${item.title}</h3>
+          <p class="mt-1 text-sm text-gray-500">From: ${item.pack}</p>
+          <a href="${item.packLink}" class="mt-3 inline-block text-indigo-600 font-semibold hover:underline">Open Now</a>
+        </div>
+      </div>
+    `
+      )
+      .join('');
+    container.scrollLeft = 0;
+  }
+
+  function shift(dir) {
+    const width = container.clientWidth;
+    container.scrollBy({ left: dir * width, behavior: 'smooth' });
+  }
+
+  prevBtn.addEventListener('click', () => shift(-1));
+  nextBtn.addEventListener('click', () => shift(1));
+
+  tabs.forEach((tab) => {
+    tab.addEventListener('click', () => {
+      tabs.forEach((t) => t.classList.remove('active'));
+      tab.classList.add('active');
+      currentFilter = tab.dataset.filter;
+      render();
+    });
+  });
+
+  function subscribe() {
+    fs.collection('pulls')
+      .orderBy('timestamp', 'desc')
+      .limit(50)
+      .onSnapshot(
+        (snap) => {
+          const items = [];
+          snap.forEach((doc) => {
+            const data = doc.data() || {};
+            const rarity = (data.rarity || data.rarityLabel || '').toLowerCase();
+            if (!ULTRA_RARITIES.includes(rarity)) return;
+            const packName = data.pack || data.packName || '';
+            items.push({
+              title: data.title || data.cardName || '',
+              pack: packName,
+              cardImg: data.cardImg || data.cardImage || data.image || '',
+              packImg: data.packImg || data.packImage || data.caseImage || '',
+              packLink:
+                data.packLink || `pack-opener/?pack=${encodeURIComponent(packName)}`,
+            });
+          });
+          if (items.length) {
+            dropsData.liked = items;
+            dropsData.new = items;
+            dropsData.rare = items;
+            render();
+          } else {
+            useFallback();
+          }
+        },
+        (err) => {
+          console.error('Best drops listener failed', err);
+          useFallback();
+        }
+      );
+  }
+
+  useFallback();
+  subscribe();
+});
+

--- a/styles/main.css
+++ b/styles/main.css
@@ -798,6 +798,49 @@ html {
   animation: glow 2s ease-in-out infinite;
 }
 
+.best-drops-bg {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 25% 25%, rgba(139, 92, 246, 0.15), transparent 60%), radial-gradient(circle at 75% 75%, rgba(59, 130, 246, 0.15), transparent 60%);
+  animation: float-bg 12s ease-in-out infinite;
+}
+
+@keyframes float-bg {
+  0% { transform: translateY(0); }
+  50% { transform: translateY(-20px); }
+  100% { transform: translateY(0); }
+}
+
+.filter-tab {
+  padding: 0.5rem 1rem;
+  border-radius: 9999px;
+  font-weight: 500;
+  background-color: rgba(255, 255, 255, 0.1);
+  color: #e0e7ff;
+}
+
+.filter-tab.active {
+  background: linear-gradient(to right, #6366f1, #8b5cf6);
+  color: white;
+}
+
+.carousel-btn {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 9999px;
+  padding: 0.5rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+}
+
+.carousel-btn:hover {
+  background: #ffffff;
+}
+
+.carousel-btn.prev { left: -1.5rem; }
+.carousel-btn.next { right: -1.5rem; }
+
 .animate-pop {
   animation: pop 0.3s ease-out;
 }


### PR DESCRIPTION
## Summary
- Remove static submission CTA from Best Drops section
- Add Firestore-driven carousel that updates on ultra-rare pulls with an "Open Now" link
- Limit displayed drops to the latest 10 pulls
- Fix Best Drops listener to populate items and handle empty states
- Provide random fallback drops when no ultra-rare pulls are found

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac7f9a1e408320832c7fa6a125bb0a