### PR TITLE
Remove leveling and badge systems

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -56,7 +56,7 @@
       <a href="#" class="text-sm text-white hover:text-pink-400" onclick="showSection('users')">Users</a>
       <a href="#" class="text-sm text-white hover:text-pink-400" onclick="showSection('marketplace')">Marketplace</a>
       <a href="#" class="text-sm text-white hover:text-pink-400" onclick="showSection('quests')">Quests</a>
-      <a href="#" class="text-sm text-white hover:text-pink-400" onclick="showSection('milestones')">Milestones</a>
+      <a href="#" class="text-sm text-white hover:text-pink-400" onclick="showSection('rewards')">Rewards</a>
     </div>
   </nav>
 
@@ -198,21 +198,12 @@
   </form>
 </section>
 
-
-<section id="milestones-section" class="hidden">
-  <h1 class="text-3xl font-bold mb-6">Milestones</h1>
-  <form id="milestone-config-form" class="space-y-6 max-w-xl bg-gray-800 p-6 rounded-lg">
-    <div>
-      <h2 class="text-2xl mb-4">Badges</h2>
-      <div id="badge-list" class="space-y-4"></div>
-      <button type="button" onclick="addBadge()" class="mt-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded">+ Add Badge</button>
-    </div>
-    <div>
-      <h2 class="text-2xl mb-4">Level Requirements</h2>
-      <div id="level-list" class="space-y-4"></div>
-      <button type="button" onclick="addLevel()" class="mt-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded">+ Add Level</button>
-    </div>
-    <button type="submit" class="px-6 py-2 bg-green-600 hover:bg-green-700 rounded">Save</button>
+<section id="rewards-section" class="hidden">
+  <h1 class="text-3xl font-bold mb-6">Rewards Wheel</h1>
+  <form id="wheel-form" class="space-y-4 max-w-xl bg-gray-800 p-6 rounded-lg">
+    <div id="wheel-rewards" class="space-y-4"></div>
+    <button type="button" id="add-reward" class="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded">Add Reward</button>
+    <button type="submit" class="px-4 py-2 bg-green-600 hover:bg-green-700 rounded">Save</button>
   </form>
 </section>
 
@@ -258,7 +249,7 @@
     }
 
   function showSection(id) {
-  const sections = ['cases', 'shipments', 'support', 'users', 'marketplace', 'quests', 'milestones'];
+  const sections = ['cases', 'shipments', 'support', 'users', 'marketplace', 'quests', 'rewards'];
   sections.forEach(section => {
     document.getElementById(section + '-section').classList.add('hidden');
   });
@@ -774,7 +765,6 @@ firebase.auth().onAuthStateChanged(user => {
   loadSupportForms();
   loadMarketplaceItems();
   loadQuestConfig();
-  loadMilestoneConfig();
 });
 
 
@@ -881,70 +871,42 @@ document.getElementById('quest-config-form').addEventListener('submit', e => {
   firebase.database().ref('questConfig').set(config).then(() => showToast('✅ Quest config saved'));
 });
 
-function addBadge(badge = {}) {
+function addWheelReward(reward = {}) {
   const div = document.createElement('div');
-  div.className = 'flex gap-2 items-center';
+  div.className = 'p-4 bg-gray-700 rounded space-y-2';
   div.innerHTML = `
-    <input type="text" placeholder="Badge Name" class="badge-name w-full p-2 rounded" value="${badge.name || ''}">
-    <input type="number" placeholder="Pack Threshold" class="badge-threshold w-32 p-2 rounded" value="${badge.threshold || ''}">
-    <input type="color" class="badge-color w-16 h-10 rounded" value="${badge.color || '#9333ea'}">
-    <button type="button" class="text-red-400 hover:text-red-600" onclick="this.parentElement.remove()">Remove</button>
+    <div class="flex justify-end"><button onclick="this.parentElement.parentElement.remove()" class="text-red-400 hover:text-red-600 text-sm">Remove</button></div>
+    <input type="text" placeholder="Label" value="${reward.label || ''}" class="reward-label w-full p-2 rounded">
+    <input type="number" placeholder="Amount" value="${reward.amount || ''}" class="reward-amount w-full p-2 rounded">
+    <input type="color" value="${reward.color || '#3b82f6'}" class="reward-color w-full h-10 rounded">
+    <input type="number" placeholder="Odds (%)" value="${reward.odds ?? reward.weight ?? 1}" class="reward-odds w-full p-2 rounded">
   `;
-  document.getElementById('badge-list').appendChild(div);
+  document.getElementById('wheel-rewards').appendChild(div);
 }
 
-function addLevel(level = {}) {
-  const div = document.createElement('div');
-  div.className = 'flex gap-2 items-center';
-  const threshold = typeof level === 'object' ? (level.threshold || '') : level;
-  const reward = typeof level === 'object' ? (level.reward || 0) : 0;
-  div.innerHTML = `
-    <input type="number" placeholder="Pack Threshold" class="level-threshold w-full p-2 rounded" value="${threshold}">
-    <input type="number" placeholder="Coin Reward" class="level-reward w-full p-2 rounded" value="${reward}">
-    <button type="button" class="text-red-400 hover:text-red-600" onclick="this.parentElement.remove()">Remove</button>
-  `;
-  document.getElementById('level-list').appendChild(div);
-}
-
-function loadMilestoneConfig() {
-  const ref = firebase.database().ref('milestoneConfig');
-  ref.once('value').then(snap => {
-    const cfg = snap.val() || {};
-    const badges = cfg.badges || [];
-    const levels = cfg.levels || [];
-    if (badges.length) {
-      badges.forEach(b => addBadge(b));
-    } else {
-      addBadge();
-    }
-    if (levels.length) {
-      levels.forEach(l => {
-        if (typeof l === 'object') addLevel(l);
-        else addLevel({ threshold: l, reward: 0 });
-      });
-    } else {
-      addLevel();
-    }
+function loadWheelRewards() {
+  const ref = firebase.database().ref('wheelRewards');
+  ref.on('value', snap => {
+    const container = document.getElementById('wheel-rewards');
+    container.innerHTML = '';
+    Object.values(snap.val() || {}).forEach(r => addWheelReward(r));
   });
 }
 
-document.getElementById('milestone-config-form').addEventListener('submit', e => {
+document.getElementById('add-reward').addEventListener('click', () => addWheelReward());
+
+document.getElementById('wheel-form').addEventListener('submit', e => {
   e.preventDefault();
-  const badges = [];
-  document.querySelectorAll('#badge-list > div').forEach(div => {
-    const name = div.querySelector('.badge-name').value.trim();
-    const threshold = parseInt(div.querySelector('.badge-threshold').value) || 0;
-    const color = div.querySelector('.badge-color').value || '#9333ea';
-    if (name) badges.push({ name, threshold, color });
-  });
-  const levels = [];
-  document.querySelectorAll('#level-list > div').forEach(div => {
-    const threshold = parseInt(div.querySelector('.level-threshold').value);
-    const reward = parseInt(div.querySelector('.level-reward').value) || 0;
-    if (!isNaN(threshold)) levels.push({ threshold, reward });
-  });
-  firebase.database().ref('milestoneConfig').set({ badges, levels }).then(() => showToast('✅ Milestone config saved'));
+  const rewards = Array.from(document.querySelectorAll('#wheel-rewards .p-4')).map(div => ({
+    label: div.querySelector('.reward-label').value,
+    amount: parseInt(div.querySelector('.reward-amount').value) || 0,
+    color: div.querySelector('.reward-color').value,
+    odds: parseFloat(div.querySelector('.reward-odds').value) || 0
+  })).filter(r => r.label);
+  firebase.database().ref('wheelRewards').set(rewards).then(() => showToast('✅ Rewards saved'));
 });
+
+loadWheelRewards();
 
 document.getElementById('clear-battles').addEventListener('click', () => {
   firestore.collection('battles').get().then(snap => {

--- a/case.html
+++ b/case.html
@@ -608,11 +608,8 @@ document.getElementById("open-case-button").addEventListener("click", async () =
     const invRef = firebase.database().ref('users/' + user.uid + '/inventory').push();
     await invRef.set(unboxData);
     await firebase.database().ref('users/' + user.uid + '/unboxHistory/' + invRef.key).set(unboxData);
-    const levelResult = await updateMilestones(user.uid, winningPrize.value);
-    if (levelResult.leveledUp) {
-      await firebase.database().ref('users/' + user.uid + '/balance').transaction(b => (b || 0) + (levelResult.reward || 0));
-    }
-    winnings[0] = { ...winningPrize, key: invRef.key, levelResult };
+    await updateMilestones(user.uid, winningPrize.value);
+    winnings[0] = { ...winningPrize, key: invRef.key };
 
     const winIndex = openerItems.findIndex(p => p.name === winningPrize.name);
     await transitionToReel();
@@ -620,10 +617,6 @@ document.getElementById("open-case-button").addEventListener("click", async () =
       PackOpener.spinToIndex(winIndex, { durationMs: 2400, nearMiss: true, onReveal: () => resolve() });
     });
 
-    const lr = winnings[0].levelResult;
-    if (lr.leveledUp) {
-      showToast(`Level ${lr.level}! +${formatCoins(lr.reward)} coins`, 'bg-green-600');
-    }
   }
 
   if (isFreeCase) {

--- a/components/header.html
+++ b/components/header.html
@@ -25,15 +25,6 @@
       <span>coins</span>
       <button id="topup-button" class="text-green-400 font-bold ml-1">+</button>
     </div>
-    <!-- XP / Level Display -->
-<div id="level-display" class="flex items-center gap-2 bg-black/40 px-3 py-1 rounded-full border border-white/10 shadow-md text-xs">
-  <span class="text-pink-400 font-bold">Lvl <span id="level-number">1</span></span>
-  <div class="relative w-24 h-2 bg-gray-700 rounded-full overflow-hidden">
-    <div id="xp-bar" class="absolute top-0 left-0 h-full bg-gradient-to-r from-pink-500 via-yellow-400 to-purple-500 rounded-full transition-all duration-300" style="width: 0%"></div>
-  </div>
-</div>
-
-
     <!-- Username + Dropdown -->
     <div class="relative">
       <button id="dropdown-toggle" class="flex items-center space-x-2 text-white focus:outline-none">

--- a/components/nav.html
+++ b/components/nav.html
@@ -11,13 +11,10 @@
     <a href="box-battles.html" class="flex items-center gap-1 text-purple-400 font-semibold hover:text-purple-300 transition">
       <i class="fas fa-sword"></i><i class="fas fa-shield-alt ml-1 mr-1"></i> Battles
     </a>
+    <a href="rewards.html" class="flex items-center gap-1 text-yellow-400 font-semibold hover:text-yellow-300 transition">
+      <i class="fas fa-gift"></i> Rewards
+    </a>
     <div id="user-balance" class="flex items-center gap-1 bg-gray-800 text-white px-3 py-1 rounded-full text-sm hidden">
-      <div id="level-display" class="flex items-center gap-2 bg-black/40 px-3 py-1 rounded-full border border-white/10 shadow-md text-xs">
-  <span class="text-pink-400 font-bold">Lvl <span id="level-number">1</span></span>
-  <div class="relative w-24 h-2 bg-gray-700 rounded-full overflow-hidden">
-    <div id="xp-bar" class="absolute top-0 left-0 h-full bg-gradient-to-r from-pink-500 via-yellow-400 to-purple-500 rounded-full transition-all duration-300" style="width: 0%"></div>
-  </div>
-</div>
       <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" />
       <span id="balance-amount">0</span>
       <span>coins</span>
@@ -60,6 +57,9 @@
   </a>
   <a href="box-battles.html" class="block px-4 py-2 hover:bg-gray-700 text-purple-400 text-sm">
     <i class="fas fa-sword mr-1"></i><i class="fas fa-shield-alt mr-2"></i> Battles
+  </a>
+  <a href="rewards.html" class="block px-4 py-2 hover:bg-gray-700 text-yellow-400 text-sm">
+    <i class="fas fa-gift mr-2"></i> Rewards
   </a>
   <a id="mobile-auth-button" href="auth.html" class="block px-4 py-2 hover:bg-gray-700 text-red-400 text-sm">Sign In</a>
 </div>

--- a/profile.html
+++ b/profile.html
@@ -35,11 +35,6 @@
 
       <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mb-8 text-center">
         <div class="bg-gray-50 p-4 rounded-xl border border-gray-200 shadow">
-          <i class="fa-solid fa-star text-indigo-500 text-2xl mb-1"></i>
-          <p class="text-sm text-gray-600">Level</p>
-          <p id="level-number" class="text-2xl font-bold">1</p>
-        </div>
-        <div class="bg-gray-50 p-4 rounded-xl border border-gray-200 shadow">
           <i class="fa-solid fa-box-open text-indigo-500 text-2xl mb-1"></i>
           <p class="text-sm text-gray-600">Packs Opened</p>
           <p id="packs-opened" class="text-2xl font-bold">0</p>
@@ -62,19 +57,10 @@
       </div>
 
       <div class="mb-8">
-        <p class="text-sm text-center text-gray-600 mb-1">Progress to Next Level</p>
-        <div class="w-full bg-gray-200 rounded-full h-4">
-          <div id="level-progress" class="bg-indigo-500 h-4 rounded-full" style="width:0%"></div>
-        </div>
-        <p id="progress-text" class="text-xs text-center text-gray-500 mt-1"></p>
-      </div>
-
-      <div class="mb-8">
         <h3 class="text-lg font-semibold text-center text-gray-900 mb-2">Recent Pulls</h3>
         <ul id="recent-pulls" class="bg-white rounded-lg divide-y divide-gray-200"></ul>
       </div>
 
-      <div id="badge-container" class="flex flex-wrap justify-center gap-2 mb-8"></div>
 
       <div class="mb-4 text-center">
         <label class="block text-sm font-medium text-gray-700 mb-1">Username</label>

--- a/rewards.html
+++ b/rewards.html
@@ -3,72 +3,41 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Packly.gg | Daily Rewards</title>
+  <title>PrimePull.gg | Daily Spin</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-database-compat.js"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
-  <style>
-    body {
-      background: linear-gradient(135deg, #0f0f12, #1a1a2e);
-      font-family: 'Poppins', sans-serif;
-      color: white;
-      overflow-x: hidden;
-    }
-    .reward-card {
-      background: rgba(30,30,40,0.9);
-      border-radius: 1.5rem;
-      padding: 2.5rem 2rem;
-      box-shadow: 0 20px 40px rgba(0,0,0,0.4);
-      backdrop-filter: blur(10px);
-    }
-    .streak-box {
-      background-color: #2c2c3a;
-      border-radius: 0.75rem;
-      padding: 0.75rem 0.5rem;
-      text-align: center;
-      color: white;
-      transition: transform 0.3s, background-color 0.3s;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      gap: 0.25rem;
-    }
-    .streak-box:hover {
-      transform: translateY(-4px);
-    }
-    .streak-box.claimed {
-      background: linear-gradient(to top right, #ffc107, #ff9800);
-      color: #000;
-    }
-  </style>
+  <link rel="stylesheet" href="styles/main.css">
+  <link rel="stylesheet" href="styles/rewards.css">
 </head>
 <body>
 <script src="scripts/preloader.js"></script>
+  <div id="coin-rain"></div>
   <header></header>
-  <main class="min-h-screen flex flex-col items-center gap-10 px-4 pt-32">
-    <section class="reward-card w-full max-w-2xl flex flex-col items-center text-center gap-6">
-      <div class="text-yellow-400 text-6xl animate-bounce">
-        <i class="fas fa-gift"></i>
-      </div>
-      <div>
-        <h1 class="text-4xl font-bold">Daily Rewards</h1>
-        <p class="text-gray-300 mt-2">Log in every 24 hours to claim your bonus and earn streak rewards!</p>
-      </div>
-      <p id="countdown-timer" class="text-yellow-400 hidden"></p>
-      <button id="claim-bonus" class="bg-yellow-400 hover:bg-yellow-300 text-black font-bold px-8 py-3 rounded-full transform transition hover:scale-105">
-        Claim Bonus
-      </button>
-      <div class="w-full">
-        <h2 class="text-2xl font-semibold mb-4">Streak Progress</h2>
-        <div id="streak-grid" class="grid grid-cols-3 sm:grid-cols-7 gap-4"></div>
-      </div>
+  <main class="overflow-x-hidden">
+    <section class="w-full text-center pt-24 pb-20">
+      <h1 class="text-5xl font-extrabold drop-shadow-lg mb-4">
+        <span class="block text-gray-900">FREE DAILY</span>
+        <span class="block gradient-text">REWARDS</span>
+      </h1>
+      <p class="text-gray-700 mb-6">Spend more gems and open more boxes to improve your rewards!</p>
     </section>
-    <section id="quest-container" class="w-full max-w-4xl"></section>
+
+    <section id="wheel-wrapper" class="relative flex justify-center overflow-hidden h-[320px] w-full">
+      <div id="wheel-container">
+        <canvas id="wheel" width="600" height="600"></canvas>
+        <div id="pointer"><i class="fas fa-caret-down"></i></div>
+      </div>
+      <img id="mascot" src="https://firebasestorage.googleapis.com/v0/b/cases-e5b4e.firebasestorage.app/o/Untitled%20design%20(28).png?alt=media&token=61fab7cf-c6e5-4598-8865-bd95007d6961" alt="Mascot">
+    </section>
+    <button id="spin">Spin</button>
+    <p id="countdown" class="hidden text-center mt-4"></p>
+    <section id="quest-container" class="w-full max-w-4xl mt-12"></section>
   </main>
-  <div id="toast" class="fixed bottom-6 left-1/2 -translate-x-1/2 bg-gray-800 text-white px-6 py-3 rounded-lg shadow-xl hidden z-50"></div>
+  <div id="toast" class="fixed bottom-6 left-1/2 -translate-x-1/2 text-white hidden z-50"></div>
   <footer></footer>
 
   <script>
@@ -85,72 +54,162 @@
     const auth = firebase.auth();
     const db = firebase.database();
 
+    const canvas = document.getElementById('wheel');
+    const ctx = canvas.getContext('2d');
+    let rewards = [];
+    let currentRotation = 0; // cumulative rotation in degrees
+    const defaultColors = ['#1e3a8a','#4338ca','#1e40af','#3b82f6','#2563eb','#312e81','#4f46e5','#1e3a8a'];
+    const coinImg = new Image();
+    coinImg.crossOrigin = 'anonymous';
+    coinImg.src = 'https://cdn-icons-png.flaticon.com/128/6369/6369589.png';
+
+    function drawWheel() {
+      if (!coinImg.complete) {
+        coinImg.onload = drawWheel;
+        return;
+      }
+      const radius = canvas.width / 2;
+      const sliceRadius = radius - 20;
+      // offset starting angle so labels remain upright after spins
+      let start = -Math.PI / 2 + (currentRotation * Math.PI / 180);
+      const sliceAngle = (2 * Math.PI) / rewards.length;
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      rewards.forEach((r, i) => {
+        r.startAngle = start;
+        r.midAngle = start + sliceAngle / 2;
+        r.endAngle = start + sliceAngle;
+        ctx.beginPath();
+        ctx.moveTo(radius, radius);
+        ctx.arc(radius, radius, sliceRadius, r.startAngle, r.endAngle);
+        ctx.closePath();
+        ctx.fillStyle = r.color || defaultColors[i % defaultColors.length];
+        ctx.fill();
+        ctx.strokeStyle = '#0f0f12';
+        ctx.lineWidth = 2;
+        ctx.stroke();
+        // draw label from outer edge toward center so it stays within slice
+        const textOffset = 40;
+        ctx.save();
+        ctx.translate(radius, radius);
+        ctx.rotate(r.midAngle);
+        ctx.fillStyle = '#fff';
+        ctx.font = 'bold 24px Poppins';
+        ctx.textAlign = 'right';
+        ctx.textBaseline = 'middle';
+        ctx.strokeStyle = 'rgba(0,0,0,0.3)';
+        ctx.lineWidth = 3;
+        const textX = sliceRadius - textOffset;
+        ctx.strokeText(r.label, textX, 0);
+        ctx.fillText(r.label, textX, 0);
+        const textWidth = ctx.measureText(r.label).width;
+        // coin icon appears toward center, after the prize name
+        ctx.drawImage(coinImg, textX - textWidth - 30, -14, 28, 28);
+        ctx.restore();
+        start += sliceAngle;
+      });
+      const rimGrad = ctx.createLinearGradient(0, 0, 0, canvas.height);
+      rimGrad.addColorStop(0, '#facc15');
+      rimGrad.addColorStop(1, '#f97316');
+      ctx.beginPath();
+      ctx.arc(radius, radius, sliceRadius + 12, 0, 2 * Math.PI);
+      ctx.lineWidth = 8;
+      ctx.strokeStyle = rimGrad;
+      ctx.stroke();
+      const gloss = ctx.createRadialGradient(radius, radius, 0, radius, radius, sliceRadius + 12);
+      gloss.addColorStop(0, 'rgba(255,255,255,0.15)');
+      gloss.addColorStop(0.85, 'rgba(255,255,255,0)');
+      gloss.addColorStop(1, 'rgba(0,0,0,0.3)');
+      ctx.beginPath();
+      ctx.arc(radius, radius, sliceRadius + 12, 0, 2 * Math.PI);
+      ctx.fillStyle = gloss;
+      ctx.fill();
+      const hubGrad = ctx.createRadialGradient(radius, radius, 0, radius, radius, 40);
+      hubGrad.addColorStop(0, '#4b5563');
+      hubGrad.addColorStop(1, '#111827');
+      ctx.beginPath();
+      ctx.arc(radius, radius, 40, 0, 2 * Math.PI);
+      ctx.fillStyle = hubGrad;
+      ctx.fill();
+    }
+
+    function spinWheel(reward) {
+      const midDeg = reward.midAngle * 180 / Math.PI;
+      const target = 270 - midDeg;
+      const currentMod = currentRotation % 360;
+      const delta = 360 * 5 + target - currentMod;
+      currentRotation += delta;
+      canvas.style.transition = 'transform 5s cubic-bezier(0.33, 1, 0.68, 1)';
+      canvas.style.transform = `translate(-50%, -50%) rotate(${currentRotation}deg)`;
+    }
+
+    function pickWeightedIndex(items) {
+      const total = items.reduce((sum, r) => sum + (r.odds ?? r.weight ?? 1), 0);
+      let rnd = Math.random() * total;
+      for (let i = 0; i < items.length; i++) {
+        rnd -= (items[i].odds ?? items[i].weight ?? 1);
+        if (rnd < 0) return i;
+      }
+      return 0;
+    }
+
     auth.onAuthStateChanged(async user => {
-      if (!user) return window.location.href = 'auth.html';
+      const button = document.getElementById('spin');
+      const countdown = document.getElementById('countdown');
+      const toast = document.getElementById('toast');
+
+      db.ref('wheelRewards').once('value').then(snap => {
+        rewards = Object.values(snap.val() || {});
+        if (rewards.length) drawWheel();
+      });
+
+      if (!user) {
+        button.textContent = 'Sign In to Spin';
+        button.onclick = () => location.href = 'auth.html';
+        return;
+      }
+
       const userRef = db.ref('users/' + user.uid);
       const snapshot = await userRef.once('value');
       const data = snapshot.val() || {};
-
-      const now = Date.now();
-      const lastClaim = data.lastBonusClaim || 0;
+      let balance = data.balance || 0;
+      const lastSpin = data.lastWheelSpin || 0;
       const delay = 24 * 60 * 60 * 1000;
-      let streak = data.streak || 0;
-      const balance = data.balance || 0;
+      const isAdmin = data.role === 'admin';
 
-      // Reset streak if user hasn't claimed in over 48 hours
-      if (now - lastClaim > delay * 2) {
-        streak = 0;
-        await userRef.update({ streak: 0 });
-      }
-
-      const rewards = [15, 20, 25, 30, 35, 40, 45];
-      const grid = document.getElementById("streak-grid");
-      rewards.forEach((reward, index) => {
-        const claimed = index < streak;
-        const box = document.createElement('div');
-        box.className = `streak-box ${claimed ? 'claimed' : ''}`;
-        box.innerHTML = `
-          <div class="text-sm font-semibold">Day ${index + 1}</div>
-          <div class="flex items-center gap-1">
-            <span class="text-lg font-bold">+${reward}</span>
-            <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" alt="coin" class="w-5 h-5"/>
-          </div>`;
-        grid.appendChild(box);
-      });
-
-      const button = document.getElementById("claim-bonus");
-      const toast = document.getElementById("toast");
-      const countdown = document.getElementById("countdown-timer");
-
-      if (now - lastClaim < delay) {
+      if (!isAdmin && Date.now() - lastSpin < delay) {
         button.disabled = true;
-        button.innerText = "Come back later";
-        countdown.classList.remove("hidden");
+        countdown.classList.remove('hidden');
         setInterval(() => {
-          const remaining = delay - (Date.now() - lastClaim);
+          const remaining = delay - (Date.now() - lastSpin);
           if (remaining <= 0) return location.reload();
           const h = Math.floor(remaining / 3600000);
           const m = Math.floor((remaining % 3600000) / 60000);
           const s = Math.floor((remaining % 60000) / 1000);
-          countdown.innerText = `Next claim in ${h}h ${m}m ${s}s`;
+          countdown.innerText = `Next spin in ${h}h ${m}m ${s}s`;
         }, 1000);
       }
 
-      button.onclick = async () => {
-        const timeSinceLast = Date.now() - lastClaim;
-        if (timeSinceLast < delay) return;
-        const newStreak = timeSinceLast > delay * 2 ? 1 : streak >= 7 ? 1 : streak + 1;
-        const bonus = 10 + 5 * newStreak;
-        await userRef.update({
-          balance: balance + bonus,
-          streak: newStreak,
-          lastBonusClaim: Date.now(),
-        });
-        toast.innerText = `✅ Bonus claimed! +${bonus} coins added.`;
-        toast.classList.remove("hidden");
-        setTimeout(() => toast.classList.add("hidden"), 3000);
+      button.onclick = () => {
+        const now = Date.now();
+        if (!rewards.length || (!isAdmin && now - lastSpin < delay)) return;
+        const index = pickWeightedIndex(rewards);
+        const reward = rewards[index];
+        spinWheel(reward);
         button.disabled = true;
-        button.innerText = "Come back later";
+        canvas.addEventListener('transitionend', async () => {
+          canvas.style.transition = 'none';
+          canvas.style.transform = 'translate(-50%, -50%)';
+          currentRotation = currentRotation % 360;
+          drawWheel();
+          balance += reward.amount;
+          const updates = { balance };
+          if (!isAdmin) updates.lastWheelSpin = now;
+          await userRef.update(updates);
+          toast.innerHTML = `✅ You won ${reward.label} <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="inline w-4 h-4 coin-icon" alt="Coins">!`;
+          toast.classList.remove('hidden');
+          setTimeout(() => toast.classList.add('hidden'), 3000);
+          if (isAdmin) button.disabled = false;
+        }, { once: true });
       };
     });
   </script>
@@ -164,5 +223,18 @@
   <script src="scripts/navbar.js"></script>
   <script src="scripts/footer.js"></script>
   <script src="scripts/topup.js"></script>
+  <script>
+    function createCoin() {
+      const coin = document.createElement('img');
+      coin.src = 'https://cdn-icons-png.flaticon.com/128/6369/6369589.png';
+      coin.className = 'coin';
+      coin.style.left = Math.random() * 100 + 'vw';
+      const duration = 4 + Math.random() * 3;
+      coin.style.animationDuration = duration + 's';
+      document.getElementById('coin-rain').appendChild(coin);
+      setTimeout(() => coin.remove(), duration * 1000);
+    }
+    setInterval(createCoin, 400);
+  </script>
 </body>
 </html>

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -98,21 +98,6 @@ document.addEventListener('DOMContentLoaded', () => {
       document.getElementById('username-display').innerText = user.displayName || user.email;
     });
 
-    // Load badges from Firestore
-    firebase.firestore().collection('leaderboard').doc(user.uid).get().then(doc => {
-      const badgeData = doc.data() || {};
-      const badges = badgeData.badges || [];
-      const container = document.getElementById('badge-container');
-      if (!container) return;
-      if (badges.length === 0) {
-        container.innerHTML = '<p class="text-sm text-gray-400">No badges yet.</p>';
-      } else {
-        container.innerHTML = badges
-          .map(b => `<span class="bg-purple-600 text-white text-xs px-2 py-1 rounded-full">${b}</span>`)
-          .join(' ');
-      }
-    });
-
     const inventoryRef = db.ref('users/' + user.uid + '/inventory');
     inventoryRef.once('value').then(snap => {
       if (!snap.exists()) {

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -41,47 +41,8 @@ async function loadProfile(uid, currentUid) {
   const packsOpened = data.packsOpened || 0;
   const cardValue = data.cardValue || 0;
 
-  const badgeSnap = await firebase.database().ref('milestoneConfig/badges').once('value');
-  const badgeCfg = badgeSnap.val() || [];
-  let currentBadge = null;
-  if (Array.isArray(badgeCfg)) {
-    badgeCfg.forEach(b => {
-      const threshold = b.threshold || 0;
-      const type = b.type || 'packs';
-      if ((type === 'packs' && packsOpened >= threshold) || (type === 'value' && cardValue >= threshold)) {
-        if (!currentBadge || threshold > (currentBadge.threshold || 0)) currentBadge = b;
-      }
-    });
-  }
-  const badgeContainer = document.getElementById('badge-container');
-  if (currentBadge) {
-    const color = currentBadge.color || '#9333ea';
-    badgeContainer.innerHTML = `<span class="text-white text-xs px-2 py-1 rounded-full" style="background-color:${color}">${currentBadge.name}</span>`;
-  } else {
-    badgeContainer.innerHTML = '<p class="text-sm text-gray-400">No badge yet.</p>';
-  }
-
-  const levelSnap = await firebase.database().ref('milestoneConfig/levels').once('value');
-  const thresholds = levelSnap.val() || [];
-  const levelInfo = determineLevel(packsOpened, thresholds);
-  document.getElementById('level-number').innerText = levelInfo.level;
   document.getElementById('packs-opened').innerText = packsOpened.toLocaleString();
   document.getElementById('total-won').innerText = cardValue.toLocaleString();
-  const progressEl = document.getElementById('level-progress');
-  const progressText = document.getElementById('progress-text');
-  if (progressEl) {
-    let pct = 100;
-    if (levelInfo.nextThreshold > levelInfo.prevThreshold) {
-      pct = ((packsOpened - levelInfo.prevThreshold) / (levelInfo.nextThreshold - levelInfo.prevThreshold)) * 100;
-      if (progressText) {
-        const remaining = levelInfo.nextThreshold - packsOpened;
-        progressText.textContent = `${remaining} packs to next level`;
-      }
-    } else if (progressText) {
-      progressText.textContent = 'Max level achieved';
-    }
-    progressEl.style.width = pct + '%';
-  }
 
   const historySnap = await firebase.database().ref('users/' + uid + '/unboxHistory').once('value');
   let totalSpent = 0;
@@ -186,29 +147,6 @@ function updateProfile() {
       location.reload();
     })
     .catch(err => alert('❌ Error: ' + err.message));
-}
-
-function determineLevel(packs, levels) {
-  if (!Array.isArray(levels) || levels.length === 0) {
-    const level = Math.floor(packs / 10) + 1;
-    const prev = (level - 1) * 10;
-    const next = level * 10;
-    return { level, prevThreshold: prev, nextThreshold: next };
-  }
-  let lvl = 1;
-  let prev = 0;
-  let next = null;
-  levels.forEach((entry, idx) => {
-    const t = typeof entry === 'object' ? entry.threshold : entry;
-    if (packs >= t) {
-      lvl = idx + 1;
-      prev = t;
-    } else if (next === null) {
-      next = t;
-    }
-  });
-  if (next === null) next = prev;
-  return { level: lvl, prevThreshold: prev, nextThreshold: next };
 }
 
 function changePassword() {

--- a/scripts/quests.js
+++ b/scripts/quests.js
@@ -155,86 +155,24 @@ export async function renderWeeklyQuests(containerId = "quest-container") {
   });
 }
 
-// Track long-term milestones and award badges stored in Firestore.
+// Track long-term milestones such as total packs opened and total card value.
 // Called whenever a pack is opened to update stats used by the leaderboard.
 export async function updateMilestones(uid, prizeValue = 0) {
-  if (!uid) return { leveledUp: false };
+  if (!uid) return;
   const fs = firebase.firestore();
   const docRef = fs.collection('leaderboard').doc(uid);
-  // Fetch configuration for badges and levels.
-  const [badgeSnap, levelSnap] = await Promise.all([
-    firebase.database().ref('milestoneConfig/badges').once('value'),
-    firebase.database().ref('milestoneConfig/levels').once('value')
-  ]);
-  const badgeConfig = badgeSnap.val() || [];
-  const levelConfig = levelSnap.val() || [];
-  let levelResult = { leveledUp: false };
 
   await fs.runTransaction(async (tx) => {
     const doc = await tx.get(docRef);
     const data = doc.exists ? doc.data() : {};
-    const prevPacks = data.packsOpened || 0;
-    const packsOpened = prevPacks + 1;
+    const packsOpened = (data.packsOpened || 0) + 1;
     const cardValue = (data.cardValue || 0) + (prizeValue || 0);
-    let badges = data.badges || [];
-
-    const newBadges = [];
-    if (Array.isArray(badgeConfig) && badgeConfig.length) {
-      badgeConfig.forEach(b => {
-        const threshold = b.threshold || 0;
-        const name = b.name || '';
-        if (!name || badges.includes(name)) return;
-        if (b.type === 'packs' && packsOpened >= threshold) newBadges.push(name);
-        if (b.type === 'value' && cardValue >= threshold) newBadges.push(name);
-      });
-    } else {
-      if (packsOpened >= 10 && !badges.includes('10 Packs')) newBadges.push('10 Packs');
-      if (packsOpened >= 50 && !badges.includes('50 Packs')) newBadges.push('50 Packs');
-      if (cardValue >= 1000 && !badges.includes('1k Value')) newBadges.push('1k Value');
-      if (cardValue >= 5000 && !badges.includes('5k Value')) newBadges.push('5k Value');
-    }
-
-    const prevLevelInfo = determineLevel(prevPacks, levelConfig);
-    const newLevelInfo = determineLevel(packsOpened, levelConfig);
-    if (newLevelInfo.level > prevLevelInfo.level) {
-      const cfg = Array.isArray(levelConfig) ? levelConfig[newLevelInfo.level - 1] : null;
-      const reward = typeof cfg === 'object' ? cfg.reward || 0 : 0;
-      levelResult = { leveledUp: true, level: newLevelInfo.level, reward };
-    }
-
-    if (newBadges.length) badges = [...badges, ...newBadges];
 
     tx.set(docRef, {
       username: firebase.auth().currentUser?.displayName || firebase.auth().currentUser?.email || 'Anonymous',
       packsOpened,
       cardValue,
-      badges,
     }, { merge: true });
   });
-
-  return levelResult;
-}
-
-function determineLevel(packs, levels) {
-  if (!Array.isArray(levels) || levels.length === 0) {
-    const level = Math.floor(packs / 10) + 1;
-    const prev = (level - 1) * 10;
-    const next = level * 10;
-    return { level, prevThreshold: prev, nextThreshold: next };
-  }
-  let lvl = 1;
-  let prev = 0;
-  let next = null;
-  levels.forEach((entry, idx) => {
-    const t = typeof entry === 'object' ? entry.threshold : entry;
-    if (packs >= t) {
-      lvl = idx + 1;
-      prev = t;
-    } else if (next === null) {
-      next = t;
-    }
-  });
-  if (next === null) next = prev;
-  return { level: lvl, prevThreshold: prev, nextThreshold: next };
 }
 

--- a/styles/rewards.css
+++ b/styles/rewards.css
@@ -1,0 +1,167 @@
+body {
+  background-color: #f8fafc;
+  font-family: 'Poppins', sans-serif;
+  color: #1f2937;
+  overflow-x: hidden;
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  min-height: 100vh;
+}
+
+#wheel-wrapper {
+  position: relative;
+  width: 100%;
+  height: 320px;
+  overflow: hidden;
+  max-width: 1100px;
+  margin: 0 auto;
+  border: 1px solid #2a2f3a;
+  border-radius: 12px;
+  background: linear-gradient(180deg, #1e2333, #151820);
+}
+
+#wheel-container {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 600px;
+  height: 600px;
+}
+
+#wheel {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  transition: transform 5s cubic-bezier(.17,.67,.39,1.19);
+  filter: drop-shadow(0 20px 25px rgba(0,0,0,0.7));
+}
+
+#pointer {
+  position: absolute;
+  top: -20px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 3rem;
+  z-index: 10;
+  pointer-events: none;
+}
+
+#pointer i {
+  background: linear-gradient(#facc15, #f97316);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  filter: drop-shadow(0 0 6px rgba(0,0,0,0.6));
+  animation: bob 1.5s ease-in-out infinite;
+}
+
+@keyframes bob {
+  0%,100% { transform: translateY(0); }
+  50% { transform: translateY(6px); }
+}
+
+#mascot {
+  position: absolute;
+  bottom: -20px;
+  right: 8%;
+  width: 140px;
+  pointer-events: none;
+  animation: mascotFloat 5s ease-in-out infinite;
+  filter: drop-shadow(0 4px 6px rgba(0,0,0,0.3));
+}
+
+@keyframes mascotFloat {
+  0%,100% { transform: rotate(8deg) translateY(0); }
+  50% { transform: rotate(-8deg) translateY(-12px); }
+}
+
+#coin-rain {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: -1;
+}
+
+.coin {
+  position: absolute;
+  width: 24px;
+  height: 24px;
+  animation: fall linear forwards;
+}
+
+@keyframes fall {
+  from { transform: translateY(-100%); opacity: 1; }
+  to { transform: translateY(100vh); opacity: 0; }
+}
+
+#spin {
+  display: block;
+  margin: 1rem auto 0;
+  background: linear-gradient(to bottom, #3b82f6, #8b5cf6);
+  color: #fff;
+  font-weight: 600;
+  padding: 1rem 3rem;
+  border-radius: 9999px;
+  box-shadow: 0 8px 20px rgba(0,0,0,0.4);
+  transition: transform .2s, box-shadow .2s;
+}
+
+#spin:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(0,0,0,0.5);
+}
+
+#spin:disabled {
+  opacity: .5;
+  cursor: not-allowed;
+}
+
+#countdown {
+  color: #facc15;
+  margin-top: .5rem;
+  font-weight: 500;
+}
+
+#toast {
+  background: rgba(17,24,39,0.9);
+  border: 1px solid rgba(255,255,255,0.1);
+  padding: .75rem 1.5rem;
+  border-radius: .75rem;
+  backdrop-filter: blur(4px);
+}
+
+@media (max-width: 640px) {
+  #wheel-container {
+    width: 440px;
+    height: 440px;
+  }
+  #wheel-wrapper {
+    height: 240px;
+  }
+  #mascot {
+    width: 90px;
+    right: 2%;
+  }
+}
+
+@media (max-width: 480px) {
+  #wheel-container {
+    width: 360px;
+    height: 360px;
+  }
+  #wheel-wrapper {
+    height: 200px;
+  }
+}


### PR DESCRIPTION
## Summary
- Simplified milestones to drop leveling, badges, and related UI elements
- Kept daily rewards wheel labels centered and horizontal with larger, in-wheel text
- Realigned wheel prize labels so text begins at the outer rim and draws inward, keeping labels inside each slice
- Removed the rewards hero's "Find Out More" CTA and added a floating mascot beside the wheel for playful branding

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7702399d08320acca97139b9ef51f