### PR TITLE
Fix inventory item layout to prevent text overflow

### DIFF
--- a/inventory.html
+++ b/inventory.html
@@ -67,6 +67,7 @@
       display: flex;
       flex-direction: column;
       height: 100%;
+      overflow: hidden;
     }
 
     .item-card:hover {
@@ -88,6 +89,15 @@
       color: black;
     }
 
+    .item-name {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 2;
+      word-break: break-word;
+    }
+
     /* Item preview popup */
     #item-popup {
       background: rgba(0, 0, 0, 0.8);
@@ -98,7 +108,9 @@
       width: min(90vw, 350px);
       max-height: 80vh;
       border-radius: 0.5rem;
-      background: #ffffff;
+      background: linear-gradient(135deg, #ff9a9e, #fad0c4, #fbc2eb, #a18cd1);
+      background-size: 300% 300%;
+      animation: bgShift 8s ease infinite;
       cursor: grab;
       touch-action: none;
       will-change: transform;
@@ -130,6 +142,7 @@
         linear-gradient(135deg, rgba(255,0,255,0.4), rgba(0,255,255,0.4), rgba(255,255,0,0.4));
       opacity: 0.9;
       filter: brightness(1.2);
+      animation: holoMove 6s linear infinite;
     }
 
     .popup-card {
@@ -143,6 +156,43 @@
     @keyframes popIn {
       from { transform: scale(0.8); opacity: 0; }
       to { transform: scale(1); opacity: 1; }
+    }
+
+    @keyframes bgShift {
+      0% { background-position: 0% 50%; }
+      50% { background-position: 100% 50%; }
+      100% { background-position: 0% 50%; }
+    }
+
+    @keyframes holoMove {
+      0% { background-position: 0% 0%; }
+      50% { background-position: 100% 100%; }
+      100% { background-position: 0% 0%; }
+    }
+
+    .popup-info {
+      margin-top: 1rem;
+      padding: 0.75rem 1rem;
+      background: rgba(255, 255, 255, 0.9);
+      backdrop-filter: blur(4px);
+      border-radius: 0.5rem;
+      display: inline-block;
+    }
+
+    #rotate-hint {
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+      font-size: 0.75rem;
+    }
+
+    #rotate-hint i {
+      animation: sway 1.5s ease-in-out infinite;
+    }
+
+    @keyframes sway {
+      0%, 100% { transform: translateX(-3px); }
+      50% { transform: translateX(3px); }
     }
 
   </style>
@@ -190,7 +240,7 @@
         <button onclick="shipSelected()" class="px-4 py-1.5 text-sm rounded-full font-semibold text-white bg-gradient-to-r from-green-400 to-teal-500 hover:from-teal-500 hover:to-green-400 transition btn whitespace-nowrap">Ship Selected</button>
       </div>
     </div>
-      <div id="inventory-container" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-5 gap-4 sm:gap-6 auto-rows-fr"></div>
+      <div id="inventory-container" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-5 gap-4 sm:gap-6 auto-rows-auto"></div>
     </section>
 
     <section id="orders-section" class="hidden">
@@ -198,19 +248,30 @@
         <h2 class="text-3xl font-bold mb-2 gradient-text flex items-center justify-center"><i class="fas fa-truck mr-2"></i>Your Recent Orders</h2>
         <p class="text-sm text-gray-600">Below are your previous shipment requests and their current status.</p>
       </div>
-      <div id="orders-container" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 auto-rows-fr"></div>
+      <div id="orders-container" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 auto-rows-auto"></div>
     </section>
   </main>
 
   <!-- Item Preview Popup -->
   <div id="item-popup" class="fixed inset-0 hidden flex items-center justify-center z-50">
-    <div class="popup-card relative">
+    <div class="popup-card relative text-center">
       <div id="popup-rotator">
         <img id="popup-item-image" src="" alt="Item preview" />
         <div id="holo-overlay"></div>
       </div>
+      <div class="popup-info">
+        <h2 id="popup-item-name" class="text-lg font-semibold text-gray-800"></h2>
+        <div class="flex items-center justify-center gap-2 mt-2">
+          <span id="popup-item-rarity" class="pill"></span>
+          <p class="flex items-center gap-1 text-gray-700">
+            <span id="popup-item-value"></span>
+            <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" width="16" height="16" class="coin-icon" />
+          </p>
+        </div>
+      </div>
       <div id="rotate-hint" class="absolute bottom-2 right-2 text-white opacity-80 pointer-events-none">
-        <i class="fa-solid fa-arrows-rotate text-2xl animate-spin" style="animation-duration:3s;"></i>
+        <i class="fa-solid fa-arrows-left-right"></i>
+        <span>Drag</span>
       </div>
       <button id="close-item-popup" class="absolute -top-4 -right-4 w-8 h-8 rounded-full bg-gray-800 text-white flex items-center justify-center">&times;</button>
     </div>

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -141,7 +141,7 @@ document.addEventListener('DOMContentLoaded', () => {
         container.innerHTML += `
           <div class="item-card rounded-2xl p-6 text-center h-full">
             <img src="${data.image}" class="mx-auto mb-4 h-24 object-contain rounded shadow-lg" />
-            <h2 class="font-semibold text-lg text-gray-800 truncate">${data.name}</h2>
+            <h2 class="item-name font-semibold text-lg text-gray-800">${data.name}</h2>
             <p class="text-sm text-gray-600 mb-1 capitalize">Status: ${data.status}</p>
             <p class="text-sm text-gray-600 mt-auto">Shipping Info: ${data.shippingInfo?.name || ''}</p>
           </div>`;
@@ -201,24 +201,17 @@ function renderItems(items) {
   items.forEach(item => {
     const refund = Math.floor((item.value || 0) * 0.8);
     const checked = selectedItems.has(item.key) ? 'checked' : '';
-    const rarityClassMap = { 'common': 'common', 'uncommon': 'uncommon', 'rare': 'rare', 'ultra rare': 'ultra', 'legendary': 'legendary' };
-    const rarityClass = rarityClassMap[item.rarity] || 'common';
     container.innerHTML += `
       <div class="item-card rounded-2xl p-6 text-center h-full">
         <input type="checkbox" onchange="toggleItem('${item.key}')" ${checked} class="mb-3 accent-indigo-600" ${item.shipped || item.requested ? 'disabled' : ''} />
-        <img src="${item.image}" onclick="showItemPopup('${encodeURIComponent(item.image)}')" class="mx-auto mb-4 h-32 object-contain rounded shadow-lg cursor-pointer transition-transform duration-300 hover:rotate-2 hover:scale-110" />
-        <h2 class="font-semibold text-gray-800 text-lg truncate">${item.name}</h2>
-        <span class="pill ${rarityClass}">${item.rarity}</span>
-        <p class="text-sm text-gray-600 mb-3 flex items-center justify-center gap-1">
-          <span>Value: ${item.value || 0}</span>
-          <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" width="16" height="16" class="coin-icon" />
-        </p>
-        <div class="flex gap-2 mt-auto">
-          <button onclick="sellBack('${item.key}', ${item.value || 0})" ${item.shipped || item.requested ? 'disabled class="flex-1 px-3 py-1.5 text-sm bg-gray-300 text-gray-500 cursor-not-allowed rounded-full flex items-center justify-center gap-1"' : 'class="flex-1 px-3 py-1.5 text-sm text-white bg-gradient-to-r from-indigo-600 to-purple-600 hover:from-purple-600 hover:to-indigo-600 rounded-full flex items-center justify-center gap-1 whitespace-nowrap"'}>
+        <img src="${item.image}" onclick="showItemPopup('${encodeURIComponent(item.image)}','${encodeURIComponent(item.name)}','${encodeURIComponent(item.rarity)}', ${item.value || 0})" class="mx-auto mb-4 h-32 object-contain rounded shadow-lg cursor-pointer transition-transform duration-300 hover:rotate-2 hover:scale-110" />
+        <h2 class="item-name font-semibold text-gray-800 text-lg mb-3">${item.name}</h2>
+        <div class="flex flex-col sm:flex-row gap-2 mt-auto">
+          <button onclick="sellBack('${item.key}', ${item.value || 0})" ${item.shipped || item.requested ? 'disabled class="w-full sm:flex-1 px-3 py-1.5 text-sm bg-gray-300 text-gray-500 cursor-not-allowed rounded-full flex items-center justify-center gap-1"' : 'class="w-full sm:flex-1 px-3 py-1.5 text-sm text-white bg-gradient-to-r from-indigo-600 to-purple-600 hover:from-purple-600 hover:to-indigo-600 rounded-full flex items-center justify-center gap-1"'}>
             <span>Sell for ${refund}</span>
             <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" width="14" height="14" class="coin-icon" />
           </button>
-          <button onclick="shipItem('${item.key}')" ${item.shipped || item.requested ? 'disabled class="flex-1 px-3 py-1.5 text-sm bg-gray-300 text-gray-500 cursor-not-allowed rounded-full whitespace-nowrap"' : 'class="flex-1 px-3 py-1.5 text-sm text-white bg-gradient-to-r from-green-400 to-teal-500 hover:from-teal-500 hover:to-green-400 rounded-full whitespace-nowrap"'}>Ship</button>
+          <button onclick="shipItem('${item.key}')" ${item.shipped || item.requested ? 'disabled class="w-full sm:flex-1 px-3 py-1.5 text-sm bg-gray-300 text-gray-500 cursor-not-allowed rounded-full"' : 'class="w-full sm:flex-1 px-3 py-1.5 text-sm text-white bg-gradient-to-r from-green-400 to-teal-500 hover:from-teal-500 hover:to-green-400 rounded-full"'}>Ship</button>
         </div>
       </div>`;
   });
@@ -365,13 +358,25 @@ function shipItem(key) {
   window.location.href = 'shipping.html';
 }
 
-function showItemPopup(encodedSrc) {
+function showItemPopup(encodedSrc, encodedName, encodedRarity, value) {
   const src = decodeURIComponent(encodedSrc);
+  const name = decodeURIComponent(encodedName || '');
+  const rarity = decodeURIComponent(encodedRarity || '');
   const img = document.getElementById('popup-item-image');
   const rotator = document.getElementById('popup-rotator');
   const holo = document.getElementById('holo-overlay');
   if (!img || !rotator) return;
   img.src = src;
+  const nameEl = document.getElementById('popup-item-name');
+  if (nameEl) nameEl.textContent = name;
+  const rarityEl = document.getElementById('popup-item-rarity');
+  if (rarityEl) {
+    const rarityClassMap = { 'common': 'common', 'uncommon': 'uncommon', 'rare': 'rare', 'ultra rare': 'ultra', 'legendary': 'legendary' };
+    rarityEl.className = `pill ${rarityClassMap[rarity] || 'common'}`;
+    rarityEl.textContent = rarity;
+  }
+  const valueEl = document.getElementById('popup-item-value');
+  if (valueEl) valueEl.textContent = value || 0;
   popupRotX = 0;
   popupRotY = 0;
   currentRotX = 0;


### PR DESCRIPTION
## Summary
- Stack action buttons vertically on small screens so they stay within inventory card bounds
- Move rarity badge and coin value from cards into the item popup and populate them dynamically
- Keep the card rotation effect while displaying item details in the popup
- Wrap item details in a unified popup info container with an animated backdrop and clearer rotate hint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b79e7a83788320aad8dfe300d0ae2f