### PR TITLE
feat: auto-rotate hot cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,8 +251,10 @@
                 </p>
             </div>
 
-            <div class="mt-10">
-                <div id="hot-cards" class="flex space-x-4 overflow-x-auto sm:grid sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 sm:gap-6 sm:space-x-0"></div>
+            <div class="mt-10 relative">
+                <div class="pointer-events-none absolute inset-y-0 left-0 w-8 bg-gradient-to-r from-gray-50 to-transparent z-10"></div>
+                <div class="pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-gray-50 to-transparent z-10"></div>
+                <div id="hot-cards" class="flex space-x-4 overflow-x-auto sm:grid sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 sm:gap-6 sm:space-x-0 scrollbar-hide"></div>
             </div>
         </div>
     </div>

--- a/scripts/hot-cards.js
+++ b/scripts/hot-cards.js
@@ -36,6 +36,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const cardEl = document.createElement('div');
       cardEl.className = 'bg-white rounded-lg overflow-hidden shadow-md card-hover transition-all duration-300 flex-shrink-0 w-40 border-2';
       cardEl.style.borderColor = color;
+      cardEl.classList.add(`glow-${rarity}`);
       cardEl.innerHTML = `
         <img class="w-full h-48 object-contain p-4" src="${card.image}" alt="${card.name}">
         <div class="p-4">
@@ -47,5 +48,24 @@ document.addEventListener('DOMContentLoaded', () => {
         </div>`;
       container.appendChild(cardEl);
     });
+
+    startAutoScroll();
   });
+
+  function startAutoScroll() {
+    if (container.scrollWidth <= container.clientWidth) return;
+    const card = container.querySelector('div');
+    if (!card) return;
+    const cardWidth = card.getBoundingClientRect().width;
+    const gap = 16; // matches Tailwind's space-x-4
+    const step = cardWidth + gap;
+    setInterval(() => {
+      const maxScrollLeft = container.scrollWidth - container.clientWidth;
+      if (container.scrollLeft >= maxScrollLeft) {
+        container.scrollTo({ left: 0, behavior: 'smooth' });
+      } else {
+        container.scrollBy({ left: step, behavior: 'smooth' });
+      }
+    }, 3000);
+  }
 });


### PR DESCRIPTION
## Summary
- automatically cycle through recent drop cards by scrolling the hot-cards container
- add gradient edge overlays and rarity-based glow styling to hot cards

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b473c6b80c8320958960f7851af05e