### PR TITLE
Fix mobile nav balance container width

### DIFF
--- a/components/header.html
+++ b/components/header.html
@@ -65,9 +65,13 @@
 
 <!-- Mobile Dropdown -->
 <div id="mobile-dropdown" class="hidden mt-2 bg-gray-800 border border-gray-700 rounded-lg w-48 py-2 fixed right-4 top-[72px] z-[9999] shadow-lg sm:hidden">
-  <div id="user-balance-mobile" class="flex items-center justify-between px-4 py-2 text-sm text-white border-b border-gray-700">
-    <span><img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="inline w-4 h-4 mr-1"> <span id="balance-amount-mobile-dropdown">0</span> coins</span>
-    <button id="topup-button-mobile" class="text-green-400 text-lg font-bold hover:text-green-500">+</button>
+  <div id="user-balance-mobile" class="px-4 py-2 border-b border-gray-700">
+    <div class="flex items-center gap-1 bg-gray-800 text-white px-3 py-1 rounded-full text-sm w-fit mx-auto">
+      <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" />
+      <span id="balance-amount-mobile-dropdown">0</span>
+      <span>coins</span>
+      <button id="topup-button-mobile" class="text-green-400 text-lg font-bold hover:text-green-500 ml-1">+</button>
+    </div>
   </div>
   <a id="inventory-link" href="inventory.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm">Inventory</a>
   <a href="how-it-works.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm">How It Works</a>

--- a/components/nav.html
+++ b/components/nav.html
@@ -49,9 +49,13 @@
   </div>
 </nav>
 <div id="mobile-dropdown" class="hidden mt-2 bg-gray-800 border border-gray-700 rounded-lg w-48 py-2 fixed right-4 top-[72px] z-[9999] shadow-lg sm:hidden">
-  <div id="user-balance-mobile" class="flex items-center justify-between px-4 py-2 text-sm text-white border-b border-gray-700">
-    <span><img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="inline w-4 h-4 mr-1"> <span id="balance-amount-mobile-dropdown">0</span> coins</span>
-    <button id="topup-button-mobile" class="text-green-400 text-lg font-bold hover:text-green-500">+</button>
+  <div id="user-balance-mobile" class="px-4 py-2 border-b border-gray-700">
+    <div class="flex items-center gap-1 bg-gray-800 text-white px-3 py-1 rounded-full text-sm w-fit mx-auto">
+      <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" />
+      <span id="balance-amount-mobile-dropdown">0</span>
+      <span>coins</span>
+      <button id="topup-button-mobile" class="text-green-400 text-lg font-bold hover:text-green-500 ml-1">+</button>
+    </div>
   </div>
   <a id="inventory-link" href="inventory.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm hidden">Inventory</a>
   <a href="how-it-works.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm">How It Works</a>

--- a/scripts/header.js
+++ b/scripts/header.js
@@ -87,7 +87,7 @@ document.addEventListener("DOMContentLoaded", () => {
           <a data-nav="marketplace.html" href="marketplace.html" class="block pl-3 pr-4 py-2 border-l-4 border-transparent text-base font-medium text-gray-600 hover:bg-gray-50 hover:border-gray-300"><i class="fas fa-store mr-2"></i>Marketplace</a>
         </div>
         <div class="pt-4 pb-3 border-t border-gray-200">
-          <div id="user-balance-mobile-drawer" class="hidden coin-box text-sm mx-4 mb-3">
+          <div id="user-balance-mobile-drawer" class="hidden coin-box text-sm mx-auto mb-3">
             <div class="balance">
               <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" alt="Coins">
               <span id="balance-amount-mobile-dropdown" class="font-medium">0</span>

--- a/styles/main.css
+++ b/styles/main.css
@@ -88,8 +88,8 @@ body {
 }
 
 .coin-box {
-  display: flex;
-  align-items: stretch;
+  display: inline-flex;
+  align-items: center;
   border: 1px solid #e5e7eb;
   border-radius: 8px;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- Center mobile balance pill to prevent stretching across the screen
- Ensure coin box styles size to content
- Center balance display in header mobile drawer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b79e2fe70483208b81a091241dfc93