### PR TITLE
Replace popup alerts with toast notifications

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -748,22 +748,22 @@ function deleteUser(uid) {
 
 function sendPasswordReset(email) {
   if (!email) {
-    alert('User has no email to reset.');
+    showToast('User has no email to reset.', 'error');
     return;
   }
   firebase.auth().sendPasswordResetEmail(email).then(() => {
     showToast('✅ Reset email sent');
-  }).catch(err => alert(err.message));
+  }).catch(err => showToast(err.message, 'error'));
 }
 firebase.auth().onAuthStateChanged(user => {
   if (!user) {
-    alert("Please log in.");
+    showToast("Please log in.", 'error');
     window.location.href = "/auth.html";
     return;
   }
 
   if (!allowedAdmins.includes(user.email)) {
-    alert("Access denied. Admins only.");
+    showToast("Access denied. Admins only.", 'error');
     window.location.href = "/";
     return;
   }
@@ -785,7 +785,7 @@ document.getElementById("marketplace-form").addEventListener("submit", async (e)
   const value = parseInt(document.getElementById("market-value").value.trim());
   const rarity = document.getElementById("market-rarity").value;
 
-  if (!name || !image || !value || !rarity) return alert("All fields are required!");
+  if (!name || !image || !value || !rarity) return showToast("All fields are required!", 'error');
 
 const form = document.getElementById("marketplace-form");
 const editingKey = form.dataset.editing;

--- a/auth.html
+++ b/auth.html
@@ -131,7 +131,7 @@ document.getElementById('send-code').addEventListener('click', () => {
   phoneNumber = formatPhoneNumber(phoneNumber);
   const e164Regex = /^\+[1-9]\d{9,14}$/;
   if (!e164Regex.test(phoneNumber)) {
-    alert('Please enter a valid phone number with country code.');
+    showToast('Please enter a valid phone number with country code.', 'error');
     return;
   }
   const sendBtn = document.getElementById('send-code');
@@ -153,10 +153,10 @@ document.getElementById('send-code').addEventListener('click', () => {
     .then(id => {
       verificationId = id;
       document.getElementById('phone-verification').classList.remove('hidden');
-      alert('Verification code sent!');
+      showToast('Verification code sent!', 'success');
     })
     .catch(error => {
-      alert('❌ ' + error.message);
+      showToast('❌ ' + error.message, 'error');
     });
 });
 
@@ -167,14 +167,14 @@ let phoneVerified = false;
 verifyBtn.addEventListener('click', async () => {
   const code = document.getElementById('verification-code').value.trim();
   if (!verificationId) {
-    alert('Please request a verification code first.');
+    showToast('Please request a verification code first.', 'error');
     return;
   }
   try {
     const credential = firebase.auth.PhoneAuthProvider.credential(verificationId, code);
     const result = await auth.signInWithCredential(credential);
     if (!result.additionalUserInfo.isNewUser) {
-      alert('This phone number is already associated with another account.');
+      showToast('This phone number is already associated with another account.', 'error');
       await auth.signOut();
       return;
     }
@@ -182,9 +182,9 @@ verifyBtn.addEventListener('click', async () => {
     verifyBtn.disabled = true;
     registerBtn.disabled = false;
     registerBtn.classList.remove('opacity-50', 'cursor-not-allowed');
-    alert('Phone verified! Please complete registration.');
+    showToast('Phone verified! Please complete registration.', 'success');
   } catch (error) {
-    alert('❌ ' + error.message);
+    showToast('❌ ' + error.message, 'error');
   }
 });
 
@@ -211,7 +211,7 @@ function toggleForms() {
 registerForm.addEventListener('submit', async e => {
   e.preventDefault();
   if (!phoneVerified) {
-    alert('Please verify your phone number first.');
+    showToast('Please verify your phone number first.', 'error');
     return;
   }
 
@@ -223,11 +223,11 @@ registerForm.addEventListener('submit', async e => {
   try {
     await auth.currentUser.verifyBeforeUpdateEmail(email);
     localStorage.setItem('pendingUser', JSON.stringify({ name, username, email, emailAlerts }));
-    alert('Verification email sent! Please check your inbox.');
+    showToast('Verification email sent! Please check your inbox.', 'success');
     await auth.signOut();
     window.location.href = 'auth.html';
   } catch (error) {
-    alert('❌ ' + error.message);
+    showToast('❌ ' + error.message, 'error');
   }
 });
 
@@ -249,20 +249,20 @@ loginForm.addEventListener('submit', e => {
         if (!auth.currentUser.emailVerified && !userData?.emailVerified) {
           try {
             await auth.currentUser.sendEmailVerification();
-            alert('Please verify your email. A verification link has been sent.');
+            showToast('Please verify your email. A verification link has been sent.', 'error');
           } catch (error) {
-            alert('❌ ' + error.message);
+            showToast('❌ ' + error.message, 'error');
           }
           await auth.signOut();
           return;
         }
-        alert('Login successful!');
+        showToast('Login successful!', 'success');
         const redirectUrl = sessionStorage.getItem('postLoginRedirect');
         sessionStorage.removeItem('postLoginRedirect');
         window.location.href = redirectUrl ? redirectUrl : 'index.html';
       })
       .catch(error => {
-        alert(error.message);
+        showToast(error.message, 'error');
       });
   });
 
@@ -273,7 +273,7 @@ auth.onAuthStateChanged(async user => {
     if (user.emailVerified) {
       const password = prompt('Please set a password for your account:');
       if (!password) {
-        alert('Password is required to complete registration.');
+        showToast('Password is required to complete registration.', 'error');
         await auth.signOut();
         return;
       }
@@ -292,18 +292,18 @@ auth.onAuthStateChanged(async user => {
           emailVerified: true
         });
         localStorage.removeItem('pendingUser');
-        alert('Registration complete! You can now log in with your email and password.');
+        showToast('Registration complete! You can now log in with your email and password.', 'success');
         await auth.signOut();
         window.location.href = 'auth.html';
       } catch (error) {
-        alert('❌ ' + error.message);
+        showToast('❌ ' + error.message, 'error');
       }
     } else {
       try {
         await auth.currentUser.verifyBeforeUpdateEmail(email);
-        alert('Please verify your email using the link sent to you. A new verification email has been sent.');
+        showToast('Please verify your email using the link sent to you. A new verification email has been sent.', 'success');
       } catch (error) {
-        alert('❌ ' + error.message);
+        showToast('❌ ' + error.message, 'error');
       }
       await auth.signOut();
     }
@@ -313,16 +313,16 @@ auth.onAuthStateChanged(async user => {
 function forgotPassword() {
   const email = document.getElementById('login-email').value;
   if (!email) {
-    alert("Please enter your email address to reset your password.");
+    showToast("Please enter your email address to reset your password.", 'error');
     return;
   }
 
   auth.sendPasswordResetEmail(email)
     .then(() => {
-      alert("✅ Password reset email sent! Please check your inbox.");
+      showToast("✅ Password reset email sent! Please check your inbox.", 'success');
     })
     .catch(error => {
-      alert("❌ " + error.message);
+      showToast("❌ " + error.message, 'error');
     });
 }
 </script>

--- a/box-battles.html
+++ b/box-battles.html
@@ -622,10 +622,10 @@
 
     async function createLobby(){
       const me = currentUser();
-      if (!me) { alert('Please sign in to create a battle.'); return; }
+      if (!me) { showToast('Please sign in to create a battle.', 'error'); return; }
       const maxPlayers = parseInt($('#player-count').value||4);
       const packs = gatherSelectedPacks();
-      if (!packs.length){ alert('Pick at least one pack'); return; }
+      if (!packs.length){ showToast('Pick at least one pack', 'error'); return; }
       const spinCount = packs.length;
 
       const cost = packs.reduce((s,p)=> s + (p.price||0), 0);
@@ -636,7 +636,7 @@
         if ((bal||0) < cost) return; // abort
         return (bal||0) - cost;
       });
-      if (!committed){ alert('Insufficient balance'); return; }
+      if (!committed){ showToast('Insufficient balance', 'error'); return; }
 
       const b = {
         createdAt: firebase.firestore.FieldValue.serverTimestamp(),
@@ -656,16 +656,16 @@
       } catch(err){
         await balanceRef.transaction(bal => (bal||0) + cost); // refund on failure
         console.error(err);
-        alert('Failed to create battle');
+        showToast('Failed to create battle', 'error');
       }
     }
 
     async function joinBattle(battleId){
       const me = currentUser();
-      if (!me) { alert('Please sign in to join battles.'); return; }
+      if (!me) { showToast('Please sign in to join battles.', 'error'); return; }
       const docRef = battlesRef.doc(battleId);
       const snap = await docRef.get();
-      if (!snap.exists){ alert('Battle missing'); return; }
+      if (!snap.exists){ showToast('Battle missing', 'error'); return; }
       const battleData = snap.data();
       const cost = battleData.cost || (battleData.packs||[]).reduce((s,p)=> s + (p.price||0), 0);
 
@@ -675,7 +675,7 @@
         if ((bal||0) < cost) return; // abort
         return (bal||0) - cost;
       });
-      if (!committed){ alert('Insufficient balance'); return; }
+      if (!committed){ showToast('Insufficient balance', 'error'); return; }
 
       let joined = false;
       try {
@@ -701,13 +701,13 @@
       } catch(err){
         await balanceRef.transaction(bal => (bal||0) + cost); // refund
         console.error(err);
-        alert('Failed to join battle');
+        showToast('Failed to join battle', 'error');
         return;
       }
 
       if (!joined){
         await balanceRef.transaction(bal => (bal||0) + cost); // refund
-        alert('Unable to join battle.');
+        showToast('Unable to join battle.', 'error');
         return;
       }
 

--- a/case.html
+++ b/case.html
@@ -535,7 +535,7 @@ document.getElementById("open-case-button").addEventListener("click", async () =
   if (!user) {
     btn.disabled = false;
     btn.classList.remove("cursor-not-allowed", "opacity-60");
-    return alert("Please sign in to open cases.");
+    return showToast("Please sign in to open cases.", 'error');
   }
 
   const userSnap = await firebase.database().ref('users/' + user.uid).once("value");
@@ -577,7 +577,7 @@ document.getElementById("open-case-button").addEventListener("click", async () =
   if (!fairData) {
     btn.disabled = false;
     btn.classList.remove("cursor-not-allowed", "opacity-60");
-    return alert("Provably fair data missing.");
+    return showToast("Provably fair data missing.", 'error');
   }
   const { nonce } = fairData;
 

--- a/contact.html
+++ b/contact.html
@@ -89,7 +89,7 @@
   document.getElementById('contact-form').addEventListener('submit', async (e) => {
     e.preventDefault();
     const user = firebase.auth().currentUser;
-    if (!user) return alert('Please sign in to send a message.');
+    if (!user) return showToast('Please sign in to send a message.', 'error');
 
     const formRef = db.ref('supportCases').push();
     const newMessageKey = db.ref().push().key;
@@ -106,7 +106,7 @@ await formRef.set({
     }
   }
 });
-    alert('✅ Message sent successfully!');
+    showToast('✅ Message sent successfully!', 'success');
     document.getElementById('contact-form').reset();
   });
 
@@ -148,7 +148,7 @@ const messagesHtml = Object.values(data.messages || {}).map(msg => {
     const replyText = textarea.value.trim();
     if (!replyText) return;
     const user = firebase.auth().currentUser;
-    if (!user) return alert('Please sign in.');
+    if (!user) return showToast('Please sign in.', 'error');
 
     const caseRef = db.ref('supportCases/' + caseId + '/messages');
     caseRef.once('value').then(snapshot => {
@@ -177,7 +177,7 @@ db.ref().update(updates);
     event.preventDefault();
     const user = firebase.auth().currentUser;
     if (!user) {
-      alert("Please sign in to purchase coins.");
+      showToast("Please sign in to purchase coins.", 'error');
       return;
     }
     firebase.firestore()
@@ -196,7 +196,7 @@ db.ref().update(updates);
         docRef.onSnapshot((snap) => {
           const { error, sessionId } = snap.data();
           if (error) {
-            alert(`An error occurred: ${error.message}`);
+            showToast(`An error occurred: ${error.message}`, 'error');
           }
           if (sessionId) {
             stripe.redirectToCheckout({ sessionId });

--- a/faq.html
+++ b/faq.html
@@ -129,7 +129,7 @@
 
     const user = firebase.auth().currentUser;
     if (!user) {
-      alert("Please sign in to purchase coins.");
+      showToast("Please sign in to purchase coins.", 'error');
       return;
     }
 
@@ -149,7 +149,7 @@
         docRef.onSnapshot((snap) => {
           const { error, sessionId } = snap.data();
           if (error) {
-            alert(`An error occurred: ${error.message}`);
+            showToast(`An error occurred: ${error.message}`, 'error');
           }
           if (sessionId) {
             stripe.redirectToCheckout({ sessionId });

--- a/how-it-works.html
+++ b/how-it-works.html
@@ -135,7 +135,7 @@
       event.preventDefault();
       const user = firebase.auth().currentUser;
       if (!user) {
-        alert("Please sign in to purchase coins.");
+        showToast("Please sign in to purchase coins.", 'error');
         return;
       }
       firebase.firestore()
@@ -154,7 +154,7 @@
           docRef.onSnapshot((snap) => {
             const { error, sessionId } = snap.data();
             if (error) {
-              alert(`An error occurred: ${error.message}`);
+              showToast(`An error occurred: ${error.message}`, 'error');
             }
             if (sessionId) {
               stripe.redirectToCheckout({ sessionId });

--- a/marketplace.html
+++ b/marketplace.html
@@ -147,7 +147,7 @@
 
         clone.querySelector(".buy-btn").addEventListener("click", async (e) => {
           e.stopPropagation();
-          if (userBalance < card.value) return alert("Not enough 🪙!");
+          if (userBalance < card.value) return showToast("Not enough 🪙!", 'error');
           await firebase.database().ref("users/" + firebase.auth().currentUser.uid + "/balance").set(userBalance - card.value);
           await firebase.database().ref("users/" + firebase.auth().currentUser.uid + "/inventory").push({
             name: card.name,
@@ -185,7 +185,7 @@
       const userBalance = userData?.balance || 0;
 
       if (userBalance < window.selectedCard.value) {
-        alert("Not enough 🪙!");
+        showToast("Not enough 🪙!", 'error');
         return;
       }
 

--- a/scripts/auth.js
+++ b/scripts/auth.js
@@ -17,7 +17,7 @@ window.addEventListener('DOMContentLoaded', () => {
       const snapshot = await userRef.once('value');
       const userData = snapshot.val() || {};
       if (!user.email || (!user.emailVerified && !userData.emailVerified)) {
-        alert('Please complete registration and verify your email to continue.');
+        showToast('Please complete registration and verify your email to continue.', 'error');
         firebase.auth().signOut();
         return;
       }

--- a/scripts/header.js
+++ b/scripts/header.js
@@ -1,3 +1,31 @@
+// Global toast helper
+if (!window.showToast) {
+  window.showToast = (message, type = "info") => {
+    let toast = document.getElementById("toast");
+    if (!toast) {
+      toast = document.createElement("div");
+      toast.id = "toast";
+      toast.className =
+        "fixed bottom-6 left-1/2 transform -translate-x-1/2 px-5 py-3 rounded-xl text-white font-bold text-sm z-[9999] shadow-lg hidden opacity-0 transition-opacity duration-300";
+      document.body.appendChild(toast);
+    }
+    toast.textContent = message;
+    toast.classList.remove("hidden", "opacity-0", "bg-red-600", "bg-green-600", "bg-gray-800");
+    const color = type === "error" ? "bg-red-600" : type === "success" ? "bg-green-600" : "bg-gray-800";
+    toast.classList.add(color);
+    // trigger fade in
+    void toast.offsetWidth;
+    toast.classList.add("opacity-100");
+    setTimeout(() => {
+      toast.classList.remove("opacity-100");
+      setTimeout(() => toast.classList.add("hidden"), 300);
+    }, 3000);
+  };
+}
+
+// Replace native alerts with toasts
+window.alert = (msg) => window.showToast(msg);
+
 document.addEventListener("DOMContentLoaded", () => {
   const header = document.querySelector("header");
   if (!header) return;

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -338,7 +338,7 @@ function sellSelected() {
     });
 
     userRef.update({ balance: currentBalance }).then(() => {
-      alert(`Sold selected items for ${total} coins.`);
+      showToast(`Sold selected items for ${total} coins.`, 'success');
       window.location.reload();
     });
   });
@@ -351,7 +351,7 @@ function shipSelected() {
     if (item) shipmentSelection.push({ id: item.id, name: item.name, image: item.image });
   });
 
-  if (shipmentSelection.length === 0) return alert("Select items to ship.");
+  if (shipmentSelection.length === 0) return showToast("Select items to ship.", 'error');
 
   localStorage.setItem('shipItems', JSON.stringify(shipmentSelection));
   window.location.href = 'shipping.html';

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -182,10 +182,10 @@ function updateProfile() {
   user.updateProfile({ displayName: newUsername })
     .then(() => firebase.database().ref('users/' + user.uid).update({ username: newUsername }))
     .then(() => {
-      alert('✅ Username updated!');
+      showToast('✅ Username updated!', 'success');
       location.reload();
     })
-    .catch(err => alert('❌ Error: ' + err.message));
+    .catch(err => showToast('❌ Error: ' + err.message, 'error'));
 }
 
 function determineLevel(packs, levels) {
@@ -216,17 +216,17 @@ function changePassword() {
   const newPassword = document.getElementById('new-password').value;
   const user = firebase.auth().currentUser;
   if (!currentPassword || !newPassword) {
-    alert('Please fill out both password fields.');
+    showToast('Please fill out both password fields.', 'error');
     return;
   }
   const credential = firebase.auth.EmailAuthProvider.credential(user.email, currentPassword);
   user.reauthenticateWithCredential(credential)
     .then(() => user.updatePassword(newPassword))
     .then(() => {
-      alert('✅ Password updated successfully.');
+      showToast('✅ Password updated successfully.', 'success');
       document.getElementById('current-password').value = '';
       document.getElementById('new-password').value = '';
     })
-    .catch(error => alert('❌ ' + error.message));
+    .catch(error => showToast('❌ ' + error.message, 'error'));
 }
 

--- a/scripts/quests.js
+++ b/scripts/quests.js
@@ -134,7 +134,7 @@ export async function renderWeeklyQuests(containerId = "quest-container") {
       const live = questSnap.val() || {};
 
       if ((live.progress || 0) < quest.goal || live.claimed) {
-        alert("You must complete the task before claiming.");
+        window.showToast("You must complete the task before claiming.", "error");
         return;
       }
 

--- a/scripts/shipping.js
+++ b/scripts/shipping.js
@@ -93,14 +93,14 @@ function submitShipmentRequest() {
   const zip = document.getElementById('ship-zip').value.trim();
   const phone = document.getElementById('ship-phone').value.trim();
 
-  if (!name || !address || !city || !zip) return alert('Please fill out all fields.');
+  if (!name || !address || !city || !zip) return showToast('Please fill out all fields.', 'error');
 
   const cost = shipmentSelection.length <= 5 ? shipmentSelection.length * 500 : 2500;
   const userRef = firebase.database().ref('users/' + user.uid);
 
   userRef.once('value').then(function (snap) {
     const balance = (snap.val() && snap.val().balance) || 0;
-    if (balance < cost) return alert('Insufficient balance.');
+    if (balance < cost) return showToast('Insufficient balance.', 'error');
 
     userRef.update({ balance: balance - cost });
 

--- a/scripts/topup.js
+++ b/scripts/topup.js
@@ -62,7 +62,7 @@ function redirectToCheckout(event, priceId, button) {
 
   const user = firebase.auth().currentUser;
   if (!user) {
-    alert("Please sign in to purchase coins.");
+    showToast("Please sign in to purchase coins.", 'error');
     button.disabled = false;
     button.innerHTML = originalText;
     return;
@@ -84,7 +84,7 @@ function redirectToCheckout(event, priceId, button) {
       docRef.onSnapshot((snap) => {
         const { error, sessionId } = snap.data();
         if (error) {
-          alert(`An error occurred: ${error.message}`);
+          showToast(`An error occurred: ${error.message}`, 'error');
           button.disabled = false;
           button.innerHTML = originalText;
         }

--- a/scripts/vault.js
+++ b/scripts/vault.js
@@ -71,7 +71,7 @@ async function loadPack() {
 async function openPack() {
   if (!currentPack) return;
   const user = firebase.auth().currentUser;
-  if (!user) return alert('You must be logged in.');
+  if (!user) return showToast('You must be logged in.', 'error');
 
   const openBtn = document.getElementById('open-pack');
   openBtn.disabled = true;
@@ -82,14 +82,14 @@ async function openPack() {
   const price = parseFloat(currentPack.price || 0);
   if (balance < price) {
     openBtn.disabled = false;
-    return alert('Not enough coins.');
+    return showToast('Not enough coins.', 'error');
   }
 
   const fairSnap = await firebase.database().ref('users/' + user.uid + '/provablyFair').once('value');
   const fairData = fairSnap.val();
   if (!fairData) {
     openBtn.disabled = false;
-    return alert('Provably fair data missing.');
+    return showToast('Provably fair data missing.', 'error');
   }
   const { nonce } = fairData;
 

--- a/termsandconditions.html
+++ b/termsandconditions.html
@@ -133,7 +133,7 @@
 
     const user = firebase.auth().currentUser;
     if (!user) {
-      alert("Please sign in to purchase coins.");
+      showToast("Please sign in to purchase coins.", 'error');
       return;
     }
 
@@ -153,7 +153,7 @@
         docRef.onSnapshot((snap) => {
           const { error, sessionId } = snap.data();
           if (error) {
-            alert(`An error occurred: ${error.message}`);
+            showToast(`An error occurred: ${error.message}`, 'error');
           }
           if (sessionId) {
             stripe.redirectToCheckout({ sessionId });


### PR DESCRIPTION
## Summary
- Implement global `showToast` utility and override default `alert` behavior
- Replace remaining `alert` calls with toast notifications across JS and HTML
- Ensure user actions like profile updates and auth flows use non-blocking toasts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4b1b05504832092f797e13ca89378