### PR TITLE
Refresh header navigation for desktop and mobile

### DIFF
--- a/components/header.html
+++ b/components/header.html
@@ -1,81 +1,112 @@
 <!-- header.html -->
-<div class="navbar fixed w-full z-50 py-3 px-4 flex items-center justify-between bg-gray-900 border-b border-gray-800" style="min-height: 72px;">
-  <!-- Left: Logo -->
-  <div class="flex items-center gap-4">
-    <a href="index.html">
-      <img src="https://firebasestorage.googleapis.com/v0/b/cases-e5b4e.firebasestorage.app/o/Untitled%20design%20(28).png?alt=media&token=61fab7cf-c6e5-4598-8865-bd95007d6961" class="h-10 sm:h-12">
-    </a>
-  </div>
-  
-  <!-- Right: Desktop Menu -->
-  <div class="hidden sm:flex items-center gap-4 relative">
-    <a href="index.html" class="flex items-center gap-1 text-blue-400 font-semibold hover:text-blue-300 transition">
-      <i class="fas fa-box-open"></i> Open Packs
-    </a>
-    <a href="box-battles.html" class="flex items-center gap-1 text-purple-400 font-semibold hover:text-purple-300 transition">
-      <i class="fas fa-sword"></i><i class="fas fa-shield-alt ml-1 mr-1"></i> Battles
-    </a>
-    <a href="marketplace.html" class="flex items-center gap-1 text-pink-400 font-semibold hover:text-pink-300 transition">
-      <i class="fas fa-store"></i> Marketplace
-    </a>
-    <a href="rewards.html" class="flex items-center gap-1 text-yellow-400 font-semibold hover:text-yellow-300 transition">
-      <i class="fas fa-gift"></i> Rewards
-    </a>
-    <!-- Coin Balance -->
-    <div id="user-balance" class="flex items-center gap-1 bg-gray-800 text-white px-3 py-1 rounded-full text-sm">
-      <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" />
-      <span id="balance-amount">0</span>
-      <span>coins</span>
-      <button id="topup-button" class="text-green-400 font-bold ml-1">+</button>
-    </div>
-    <!-- Username + Dropdown -->
-    <div class="relative">
-      <button id="dropdown-toggle" class="flex items-center space-x-2 text-white focus:outline-none">
-        <i class="fas fa-user-circle text-xl"></i>
-        <span id="username-display">User</span>
-        <i class="fas fa-chevron-down text-xs"></i>
-      </button>
-      <div id="user-dropdown" class="absolute right-0 mt-2 w-48 bg-gray-800 border border-gray-700 rounded-lg shadow-lg hidden z-50">
-        <a href="inventory.html" class="block px-4 py-2 text-sm text-white hover:bg-gray-700">Inventory</a>
-        <a href="how-it-works.html" class="block px-4 py-2 text-sm text-white hover:bg-gray-700">How It Works</a>
-        <a id="signin-desktop" href="auth.html" class="block px-4 py-2 text-sm text-green-400 hover:bg-gray-700">Sign In</a>
-        <a id="logout-desktop" href="#" class="block px-4 py-2 text-sm text-red-400 hover:bg-gray-700">Logout</a>
+<header class="site-header fixed inset-x-0 top-0 z-50">
+  <div class="nav-shell">
+    <div class="flex items-center justify-between gap-6">
+      <!-- Left: Logo -->
+      <div class="flex items-center gap-3">
+        <a href="index.html" class="flex items-center gap-3">
+          <span class="inline-flex h-12 w-12 items-center justify-center rounded-full bg-slate-900/80 ring-1 ring-white/10">
+            <img src="https://firebasestorage.googleapis.com/v0/b/cases-e5b4e.firebasestorage.app/o/Untitled%20design%20(28).png?alt=media&token=61fab7cf-c6e5-4598-8865-bd95007d6961" class="h-9 w-9 object-contain" alt="Packly logo">
+          </span>
+          <div class="hidden sm:flex flex-col">
+            <span class="text-sm font-semibold uppercase tracking-[0.2em] text-slate-300">Packly</span>
+            <span class="text-xs text-slate-400">Virtual Packs • Real Cards</span>
+          </div>
+        </a>
+      </div>
+
+      <!-- Right: Desktop Menu -->
+      <div class="hidden lg:flex items-center gap-2">
+        <nav class="flex items-center gap-1" aria-label="Primary">
+          <a href="index.html" class="nav-pill">
+            <i class="fas fa-box-open"></i>
+            <span>Open Packs</span>
+          </a>
+          <a href="box-battles.html" class="nav-pill">
+            <span class="flex items-center gap-1"><i class="fas fa-sword"></i><i class="fas fa-shield-alt"></i></span>
+            <span>Battles</span>
+          </a>
+          <a href="marketplace.html" class="nav-pill">
+            <i class="fas fa-store"></i>
+            <span>Marketplace</span>
+          </a>
+          <a href="rewards.html" class="nav-pill">
+            <i class="fas fa-gift"></i>
+            <span>Rewards</span>
+          </a>
+        </nav>
+
+        <div class="ml-4 flex items-center gap-3">
+          <!-- Coin Balance -->
+          <div id="user-balance" class="balance-pill" aria-live="polite">
+            <span class="balance-icon">
+              <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="h-4 w-4 object-contain" alt="Coins" />
+            </span>
+            <span id="balance-amount" class="balance-amount">0</span>
+            <span class="balance-label">coins</span>
+            <button id="topup-button" class="topup-trigger" type="button" aria-label="Add coins">+</button>
+          </div>
+
+          <!-- Username + Dropdown -->
+          <div class="relative">
+            <button id="dropdown-toggle" class="profile-trigger" type="button" aria-haspopup="true" aria-expanded="false">
+              <i class="fas fa-user-circle text-xl"></i>
+              <span id="username-display" class="truncate">User</span>
+              <i class="fas fa-chevron-down text-xs"></i>
+            </button>
+            <div id="user-dropdown" class="profile-menu hidden" role="menu">
+              <a href="inventory.html" class="profile-menu-item" role="menuitem">Inventory</a>
+              <a href="how-it-works.html" class="profile-menu-item" role="menuitem">How It Works</a>
+              <a id="signin-desktop" href="auth.html" class="profile-menu-item profile-menu-item--positive" role="menuitem">Sign In</a>
+              <a id="logout-desktop" href="#" class="profile-menu-item profile-menu-item--danger" role="menuitem">Logout</a>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Mobile Coin Balance and Menu Toggle -->
+      <div class="flex items-center gap-2 lg:hidden">
+        <div id="user-balance-mobile-header" class="balance-pill balance-pill--compact" aria-live="polite">
+          <span class="balance-icon">
+            <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="h-4 w-4 object-contain" alt="Coins" />
+          </span>
+          <span id="balance-amount-mobile" class="balance-amount">0</span>
+        </div>
+        <button id="menu-toggle" class="mobile-toggle" type="button" aria-expanded="false" aria-controls="mobile-dropdown">
+          <span class="sr-only">Toggle navigation</span>
+          <i class="fas fa-bars"></i>
+        </button>
       </div>
     </div>
   </div>
-
-  <!-- Mobile Coin Balance and Menu Toggle -->
-  <div class="sm:hidden flex items-center gap-2">
-    <div id="user-balance-mobile-header" class="flex items-center gap-1 bg-gray-800 text-white px-3 py-1 rounded-full text-sm">
-      <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="w-4 h-4 object-contain" />
-      <span id="balance-amount-mobile">0</span>
-      <span>coins</span>
-    </div>
-    <button id="menu-toggle" class="text-white text-2xl">
-      <i class="fas fa-bars"></i>
-    </button>
-  </div>
-</div>
+</header>
 
 <!-- Mobile Dropdown -->
-<div id="mobile-dropdown" class="hidden mt-2 bg-gray-800 border border-gray-700 rounded-lg w-48 py-2 fixed right-4 top-[72px] z-[9999] shadow-lg sm:hidden">
-  <div id="user-balance-mobile" class="flex items-center justify-between px-4 py-2 text-sm text-white border-b border-gray-700">
-    <span><img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="inline w-4 h-4 mr-1"> <span id="balance-amount-mobile-dropdown">0</span> coins</span>
-    <button id="topup-button-mobile" class="text-green-400 text-lg font-bold hover:text-green-500">+</button>
+<div id="mobile-dropdown" class="mobile-menu-panel hidden" role="menu">
+  <div class="mobile-balance" role="presentation">
+    <span class="flex items-center gap-2 text-sm font-medium text-slate-100">
+      <img src="https://cdn-icons-png.flaticon.com/128/6369/6369589.png" class="h-4 w-4" alt="Coins">
+      <span id="balance-amount-mobile-dropdown">0</span> coins
+    </span>
+    <button id="topup-button-mobile" class="topup-trigger" type="button" aria-label="Add coins">+</button>
   </div>
-  <a id="inventory-link" href="inventory.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm">Inventory</a>
-  <a href="how-it-works.html" class="block px-4 py-2 hover:bg-gray-700 text-white text-sm">How It Works</a>
-  <a href="index.html" class="block px-4 py-2 hover:bg-gray-700 text-blue-400 text-sm">
-    <i class="fas fa-box-open mr-2"></i> Open Packs
+  <a id="inventory-link" href="inventory.html" class="mobile-menu-item" role="menuitem">Inventory</a>
+  <a href="how-it-works.html" class="mobile-menu-item" role="menuitem">How It Works</a>
+  <a href="index.html" class="mobile-menu-item" role="menuitem">
+    <i class="fas fa-box-open"></i>
+    <span>Open Packs</span>
   </a>
-  <a href="box-battles.html" class="block px-4 py-2 hover:bg-gray-700 text-purple-400 text-sm">
-    <i class="fas fa-sword mr-1"></i><i class="fas fa-shield-alt mr-2"></i> Battles
+  <a href="box-battles.html" class="mobile-menu-item" role="menuitem">
+    <span class="flex items-center gap-1"><i class="fas fa-sword"></i><i class="fas fa-shield-alt"></i></span>
+    <span>Battles</span>
   </a>
-  <a href="marketplace.html" class="block px-4 py-2 hover:bg-gray-700 text-pink-400 text-sm">
-    <i class="fas fa-store mr-2"></i> Marketplace
+  <a href="marketplace.html" class="mobile-menu-item" role="menuitem">
+    <i class="fas fa-store"></i>
+    <span>Marketplace</span>
   </a>
-  <a href="rewards.html" class="block px-4 py-2 hover:bg-gray-700 text-yellow-400 text-sm">
-    <i class="fas fa-gift mr-2"></i> Rewards
+  <a href="rewards.html" class="mobile-menu-item" role="menuitem">
+    <i class="fas fa-gift"></i>
+    <span>Rewards</span>
   </a>
-  <a id="mobile-auth-button" href="auth.html" class="block px-4 py-2 hover:bg-gray-700 text-red-400 text-sm">Sign In</a>
+  <a id="mobile-auth-button" href="auth.html" class="mobile-menu-item mobile-menu-item--accent" role="menuitem">Sign In</a>
 </div>

--- a/components/header.js
+++ b/components/header.js
@@ -4,18 +4,63 @@ function loadHeader() {
     .then(html => {
       document.getElementById('main-header').innerHTML = html;
 
-      // Optional: reattach any events here if needed
-      const dropdownToggle = document.getElementById("dropdown-toggle");
-      const dropdown = document.getElementById("user-dropdown");
+      const dropdownToggle = document.getElementById('dropdown-toggle');
+      const dropdown = document.getElementById('user-dropdown');
+      const closeProfileMenu = () => {
+        if (!dropdownToggle || !dropdown) return;
+        dropdown.classList.add('hidden');
+        dropdownToggle.setAttribute('aria-expanded', 'false');
+      };
 
       if (dropdownToggle && dropdown) {
-        dropdownToggle.onclick = () => dropdown.classList.toggle("hidden");
+        dropdownToggle.addEventListener('click', event => {
+          event.stopPropagation();
+          const expanded = dropdownToggle.getAttribute('aria-expanded') === 'true';
+          dropdown.classList.toggle('hidden', expanded);
+          dropdownToggle.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+        });
+
+        document.addEventListener('click', event => {
+          if (!dropdown.contains(event.target) && event.target !== dropdownToggle) {
+            closeProfileMenu();
+          }
+        });
+
+        document.addEventListener('keydown', event => {
+          if (event.key === 'Escape') {
+            closeProfileMenu();
+          }
+        });
       }
 
-      const menuToggle = document.getElementById("menu-toggle");
-      const mobileDropdown = document.getElementById("mobile-dropdown");
+      const menuToggle = document.getElementById('menu-toggle');
+      const mobileDropdown = document.getElementById('mobile-dropdown');
+      const toggleMobileMenu = open => {
+        if (!menuToggle || !mobileDropdown) return;
+        const isOpen = typeof open === 'boolean' ? open : mobileDropdown.classList.contains('hidden');
+        mobileDropdown.classList.toggle('hidden', !isOpen);
+        menuToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        document.body.classList.toggle('overflow-hidden', isOpen);
+      };
+
       if (menuToggle && mobileDropdown) {
-        menuToggle.onclick = () => mobileDropdown.classList.toggle("hidden");
+        menuToggle.addEventListener('click', () => toggleMobileMenu());
+
+        mobileDropdown.querySelectorAll('a').forEach(link => {
+          link.addEventListener('click', () => toggleMobileMenu(false));
+        });
+
+        document.addEventListener('keydown', event => {
+          if (event.key === 'Escape') {
+            toggleMobileMenu(false);
+          }
+        });
+
+        window.addEventListener('resize', () => {
+          if (window.innerWidth >= 1024) {
+            toggleMobileMenu(false);
+          }
+        });
       }
     });
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -160,6 +160,272 @@ body {
   display: inline-block;
 }
 
+/* Header refinement */
+.site-header {
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.85), rgba(30, 41, 59, 0.85));
+  backdrop-filter: blur(18px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 15px 40px rgba(15, 23, 42, 0.25);
+}
+
+.nav-shell {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 0.75rem clamp(1rem, 3vw, 2rem);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.nav-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: #e2e8f0;
+  padding: 0.5rem 0.85rem;
+  border-radius: 999px;
+  transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  position: relative;
+}
+
+.nav-pill::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.25), rgba(236, 72, 153, 0.25));
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: -1;
+}
+
+.nav-pill:hover {
+  color: #f8fafc;
+  transform: translateY(-1px);
+}
+
+.nav-pill:hover::after {
+  opacity: 1;
+}
+
+.balance-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: linear-gradient(135deg, rgba(30, 64, 175, 0.35), rgba(6, 182, 212, 0.35));
+  color: #f8fafc;
+  font-size: 0.75rem;
+  box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.08);
+}
+
+.balance-pill--compact {
+  padding-right: 0.65rem;
+}
+
+.balance-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.balance-amount {
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.balance-label {
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.topup-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #22c55e, #10b981);
+  color: #0f172a;
+  font-weight: 700;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.topup-trigger:hover {
+  transform: translateY(-1px) scale(1.05);
+  box-shadow: 0 10px 20px rgba(16, 185, 129, 0.35);
+}
+
+.profile-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.35);
+  color: #e2e8f0;
+  font-weight: 500;
+  border: 1px solid transparent;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.profile-trigger:hover,
+.profile-trigger[aria-expanded='true'] {
+  border-color: rgba(148, 163, 184, 0.45);
+  background: rgba(30, 41, 59, 0.6);
+}
+
+.profile-menu {
+  position: absolute;
+  right: 0;
+  margin-top: 0.75rem;
+  width: 13rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.95);
+  box-shadow: 0 25px 45px rgba(15, 23, 42, 0.35);
+  overflow: hidden;
+  backdrop-filter: blur(12px);
+  padding: 0.35rem 0;
+  z-index: 1000;
+}
+
+.profile-menu-item {
+  display: block;
+  padding: 0.6rem 1rem;
+  color: #e2e8f0;
+  font-size: 0.85rem;
+  font-weight: 500;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.profile-menu-item:hover {
+  background: rgba(59, 130, 246, 0.15);
+}
+
+.profile-menu-item--positive {
+  color: #34d399;
+}
+
+.profile-menu-item--danger {
+  color: #f87171;
+}
+
+.mobile-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.55);
+  color: #f8fafc;
+  font-size: 1.1rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.mobile-toggle:hover,
+.mobile-toggle[aria-expanded='true'] {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.25);
+}
+
+.mobile-menu-panel {
+  position: fixed;
+  inset: 0.75rem 0.75rem auto;
+  top: 4.75rem;
+  background: rgba(15, 23, 42, 0.97);
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 25px 45px rgba(15, 23, 42, 0.45);
+  padding: 1rem 1.25rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  backdrop-filter: blur(12px);
+  z-index: 9999;
+}
+
+.mobile-balance {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 0.85rem;
+  margin-bottom: 0.85rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.mobile-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 0.5rem;
+  color: #e2e8f0;
+  font-size: 0.95rem;
+  font-weight: 500;
+  border-radius: 0.75rem;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.mobile-menu-item:hover {
+  background: rgba(59, 130, 246, 0.12);
+}
+
+.mobile-menu-item--accent {
+  margin-top: 0.25rem;
+  justify-content: center;
+  background: linear-gradient(135deg, #3b82f6, #6366f1);
+  color: #f8fafc;
+}
+
+.mobile-menu-item--accent:hover {
+  background: linear-gradient(135deg, #2563eb, #4f46e5);
+}
+
+@media (max-width: 1023px) {
+  .nav-shell {
+    padding: 0.65rem 1rem;
+  }
+
+  .mobile-menu-panel {
+    inset: 0.75rem;
+    top: 4.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .mobile-menu-panel {
+    inset: 0.5rem;
+    top: 4.25rem;
+  }
+
+  .balance-pill {
+    font-size: 0.7rem;
+  }
+}
+
 @keyframes pulse-glow {
   0%, 100% { box-shadow: 0 0 0 0 rgba(255, 215, 0, 0.4); }
   50% { box-shadow: 0 0 15px 5px rgba(255, 215, 0, 0.6); }


### PR DESCRIPTION
## Summary
- redesign the shared header markup for a cleaner desktop layout and improved mobile menu
- add supporting styles for the refined navigation, balance pill, and overlays
- enhance header script logic to manage accessibility states and close behavior for menus

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e2dba81d608320a52d908ef7e821f6