### PR TITLE
Refine battles card layout

### DIFF
--- a/box-battles.html
+++ b/box-battles.html
@@ -409,30 +409,35 @@
     // --- Open/My/Previous lists
       function renderBattleRow(b){
         const live = (b.status==='lobby' || b.status==='countdown') ? pill('LIVE','live') : '';
-        const packs = renderPackIcons(b.packs || [], 'w-10 h-12');
-        const players = (b.players||[]).map(p=>`<div class="flex items-center gap-1">${avatar(p)}<span class="hidden md:inline text-sm">${p.displayName||'Player'}</span></div>`).join('');
-      const seatCount = `${(b.players?.length || 0)}/${b.maxPlayers}`;
-      const canJoin = (b.status==='lobby' || b.status==='countdown') && (b.players?.length||0) < b.maxPlayers;
+        const packs = renderPackIcons(b.packs || [], 'w-16 h-20');
+        const playerIcons = (b.players||[]).map(p=> avatar(p)).join('');
+        const seatCount = `${(b.players?.length || 0)}/${b.maxPlayers}`;
+        const canJoin = (b.status==='lobby' || b.status==='countdown') && (b.players?.length||0) < b.maxPlayers;
+        const cost = Number(b.cost || 0).toLocaleString();
+        const waitingText = canJoin ? 'waiting for players' : '';
 
-      const cost = Number(b.cost || 0).toLocaleString();
-      return rowCard(`
-        <div class="flex flex-wrap items-center justify-between gap-3">
-          <div class="flex items-center gap-3">
-            <div class="w-10 h-10 rounded-full grid place-items-center bg-gray-100">${b.spinCount}</div>
+        return rowCard(`
+          <div class="flex flex-col gap-3">
+            <header class="flex items-center justify-between">
+              <div class="flex items-center gap-2 text-sm font-semibold">${live}</div>
+              <div class="flex items-center text-sm text-gray-700">
+                <span class="mr-1 text-gray-500">Battle Cost</span>
+                <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 mr-1" alt="coin"/>${cost}
+              </div>
+            </header>
             <div class="flex items-center gap-2">${packs}</div>
-          </div>
-          <div class="flex flex-wrap items-center gap-3">
-            ${live}
-            <div class="flex items-center text-sm text-gray-700"><img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 mr-1" alt="coin"/>${cost}</div>
-            <div class="flex items-center gap-2">${players}<span class="text-sm text-gray-500">${seatCount}</span></div>
-            <div class="flex items-center gap-2">
-              ${canJoin ? `<button class="join-btn px-3 py-1.5 rounded-lg bg-indigo-500/80 hover:bg-indigo-500" data-id="${b.id}">Join</button>` : ''}
-              <button class="watch-btn px-3 py-1.5 rounded-lg bg-gray-100 hover:bg-gray-200" data-id="${b.id}">Watch</button>
+            <div class="flex items-center justify-between">
+              <div class="flex -space-x-2 items-center">${playerIcons}</div>
+              <div class="flex items-center gap-2">
+                ${canJoin ? `<button class="join-btn px-4 py-2 rounded-lg bg-gradient-to-r from-indigo-500 to-blue-500 hover:from-indigo-400 hover:to-blue-400 text-white" data-id="${b.id}">Join Battle</button>` : ''}
+                <button class="watch-btn px-4 py-2 rounded-lg bg-gray-100 hover:bg-gray-200" data-id="${b.id}">View Battle</button>
+                <div class="w-6 h-6 rounded-md bg-gray-100 text-gray-700 text-xs flex items-center justify-center">${seatCount}</div>
+              </div>
             </div>
+            <div class="text-sm text-gray-500">${waitingText}</div>
           </div>
-        </div>
-      `);
-    }
+        `);
+      }
 
       function renderPreviousRow(b){
         const winner = b.winner?.displayName || '—';
@@ -490,16 +495,16 @@
         const statusText = (status === 'lobby' || status === 'countdown') ? (p ? 'Ready' : 'Waiting') : '';
         return `
         <div class="player rounded-xl border border-gray-200 bg-gray-50 p-3 flex flex-col min-w-0${p?'':' opacity-70'}">
-          <div class="flex items-center justify-between mb-2 gap-2">
-            <div class="flex items-center gap-2 min-w-0">
-              <div class="relative flex-shrink-0">
-                <img src="${avatarUrl}" alt="avatar" class="w-8 h-8 rounded-full object-cover"/>
-              </div>
-              <span class="player-name text-sm truncate">${p?.displayName || ''}</span>
+          <div class="flex items-center gap-2 mb-2">
+            <div class="relative flex-shrink-0">
+              <img src="${avatarUrl}" alt="avatar" class="w-8 h-8 rounded-full object-cover"/>
             </div>
-            <div class="flex items-center gap-1 text-xs text-gray-500 min-w-0 max-w-[70px]">
-              <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-3 h-3" alt="coin"/>
-              <span class="player-total truncate">${total}</span>
+            <div class="flex-1 min-w-0">
+              <span class="player-name block text-sm truncate">${p?.displayName || ''}</span>
+              <div class="flex items-center gap-1 text-xs text-gray-500">
+                <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-3 h-3" alt="coin"/>
+                <span class="player-total">${total}</span>
+              </div>
             </div>
           </div>
           <div id="spinner-border-${i}" class="reel-host w-full h-40 border-2 border-gray-200 rounded-lg overflow-hidden">
@@ -838,22 +843,25 @@
         let allPulls = [];
         await firestore.runTransaction(async tx => {
           const s = await tx.get(docRef);
-          const d = s.data(); if (!d || d.status !== 'spinning') return;
+          const d = s.data();
+          if (!d || d.status !== 'spinning') return;
 
           const currentRound = d.roundIndex || 0;
-          const dPlayers = d.players || [];
+          if (currentRound !== round) return; // another runner already advanced
 
-          players.forEach((player, idx) => {
-            const prize = full.prizes[indexes[idx]];
+          const dPlayers = d.players || [];
+          const indexesTx = dPlayers.map(p => getWinningIndex(full, 'serverSeed', p.uid, `${currentRound}`));
+
+          dPlayers.forEach((P, idx) => {
+            const prize = full.prizes[indexesTx[idx]];
             const pull = {
               round: currentRound,
               packId: full.id,
               prizeId: prize.id,
               value: prize.value,
-              index: indexes[idx],
+              index: indexesTx[idx],
               at: firebase.firestore.Timestamp.now()
             };
-            const P = dPlayers[idx];
             P.pulls = (P.pulls || []).concat([pull]);
             P.total = (P.total || 0) + (prize.value || 0);
             dPlayers[idx] = P;

--- a/scripts/spinner.js
+++ b/scripts/spinner.js
@@ -110,7 +110,7 @@ export function spinToPrize(callback, showPopup = true, id = 0, durationSec = 5)
     spinnerWheel.style.transform = `translate3d(-${finalOffset}px,0,0)`;
   });
 
-  let animationFrame;
+  let tracker;
 
   function trackCenterPrize() {
     const cards = spinnerWheel.querySelectorAll(".item");
@@ -130,7 +130,7 @@ export function spinToPrize(callback, showPopup = true, id = 0, durationSec = 5)
     });
 
     if (closestCard) {
-      const indexAttr = closestCard.getAttribute("data-index");
+      const indexAttr = parseInt(closestCard.getAttribute("data-index"), 10);
       const prize = spinnerPrizesMap[id][indexAttr];
       const rarity = (prize?.rarity || "common").toLowerCase().replace(/\s+/g, '');
       const color = getRarityColor(rarity);
@@ -138,15 +138,14 @@ export function spinToPrize(callback, showPopup = true, id = 0, durationSec = 5)
       const borderEl = document.getElementById(`spinner-border-${id}`);
       if (borderEl) borderEl.style.borderColor = color;
     }
-
-    animationFrame = requestAnimationFrame(trackCenterPrize);
   }
 
   trackCenterPrize();
+  tracker = setInterval(trackCenterPrize, 100);
 
   return new Promise(resolve => {
   function onTransitionEnd() {
-      cancelAnimationFrame(animationFrame);
+      clearInterval(tracker);
       spinnerWheel.style.willChange = '';
       spinnerWheel.style.transition = 'none';
 


### PR DESCRIPTION
## Summary
- Revamp battle list cards with a vertical layout and mode labels
- Show pack previews, player avatars, join/view buttons and seat count on each card
- Relabel jackpot indicator as "Battle Cost" beside the price and lighten spinner tracking to avoid skips
- Stack spinner usernames and totals vertically so both remain visible
- Guard battle transactions against stale rounds so spins aren't skipped or double counted

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb7c4664e48320a9a75f01e355482d