### PR TITLE
Redesign case rewards grid cards

### DIFF
--- a/case.html
+++ b/case.html
@@ -503,15 +503,17 @@ if (repeatedBestDrops.length) {
             .replace(/\s+/g, '');
           const color = rarityColors[rarity] || "#a1a1aa";
           return `
-  <div class="prize-card relative rounded-xl p-4 bg-white border-2 text-gray-900 text-center shadow-sm cursor-pointer transition-transform duration-200 hover:scale-105" data-rarity="${rarity}" style="border-color:${color}">
-    <img src="${prize.image}" class="w-full h-[120px] object-contain mx-auto mb-3 bg-gray-50 rounded-lg" />
-    <div class="prize-name font-semibold text-sm clamp-2 mb-8">${prize.name}</div>
-    <div class="absolute bottom-2 left-2 inline-flex items-center gap-1 px-2 py-[2px] rounded-full bg-gray-800 text-yellow-300 font-medium text-xs">
-      <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4" />
-      ${formatCoins(prize.value || 0)}
+  <div class="prize-card rounded-xl overflow-hidden bg-white border-2 text-gray-900 text-center shadow-sm cursor-pointer transition-transform duration-200 hover:scale-105" data-rarity="${rarity}" style="border-color:${color}">
+    <div class="p-4">
+      <img src="${prize.image}" class="w-full h-[120px] object-contain mx-auto mb-3 bg-gray-50 rounded-lg" />
+      <div class="prize-name font-semibold text-sm clamp-2">${prize.name}</div>
     </div>
-    <div class="absolute bottom-2 right-2 text-gray-600 bg-gray-100 px-2 py-[2px] text-xs rounded-full">
-      ${formatOdds(prize.odds)}%
+    <div class="flex items-center justify-between px-2 py-1 bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-xs font-medium">
+      <div class="flex items-center gap-1">
+        <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4" />
+        ${formatCoins(prize.value || 0)}
+      </div>
+      <div>${formatOdds(prize.odds)}%</div>
     </div>
   </div>`;
         })


### PR DESCRIPTION
## Summary
- Revamp case reward cards to include a bottom gradient bar displaying coin value and odds.
- Maintain light card background while highlighting reward meta info.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0e117647883209fb419c196a60f8f