### PR TITLE
Adjust case item layouts for consistent sizing

### DIFF
--- a/case.html
+++ b/case.html
@@ -50,18 +50,29 @@
     }
     .reel { display: flex; will-change: transform; padding: 1rem 0; }
     .tile {
-      flex: 0 0 170px;
+      flex: 0 0 180px;
+      width: 180px;
+      height: 240px;
       margin: 0 10px;
       position: relative;
       background: #2a2f3a;
       border: 1px solid #3a4050;
       border-radius: 12px;
-      padding: 8px;
+      padding: 12px 12px 48px;
+      box-sizing: border-box;
       box-shadow: 0 2px 4px rgba(0,0,0,0.5);
       color: #f1f5f9;
       transition: transform 0.2s, box-shadow 0.2s;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
-    .tile img { width: 150px; height: 210px; object-fit: cover; border-radius: 8px; }
+    .tile img {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      border-radius: 8px;
+    }
     .tile:hover { transform: translateY(-4px); box-shadow: 0 4px 8px rgba(0,0,0,0.6); }
     .tile.win { box-shadow: 0 0 0 3px var(--win-color,#FFD36E); border-color: var(--win-color,#FFD36E); animation: flash 0.6s; }
     @keyframes flash {0%,100%{filter:brightness(1);}50%{filter:brightness(1.8);}}
@@ -115,18 +126,40 @@
     .pill.rare { background:#eff6ff; color:#1e3a8a; }
     .pill.ultra { background:#f5f3ff; color:#5b21b6; }
     .pill.legendary { background:#fef3c7; color:#92400e; }
-    #best-drops-track { display:flex; will-change:transform; }
+    #best-drops-track {
+      display:flex;
+      align-items:center;
+      will-change:transform;
+    }
     .best-drop-card {
-      flex: 0 0 60px;
-      height: 84px;
-      margin-right: 6px;
+      flex: 0 0 80px;
+      width: 80px;
+      height: 80px;
+      margin-right: 8px;
       background: #2a2f3a;
       border: 1px solid #3a4050;
       border-radius: 8px;
       overflow: hidden;
       box-shadow: 0 2px 4px rgba(0,0,0,0.5);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 6px;
+      box-sizing: border-box;
     }
-    .best-drop-card img { width:100%; height:100%; object-fit:cover; }
+    .best-drop-card img { width:100%; height:100%; object-fit:contain; }
+    .reel-wrapper .tile { flex: 0 0 180px; }
+    #prizes-grid .prize-card {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+    #prizes-grid .prize-card > .p-4 {
+      flex: 1 1 auto;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+    }
     .vertical-rl { writing-mode: vertical-rl; transform: rotate(180deg); }
   </style>
   <script src="pack-opener/spinner.js"></script>


### PR DESCRIPTION
## Summary
- update case spinner tiles to maintain uniform dimensions and show complete item artwork
- resize and center best drop carousel cards so images no longer clip
- make prize grid cards use a consistent layout regardless of content length

## Testing
- not run (not run)

------
https://chatgpt.com/codex/tasks/task_e_68d9714917fc83208c2fe5beae474d52