### PR TITLE
Hide sign-in modal once authentication completes

### DIFF
--- a/case.html
+++ b/case.html
@@ -374,6 +374,12 @@ document.addEventListener('DOMContentLoaded', () => {
     if (event.target === modal) hideSignInModal();
   });
   if (loginBtn) loginBtn.addEventListener('click', redirectToAuth);
+
+  if (window.firebase?.auth) {
+    firebase.auth().onAuthStateChanged((user) => {
+      if (user) hideSignInModal();
+    });
+  }
 });
 
 const formatGems = (num) => {


### PR DESCRIPTION
### Motivation
- Prevent the sign-in modal from lingering during sign-in flows by closing it immediately when Firebase reports a signed-in user.

### Description
- Add an `onAuthStateChanged` listener inside `DOMContentLoaded` in `case.html` that calls `hideSignInModal()` when `firebase.auth()` reports a non-null `user`, guarded by `window.firebase?.auth`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698964100664832088ffe97088794c29)