### PR TITLE
feat: disable email verification for login

### DIFF
--- a/auth.html
+++ b/auth.html
@@ -218,12 +218,25 @@ registerForm.addEventListener('submit', async e => {
   const name = document.getElementById('register-name').value;
   const username = document.getElementById('register-username').value;
   const email = document.getElementById('register-email').value;
+  const password = document.getElementById('register-password').value;
   const emailAlerts = document.getElementById('email-alerts').checked;
 
   try {
-    await auth.currentUser.verifyBeforeUpdateEmail(email);
-    localStorage.setItem('pendingUser', JSON.stringify({ name, username, email, emailAlerts }));
-    alert('Verification email sent! Please check your inbox.');
+    await auth.currentUser.updateEmail(email);
+    await auth.currentUser.updatePassword(password);
+    await auth.currentUser.updateProfile({ displayName: username });
+    await db.ref('users/' + auth.currentUser.uid).set({
+      name: name,
+      username: username,
+      email: auth.currentUser.email,
+      phoneNumber: auth.currentUser.phoneNumber,
+      balance: 0,
+      role: 'user',
+      freeCaseOpened: false,
+      emailAlerts: emailAlerts,
+      emailVerified: true
+    });
+    alert('Registration complete! You can now log in with your email and password.');
     await auth.signOut();
     window.location.href = 'auth.html';
   } catch (error) {
@@ -243,19 +256,6 @@ loginForm.addEventListener('submit', e => {
     auth.setPersistence(persistence)
       .then(() => auth.signInWithEmailAndPassword(email, password))
       .then(async () => {
-        const userRef = firebase.database().ref('users/' + auth.currentUser.uid);
-        const snap = await userRef.once('value');
-        const userData = snap.val();
-        if (!auth.currentUser.emailVerified && !userData?.emailVerified) {
-          try {
-            await auth.currentUser.sendEmailVerification();
-            alert('Please verify your email. A verification link has been sent.');
-          } catch (error) {
-            alert('❌ ' + error.message);
-          }
-          await auth.signOut();
-          return;
-        }
         alert('Login successful!');
         const redirectUrl = sessionStorage.getItem('postLoginRedirect');
         sessionStorage.removeItem('postLoginRedirect');
@@ -266,51 +266,7 @@ loginForm.addEventListener('submit', e => {
       });
   });
 
-auth.onAuthStateChanged(async user => {
-  const pending = localStorage.getItem('pendingUser');
-  if (user && pending) {
-    const { name, username, email, emailAlerts } = JSON.parse(pending);
-    if (user.emailVerified) {
-      const password = prompt('Please set a password for your account:');
-      if (!password) {
-        alert('Password is required to complete registration.');
-        await auth.signOut();
-        return;
-      }
-      try {
-        await auth.currentUser.updatePassword(password);
-        await auth.currentUser.updateProfile({ displayName: username });
-        await db.ref('users/' + user.uid).set({
-          name: name,
-          username: username,
-          email: user.email,
-          phoneNumber: auth.currentUser.phoneNumber,
-          balance: 0,
-          role: 'user',
-          freeCaseOpened: false,
-          emailAlerts: emailAlerts,
-          emailVerified: true
-        });
-        localStorage.removeItem('pendingUser');
-        alert('Registration complete! You can now log in with your email and password.');
-        await auth.signOut();
-        window.location.href = 'auth.html';
-      } catch (error) {
-        alert('❌ ' + error.message);
-      }
-    } else {
-      try {
-        await auth.currentUser.verifyBeforeUpdateEmail(email);
-        alert('Please verify your email using the link sent to you. A new verification email has been sent.');
-      } catch (error) {
-        alert('❌ ' + error.message);
-      }
-      await auth.signOut();
-    }
-  }
-});
-
-function forgotPassword() {
+  function forgotPassword() {
   const email = document.getElementById('login-email').value;
   if (!email) {
     alert("Please enter your email address to reset your password.");

--- a/scripts/auth.js
+++ b/scripts/auth.js
@@ -16,8 +16,8 @@ window.addEventListener('DOMContentLoaded', () => {
       const userRef = firebase.database().ref('users/' + user.uid);
       const snapshot = await userRef.once('value');
       const userData = snapshot.val() || {};
-      if (!user.email || (!user.emailVerified && !userData.emailVerified)) {
-        alert('Please complete registration and verify your email to continue.');
+      if (!user.email) {
+        alert('Please complete registration to continue.');
         firebase.auth().signOut();
         return;
       }


### PR DESCRIPTION
## Summary
- allow registration without sending verification emails
- remove email verification check from login flow
- relax global auth check to only require presence of an email

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9f47b4bbc8320b4b88765f1e699e3