### PR TITLE
Fix mobile nav balance container width

### DIFF
--- a/components/header.html
+++ b/components/header.html
@@ -64,11 +64,15 @@
 </div>
 
 <!-- Mobile Dropdown -->
-<div id="mobile-dropdown" class="hidden mt-2 bg-gray-800 border border-gray-700 rounded-lg w-48 py-2 fixed right-4 top-[72px] z-[9999] shadow-lg sm:hidden">
-  <div id="user-balance-mobile" class="flex items-center justify-between px-4 py-2 text-sm text-white border-b border-gray-700">
-    <span><img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="inline w-4 h-4 mr-1"> <span id="balance-amount-mobile-dropdown">0</span> coins</span>
-    <button id="topup-button-mobile" class="text-green-400 text-lg font-bold hover:text-green-500">+</button>
-  </div>
+  <div id="mobile-dropdown" class="hidden mt-2 bg-gray-800 border border-gray-700 rounded-lg w-48 py-2 fixed right-4 top-[72px] z-[9999] shadow-lg sm:hidden">
+    <div id="user-balance-mobile" class="px-4 py-2 border-b border-gray-700">
+      <div class="inline-flex items-center gap-1 bg-gray-800 text-white pl-4 pr-3 py-1 rounded-full text-sm">
+        <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" />
+        <span id="balance-amount-mobile-dropdown">0</span>
+        <span>coins</span>
+        <button id="topup-button-mobile" class="text-green-400 text-lg font-bold hover:text-green-500 ml-1">+</button>
+      </div>
+    </div>
   <a id="inventory-link" href="inventory.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm">Inventory</a>
   <a href="how-it-works.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm">How It Works</a>
   <a href="index.html" class="block px-4 py-2 hover:bg-gray-700 text-blue-400 text-sm">

--- a/components/nav.html
+++ b/components/nav.html
@@ -12,16 +12,16 @@
       <i class="fas fa-sword"></i><i class="fas fa-shield-alt ml-1 mr-1"></i> Battles
     </a>
     <div id="user-balance" class="flex items-center gap-1 bg-gray-800 text-white px-3 py-1 rounded-full text-sm hidden">
-      <div id="level-display" class="flex items-center gap-2 bg-black/40 px-3 py-1 rounded-full border border-white/10 shadow-md text-xs">
-  <span class="text-pink-400 font-bold">Lvl <span id="level-number">1</span></span>
-  <div class="relative w-24 h-2 bg-gray-700 rounded-full overflow-hidden">
-    <div id="xp-bar" class="absolute top-0 left-0 h-full bg-gradient-to-r from-pink-500 via-yellow-400 to-purple-500 rounded-full transition-all duration-300" style="width: 0%"></div>
-  </div>
-</div>
       <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" />
       <span id="balance-amount">0</span>
       <span>coins</span>
       <button id="topup-button" class="text-green-400 font-bold ml-1">+</button>
+    </div>
+    <div id="level-display" class="flex items-center gap-2 bg-black/40 px-3 py-1 rounded-full border border-white/10 shadow-md text-xs">
+      <span class="text-pink-400 font-bold">Lvl <span id="level-number">1</span></span>
+      <div class="relative w-24 h-2 bg-gray-700 rounded-full overflow-hidden">
+        <div id="xp-bar" class="absolute top-0 left-0 h-full bg-gradient-to-r from-pink-500 via-yellow-400 to-purple-500 rounded-full transition-all duration-300" style="width: 0%"></div>
+      </div>
     </div>
     <div class="relative">
       <button id="dropdown-toggle" class="flex items-center space-x-2 text-white focus:outline-none">
@@ -48,10 +48,14 @@
     </button>
   </div>
 </nav>
-<div id="mobile-dropdown" class="hidden mt-2 bg-gray-800 border border-gray-700 rounded-lg w-48 py-2 fixed right-4 top-[72px] z-[9999] shadow-lg sm:hidden">
-  <div id="user-balance-mobile" class="flex items-center justify-between px-4 py-2 text-sm text-white border-b border-gray-700">
-    <span><img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="inline w-4 h-4 mr-1"> <span id="balance-amount-mobile-dropdown">0</span> coins</span>
-    <button id="topup-button-mobile" class="text-green-400 text-lg font-bold hover:text-green-500">+</button>
+  <div id="mobile-dropdown" class="hidden mt-2 bg-gray-800 border border-gray-700 rounded-lg w-48 py-2 fixed right-4 top-[72px] z-[9999] shadow-lg sm:hidden">
+  <div id="user-balance-mobile" class="px-4 py-2 border-b border-gray-700">
+    <div class="inline-flex items-center gap-1 bg-gray-800 text-white pl-4 pr-3 py-1 rounded-full text-sm">
+      <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" />
+      <span id="balance-amount-mobile-dropdown">0</span>
+      <span>coins</span>
+      <button id="topup-button-mobile" class="text-green-400 text-lg font-bold hover:text-green-500 ml-1">+</button>
+    </div>
   </div>
   <a id="inventory-link" href="inventory.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm hidden">Inventory</a>
   <a href="how-it-works.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm">How It Works</a>

--- a/scripts/header.js
+++ b/scripts/header.js
@@ -87,8 +87,8 @@ document.addEventListener("DOMContentLoaded", () => {
           <a data-nav="marketplace.html" href="marketplace.html" class="block pl-3 pr-4 py-2 border-l-4 border-transparent text-base font-medium text-gray-600 hover:bg-gray-50 hover:border-gray-300"><i class="fas fa-store mr-2"></i>Marketplace</a>
         </div>
         <div class="pt-4 pb-3 border-t border-gray-200">
-          <div id="user-balance-mobile-drawer" class="hidden coin-box text-sm mx-4 mb-3">
-            <div class="balance">
+          <div id="user-balance-mobile-drawer" class="hidden coin-box text-sm ml-4 mb-3">
+            <div class="balance pl-4 pr-3">
               <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" alt="Coins">
               <span id="balance-amount-mobile-dropdown" class="font-medium">0</span>
             </div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -88,8 +88,8 @@ body {
 }
 
 .coin-box {
-  display: flex;
-  align-items: stretch;
+  display: inline-flex;
+  align-items: center;
   border: 1px solid #e5e7eb;
   border-radius: 8px;
   overflow: hidden;
@@ -100,7 +100,7 @@ body {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 8px;
+  padding: 4px 12px 4px 16px;
   background-color: #ffffff;
   color: #374151;
 }


### PR DESCRIPTION
## Summary
- Align mobile dropdown balance pill with other hamburger menu items
- Left-align mobile drawer balance element in header script
- Separate XP/level pill from balance container in navigation markup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b79e2fe70483208b81a091241dfc93