### PR TITLE
feat: auto-rotate hot cards

### DIFF
--- a/scripts/hot-cards.js
+++ b/scripts/hot-cards.js
@@ -47,5 +47,24 @@ document.addEventListener('DOMContentLoaded', () => {
         </div>`;
       container.appendChild(cardEl);
     });
+
+    startAutoScroll();
   });
+
+  function startAutoScroll() {
+    if (container.scrollWidth <= container.clientWidth) return;
+    const card = container.querySelector('div');
+    if (!card) return;
+    const cardWidth = card.getBoundingClientRect().width;
+    const gap = 16; // matches Tailwind's space-x-4
+    const step = cardWidth + gap;
+    setInterval(() => {
+      const maxScrollLeft = container.scrollWidth - container.clientWidth;
+      if (container.scrollLeft >= maxScrollLeft) {
+        container.scrollTo({ left: 0, behavior: 'smooth' });
+      } else {
+        container.scrollBy({ left: step, behavior: 'smooth' });
+      }
+    }, 3000);
+  }
 });


### PR DESCRIPTION
## Summary
- automatically cycle through recent drop cards by scrolling the hot-cards container

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b473c6b80c8320958960f7851af05e