### PR TITLE
Fix spinner coin display NaN

### DIFF
--- a/case.html
+++ b/case.html
@@ -450,7 +450,8 @@ const openerItems = prizeList.map((p, i) => ({
   id: i,
   name: p.name,
   image: p.image,
-  value: formatCoins(p.value || 0),
+  // Pass raw numeric value; spinner.js will format the coin amount itself
+  value: Number(p.value) || 0,
   rarity: (p.rarity || 'common').toLowerCase().replace(/\s+/g,'')
 }));
 PackOpener.init({ root: document.getElementById('reel'), items: openerItems });


### PR DESCRIPTION
## Summary
- Pass raw numeric coin values to spinner items to prevent NaN display

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0e7cc41c88320a0e4aed81014a441